### PR TITLE
[imager] Add recert force-expire towards seed cluster 

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -117,6 +117,7 @@ AUTHFILE=/tmp/backup-secret.json
 podman login --authfile ${AUTHFILE} -u ${MY_ID} quay.io/${MY_REPO_ID}
 
 IMG_REFSPEC=quay.io/${MY_REPO_ID}/${MY_REPO}:${MY_TAG}
+IMG_RECERT_TOOL=quay.io/edge-infrastructure/recert:latest
 
 podman run --privileged --pid=host --rm --net=host \
     -v /etc:/etc \
@@ -124,6 +125,19 @@ podman run --privileged --pid=host --rm --net=host \
     -v /var/run:/var/run \
     -v /run/systemd/journal/socket:/run/systemd/journal/socket \
     -v ${AUTHFILE}:${AUTHFILE} \
-    --entrypoint /ibu-imager ${LCA_IMAGE} create --authfile ${AUTHFILE} --image ${IMG_REFSPEC}
+    --entrypoint /ibu-imager ${LCA_IMAGE} create --authfile ${AUTHFILE} \
+                                                 --image ${IMG_REPO} \
+                                                 --recert-image ${IMG_RECERT_TOOL}
 ```
 
+#### Disconnected environments
+
+For disconnected environments, first mirror the `lifecycle-agent` container image to your local registry using
+[skopeo](https://github.com/containers/skopeo) or a similar tool.
+
+Additionally, you'd need to mirror the [recert](https://github.com/rh-ecosystem-edge/recert) tool, which is used to
+perform some checks in the seed SNO cluster.
+
+```shell
+skopeo copy docker://quay.io/edge-infrastructure/recert docker://${LOCAL_REGISTRY}/edge-infrastructure/recert
+```

--- a/ibu-imager/README.md
+++ b/ibu-imager/README.md
@@ -154,7 +154,9 @@ To create an IBU seed image out of your Single Node OpenShift (SNO), run the fol
  				-v /var:/var \
  				-v /var/run:/var/run \
  				-v /run/systemd/journal/socket:/run/systemd/journal/socket \
- 				quay.io/lochoa/ibu-imager:4.14.0 create --authfile /var/lib/kubelet/config.json --image quay.io/somewhere/ibu-seed-images:4.14.0-du
+ 				quay.io/lochoa/ibu-imager:4.14.0 create --authfile /var/lib/kubelet/config.json \
+ 				                                        --image quay.io/somewhere/ibu-seed-images:4.14.0-du
+ 				                                        --recert-image quay.io/edge-infrastructure/recert:latest
 
  ___ ____  _   _            ___
 |_ _| __ )| | | |          |_ _|_ __ ___   __ _  __ _  ___ _ __

--- a/ibu-imager/cmd/create.go
+++ b/ibu-imager/cmd/create.go
@@ -45,6 +45,7 @@ var (
 
 	// recertContainerImage is the container image for the recert tool
 	recertContainerImage string
+	recertSkipValidation bool
 )
 
 func init() {
@@ -67,11 +68,13 @@ func init() {
 	// Add create command
 	rootCmd.AddCommand(createCmd)
 
-	// Add flags related to container registry
+	// Add flags to imager command
 	createCmd.Flags().StringVarP(&authFile, "authfile", "a", imageRegistryAuthFile, "The path to the authentication file of the container registry.")
 	createCmd.Flags().StringVarP(&containerRegistry, "image", "i", "", "The full image name with the container registry to push the OCI image.")
 	createCmd.Flags().StringVarP(&recertContainerImage, "recert-image", "e", defaultRecertImage, "The full image name for the recert container tool.")
+	createCmd.Flags().BoolVarP(&recertSkipValidation, "skip-recert-validation", "", false, "Skips the validations performed by the recert tool.")
 
+	// Mark flags as required
 	createCmd.MarkFlagRequired("image")
 }
 
@@ -99,7 +102,7 @@ func create() {
 	}
 
 	seedCreator := seed.NewSeedCreator(client, log, op, rpmOstreeClient, backupDir, kubeconfigFile,
-		containerRegistry, authFile, recertContainerImage)
+		containerRegistry, authFile, recertContainerImage, recertSkipValidation)
 	err = seedCreator.CreateSeedImage()
 	if err != nil {
 		log.Fatal(err)

--- a/ibu-imager/cmd/create.go
+++ b/ibu-imager/cmd/create.go
@@ -73,7 +73,6 @@ func init() {
 	createCmd.Flags().StringVarP(&recertContainerImage, "recert-image", "e", defaultRecertImage, "The full image name for the recert container tool.")
 
 	createCmd.MarkFlagRequired("image")
-	createCmd.MarkFlagRequired("recert-image")
 }
 
 func create() {

--- a/ibu-imager/cmd/create.go
+++ b/ibu-imager/cmd/create.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -37,10 +36,15 @@ import (
 
 var (
 	scheme = runtime.NewScheme()
+
 	// authFile is the path to the registry credentials used to push the OCI image
 	authFile string
+
 	// containerRegistry is the registry to push the OCI image
 	containerRegistry string
+
+	// recertContainerImage is the container image for the recert tool
+	recertContainerImage string
 )
 
 func init() {
@@ -48,9 +52,6 @@ func init() {
 	utilruntime.Must(v1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
-
-// recertContainerImage is the container image for the recert tool
-var recertContainerImage string
 
 // createCmd represents the create command
 var createCmd = &cobra.Command{
@@ -70,19 +71,15 @@ func init() {
 	createCmd.Flags().StringVarP(&authFile, "authfile", "a", imageRegistryAuthFile, "The path to the authentication file of the container registry.")
 	createCmd.Flags().StringVarP(&containerRegistry, "image", "i", "", "The full image name with the container registry to push the OCI image.")
 	createCmd.Flags().StringVarP(&recertContainerImage, "recert-image", "e", defaultRecertImage, "The full image name for the recert container tool.")
+
+	createCmd.MarkFlagRequired("image")
+	createCmd.MarkFlagRequired("recert-image")
 }
 
 func create() {
 
 	var err error
 	log.Printf("OCI image creation has started")
-
-	// Check if containerRegistry was provided by the user
-	if containerRegistry == "" {
-		fmt.Printf(" *** Please provide a valid container registry to store the created OCI images *** \n")
-		log.Info("Skipping OCI image creation.")
-		return
-	}
 
 	op := ops.NewOps(log, ops.NewExecutor(log, true))
 	rpmOstreeClient := ostree.NewClient("ibu-imager", op)
@@ -94,12 +91,12 @@ func create() {
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile)
 	if err != nil {
-		log.Fatal("failed top create k8s config", err)
+		log.Fatal("Failed to create k8s config", err)
 	}
 
 	client, err := runtimeClient.New(config, runtimeClient.Options{Scheme: scheme})
 	if err != nil {
-		log.Fatal("failed to create runtime client", err)
+		log.Fatal("Failed to create runtime client", err)
 	}
 
 	seedCreator := seed.NewSeedCreator(client, log, op, rpmOstreeClient, backupDir, kubeconfigFile,
@@ -127,9 +124,6 @@ func copyConfigurationScripts() error {
 	log.Infof("Copying installation_configuration_files/scripts to local/bin")
 	return cp.Copy("installation_configuration_files/scripts", "/var/usrlocal/bin", cp.Options{AddPermission: os.FileMode(0o777)})
 }
-
-// copyEnvFile reads and copy the env file from the source directory to the destination directory
-// while performing variable substitution for each var.
 
 func handleServices(ops ops.Ops) error {
 	dir := "installation_configuration_files/services"

--- a/ibu-imager/ops/ops.go
+++ b/ibu-imager/ops/ops.go
@@ -2,9 +2,18 @@ package ops
 
 import (
 	"fmt"
+	"net/http"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// Default location for etcdStaticPodFile
+	etcdStaticPodFile = "/etc/kubernetes/manifests/etcd-pod.yaml"
 )
 
 // Ops is an interface for executing commands and actions in the host namespace
@@ -14,6 +23,8 @@ type Ops interface {
 	SystemctlAction(action string, args ...string) (string, error)
 	RunInHostNamespace(command string, args ...string) (string, error)
 	RunBashInHostNamespace(command string, args ...string) (string, error)
+	WaitForEtcd(endpoint string) error
+	GetImageFromPodDefinition(containerImage string) (string, error)
 }
 
 type ops struct {
@@ -66,4 +77,79 @@ func (o *ops) RunInHostNamespace(command string, args ...string) (string, error)
 func (o *ops) RunBashInHostNamespace(command string, args ...string) (string, error) {
 	args = append([]string{command}, args...)
 	return o.RunInHostNamespace("bash", "-c", strings.Join(args, " "))
+}
+
+// WaitForEtcd waits for the availability of the etcd server at the given healthz endpoint.
+// It continuously checks the healthz endpoint to determine the server's availability.
+// If the etcd server becomes accessible, it returns nil, indicating success. Otherwise, it returns an error.
+func (o *ops) WaitForEtcd(healthzEndpoint string) error {
+	// Use the default HTTP client
+	client := http.DefaultClient
+
+	for {
+		// Send an HTTP GET request to the healthz endpoint
+		resp, err := client.Get(healthzEndpoint)
+		if err != nil {
+			// If there was an error, wait for a short interval before retrying
+			time.Sleep(1 * time.Second)
+			o.log.Info(err)
+			continue
+		}
+
+		// Ensure the response body is closed after reading
+		defer resp.Body.Close()
+
+		// If the server responds with HTTP status 200 (OK), it's up and running
+		if resp.StatusCode == http.StatusOK {
+			return nil
+		}
+
+		// Wait for a short interval before retrying
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// GetImageFromPodDefinition reads a YAML file containing pod configuration data
+// and extracts the image name for a given container named.
+// It returns the image name if found, or an error if not found or encountered any issues.
+func (o *ops) GetImageFromPodDefinition(containerImage string) (string, error) {
+
+	// Define a struct to match the structure of the YAML data
+	type PodConfig struct {
+		APIVersion string `yaml:"apiVersion"`
+		Kind       string `yaml:"kind"`
+		Metadata   struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Spec struct {
+			Containers []struct {
+				Name  string `yaml:"name"`
+				Image string `yaml:"image"`
+			} `yaml:"containers"`
+		} `yaml:"spec"`
+	}
+
+	// Read the YAML file
+	yamlData, err := os.ReadFile(etcdStaticPodFile)
+	if err != nil {
+		return "", fmt.Errorf("error reading the YAML file: %w", err)
+	}
+
+	// Unmarshal the YAML data into the struct
+	var podConfig PodConfig
+	if err = yaml.Unmarshal(yamlData, &podConfig); err != nil {
+		return "", fmt.Errorf("error unmarshaling YAML data: %w", err)
+	}
+
+	// Loop through the containers and find the one named "etcd"
+	var etcdImage string
+	for _, container := range podConfig.Spec.Containers {
+		if container.Name == containerImage {
+			etcdImage = container.Image
+			return etcdImage, nil
+		}
+	}
+
+	// Return an error if no "etcd" container found or no image specified in YAML definition.
+	return "", fmt.Errorf("no 'etcd' container found or no image specified in YAML definition: %w", err)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,7 +21,7 @@ func WriteToFile(data interface{}, filePath string) error {
 func RenderTemplateFile(srcTemplate string, params map[string]any, dest string, perm os.FileMode) error {
 	templateData, err := os.ReadFile(srcTemplate)
 	if err != nil {
-		return fmt.Errorf("error occurred while trying to read %s : %w", srcTemplate, err)
+		return fmt.Errorf("error occurred while trying to read %s: %w", srcTemplate, err)
 	}
 
 	tmpl := template.New("template")
@@ -32,7 +32,7 @@ func RenderTemplateFile(srcTemplate string, params map[string]any, dest string, 
 	}
 
 	if err = os.WriteFile(dest, buf.Bytes(), perm); err != nil {
-		return fmt.Errorf("error occurred while trying to write rendered data to %s : %w", dest, err)
+		return fmt.Errorf("error occurred while trying to write rendered data to %s: %w", dest, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This validation ensures that the seed SNO cluster can be re-certified during the IBU workflow later on without errors. Additionally, it forces the expiration of the certificates in the seed SNO cluster.