### PR TITLE
[imager] Add envFile to dynamically configure vars in systemd units

### DIFF
--- a/ibu-imager/cmd/consts.go
+++ b/ibu-imager/cmd/consts.go
@@ -19,6 +19,8 @@ package cmd
 const (
 	// Pull secret. Written by the machine-config-operator
 	imageRegistryAuthFile = "/var/lib/kubelet/config.json"
+	// defaultRecertImage is the default recert image location
+	defaultRecertImage = "quay.io/edge-infrastructure/recert:latest"
 	// backupDir is the directory where the ostree backup will be
 	backupDir = "/var/tmp/backup"
 	// Default kubeconfigFile location

--- a/ibu-imager/cmd/create.go
+++ b/ibu-imager/cmd/create.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"text/template"
 
 	cp "github.com/otiai10/copy"
 	"github.com/spf13/cobra"
@@ -34,6 +36,9 @@ var authFile string
 
 // containerRegistry is the registry to push the OCI image
 var containerRegistry string
+
+// recertContainerImage is the container image for the recert tool
+var recertContainerImage string
 
 // createCmd represents the create command
 var createCmd = &cobra.Command{
@@ -52,6 +57,7 @@ func init() {
 	// Add flags related to container registry
 	createCmd.Flags().StringVarP(&authFile, "authfile", "a", imageRegistryAuthFile, "The path to the authentication file of the container registry.")
 	createCmd.Flags().StringVarP(&containerRegistry, "image", "i", "", "The full image name with the container registry to push the OCI image.")
+	createCmd.Flags().StringVarP(&recertContainerImage, "recert-image", "e", defaultRecertImage, "The full image name for the recert container tool.")
 }
 
 func create() {
@@ -92,12 +98,58 @@ func copyConfigurationFiles(ops ops.Ops) error {
 		return err
 	}
 
+	// Prepare variable substitutions for template files
+	substitutions := map[string]interface{}{
+		"RecertContainerImage": recertContainerImage,
+	}
+
+	// copy env file
+	err = copyEnvFile(substitutions)
+	if err != nil {
+		return err
+	}
+
 	return handleServices(ops)
 }
 
 func copyConfigurationScripts() error {
 	log.Infof("Copying installation_configuration_files/scripts to local/bin")
 	return cp.Copy("installation_configuration_files/scripts", "/var/usrlocal/bin", cp.Options{AddPermission: os.FileMode(0o777)})
+}
+
+// copyEnvFile reads and copy the env file from the source directory to the destination directory
+// while performing variable substitution for each var.
+func copyEnvFile(data interface{}) error {
+	// Define source and destination file paths
+	srcFile := "installation_configuration_files/conf/installation-configuration.env"
+	destFile := "/etc/systemd/system/installation-configuration.env"
+
+	// Read the content of the source file
+	scriptContent, err := os.ReadFile(srcFile)
+	if err != nil {
+		return err
+	}
+
+	// Create a new template and parse the script content
+	t, err := template.New("envTemplate").Parse(string(scriptContent))
+	if err != nil {
+		return err
+	}
+
+	// Execute the template with the provided data for variable substitution
+	var modifiedScript strings.Builder
+	err = t.Execute(&modifiedScript, data)
+	if err != nil {
+		return err
+	}
+
+	// Write the modified script content to the destination file with appropriate permissions
+	err = os.WriteFile(destFile, []byte(modifiedScript.String()), os.FileMode(0o644))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func handleServices(ops ops.Ops) error {

--- a/ibu-imager/installation_configuration_files/conf/installation-configuration.env
+++ b/ibu-imager/installation_configuration_files/conf/installation-configuration.env
@@ -1,0 +1,1 @@
+RECERT_IMAGE="{{ .RecertContainerImage }}"

--- a/ibu-imager/installation_configuration_files/scripts/installation-configuration.sh
+++ b/ibu-imager/installation_configuration_files/scripts/installation-configuration.sh
@@ -32,9 +32,9 @@ function recert {
     OLD_IP=$(cat /etc/default/seed-ip)
 
     ETCD_IMAGE="$(jq -r '.spec.containers[] | select(.name == "etcd") | .image' </etc/kubernetes/manifests/etcd-pod.yaml)"
-    RECERT_IMAGE="quay.io/edge-infrastructure/recert:latest"
+    local recert_tool_image=${RECERT_IMAGE:-quay.io/edge-infrastructure/recert:latest}
     local certs_dir=/var/opt/openshift/certs
-    local recert_cmd="sudo podman run --name recert --network=host --privileged -v /var/opt/openshift:/var/opt/openshift -v /etc/kubernetes:/kubernetes -v /var/lib/kubelet:/kubelet -v /etc/machine-config-daemon:/machine-config-daemon ${RECERT_IMAGE} --etcd-endpoint localhost:2379 --static-dir /kubernetes --static-dir /kubelet --static-dir /machine-config-daemon --extend-expiration"
+    local recert_cmd="sudo podman run --name recert --network=host --privileged -v /var/opt/openshift:/var/opt/openshift -v /etc/kubernetes:/kubernetes -v /var/lib/kubelet:/kubelet -v /etc/machine-config-daemon:/machine-config-daemon ${recert_tool_image} --etcd-endpoint localhost:2379 --static-dir /kubernetes --static-dir /kubelet --static-dir /machine-config-daemon --extend-expiration"
     sudo podman run --authfile=/var/lib/kubelet/config.json --name recert_etcd --detach --rm --network=host --privileged --entrypoint etcd -v /var/lib/etcd:/store ${ETCD_IMAGE} --name editor --data-dir /store
     sleep 10 # TODO: wait for etcd
 

--- a/ibu-imager/installation_configuration_files/services/installation-configuration.service
+++ b/ibu-imager/installation_configuration_files/services/installation-configuration.service
@@ -1,9 +1,12 @@
 [Unit]
 Description=Image base SNO configuration script
 After=nodeip-configuration.service prepare-installation-configuration.service
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/bin/installation-configuration.sh
+EnvironmentFile=-/etc/systemd/system/installation-configuration.env
+
 [Install]
 WantedBy=multi-user.target

--- a/ibu-imager/installation_configuration_files/services/prepare-installation-configuration.service
+++ b/ibu-imager/installation_configuration_files/services/prepare-installation-configuration.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Image base SNO configuration script
 Before=nodeip-configuration.service
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/bin/prepare-installation-configuration.sh
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This file can be used to configure on-the-fly the variables used / needed in the scripts called by the systemd units like  installation-configuration.service.