### PR TITLE
Fix check condition for crio down

### DIFF
--- a/ibu-imager/seedcreator/seedcreator.go
+++ b/ibu-imager/seedcreator/seedcreator.go
@@ -1,9 +1,11 @@
 package seedcreator
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 
@@ -155,7 +157,9 @@ func (s *SeedCreator) stopServices() error {
 
 	s.log.Println("Stopping containers and CRI-O runtime.")
 	crioSystemdStatus, err := s.ops.SystemctlAction("is-active", "crio")
-	if err != nil {
+	var exitErr *exec.ExitError
+	// If ExitCode is 3, the command succeeded and told us that crio is down
+	if err != nil && errors.As(err, &exitErr) && exitErr.ExitCode() != 3 {
 		return err
 	}
 	s.log.Println("crio status is", crioSystemdStatus)


### PR DESCRIPTION
If crio is down, `systemctl is-active` ends with status code 3, so we need to capture that exit code and continue execution
/cc @leo8a 
/cc @tsorya