### PR TITLE
Revert back to dockerhub go registry but go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.19 as builder
+FROM registry.hub.docker.com/library/golang:1.20 as builder
 
 WORKDIR /workspace
 
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a
 
 #####################################################################################################
 # Build the imager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.19 as imager
+FROM registry.hub.docker.com/library/golang:1.20 as imager
 
 ENV CRIO_VERSION="v1.28.0"
 

--- a/ibu-imager/Dockerfile
+++ b/ibu-imager/Dockerfile
@@ -1,5 +1,5 @@
 ########## Builder ##########
-FROM registry.access.redhat.com/ubi9/go-toolset:1.19 AS builder
+FROM registry.hub.docker.com/library/golang:1.20 AS builder
 
 ENV CRIO_VERSION="v1.28.0"
 


### PR DESCRIPTION
This PR reverts build images to dockerhub, but updates them to go 1.20, as both projects are on go 1.20.