### PR TITLE
ibu-imager: Use full refspec for the remote repository

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -116,7 +116,7 @@ LCA_IMAGE=$(oc get deployment -n openshift-lifecycle-agent lifecycle-agent-contr
 AUTHFILE=/tmp/backup-secret.json
 podman login --authfile ${AUTHFILE} -u ${MY_ID} quay.io/${MY_REPO_ID}
 
-IMG_REPO=quay.io/${MY_REPO_ID}/${MY_REPO}
+IMG_REFSPEC=quay.io/${MY_REPO_ID}/${MY_REPO}:${MY_TAG}
 
 podman run --privileged --pid=host --rm --net=host \
     -v /etc:/etc \
@@ -124,6 +124,6 @@ podman run --privileged --pid=host --rm --net=host \
     -v /var/run:/var/run \
     -v /run/systemd/journal/socket:/run/systemd/journal/socket \
     -v ${AUTHFILE}:${AUTHFILE} \
-    --entrypoint /ibu-imager ${LCA_IMAGE} create --authfile ${AUTHFILE} --registry ${IMG_REPO}
+    --entrypoint /ibu-imager ${LCA_IMAGE} create --authfile ${AUTHFILE} --image ${IMG_REFSPEC}
 ```
 

--- a/ibu-imager/cmd/consts.go
+++ b/ibu-imager/cmd/consts.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 const (
-	// Default OCI image tag
-	backupTag = "oneimage"
 	// Pull secret. Written by the machine-config-operator
 	imageRegistryAuthFile = "/var/lib/kubelet/config.json"
 	// backupDir is the directory where the ostree backup will be

--- a/ibu-imager/cmd/create.go
+++ b/ibu-imager/cmd/create.go
@@ -51,7 +51,7 @@ func init() {
 
 	// Add flags related to container registry
 	createCmd.Flags().StringVarP(&authFile, "authfile", "a", imageRegistryAuthFile, "The path to the authentication file of the container registry.")
-	createCmd.Flags().StringVarP(&containerRegistry, "registry", "r", "", "The container registry used to push the OCI image.")
+	createCmd.Flags().StringVarP(&containerRegistry, "image", "i", "", "The full image name with the container registry to push the OCI image.")
 }
 
 func create() {
@@ -75,7 +75,7 @@ func create() {
 	}
 
 	seedCreator := seed.NewSeedCreator(log, op, rpmOstreeClient, backupDir, kubeconfigFile,
-		containerRegistry, backupTag, authFile)
+		containerRegistry, authFile)
 	err = seedCreator.CreateSeedImage()
 	if err != nil {
 		log.Fatal(err)

--- a/ibu-imager/internal/seedcreator/seedcreator_test.go
+++ b/ibu-imager/internal/seedcreator/seedcreator_test.go
@@ -11,8 +11,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/sirupsen/logrus"
 	"ibu-imager/internal/ops"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestIbuImager(t *testing.T) {
@@ -33,7 +34,7 @@ var _ = Describe("Backup /var", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		opsMock = ops.NewMockOps(ctrl)
 		tmpDir, _ = os.MkdirTemp("", "test")
-		seed = NewSeedCreator(l, opsMock, nil, tmpDir, "", "", "", "")
+		seed = NewSeedCreator(l, opsMock, nil, tmpDir, "", "", "")
 	})
 	AfterEach(func() {
 		Expect(os.RemoveAll(tmpDir)).To(Succeed())


### PR DESCRIPTION
Remove hardcoded image tag `oneimage` and force the command line parameter to include the full refspec.

Example:
`ibu-imager create -r quay.io/someone/ibu-seed-image:mytag`