### PR TITLE
Use RH go-toolset instead of dockerhub golang base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.hub.docker.com/library/golang:1.19 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 as builder
 
 WORKDIR /workspace
 
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a
 
 #####################################################################################################
 # Build the imager binary
-FROM registry.hub.docker.com/library/golang:1.19 as imager
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 as imager
 
 ENV CRIO_VERSION="v1.28.0"
 

--- a/ibu-imager/Dockerfile
+++ b/ibu-imager/Dockerfile
@@ -1,5 +1,5 @@
 ########## Builder ##########
-FROM registry.hub.docker.com/library/golang:1.19 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 AS builder
 
 ENV CRIO_VERSION="v1.28.0"
 


### PR DESCRIPTION
This PR replaces Dockerhub's [golang](https://registry.hub.docker.com/layers/library/golang/1.19/images/sha256-1611d4f97c5ab666d3c123d72b3bb646dd12bbf7577dd1388fdb191d54cdf440?context=explore) base image with the Red Hat's [go-toolset](https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690?architecture=amd64&image=653020421d14c242647051fc&container-tabs=overview) one. 

The latter is a bit bigger `449.3 MB` vs `361.55 MB`, but it's scanned for vulnerabilities and it's actively being maintained by RH.

