### PR TITLE
Adding clusterversion watch to rbac, delete ingress as we don't need it currently

### DIFF
--- a/bundle/manifests/lifecycle-agent-manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/lifecycle-agent-manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -38,6 +38,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:

--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -88,13 +88,6 @@ spec:
           verbs:
           - get
           - list
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - imagedigestmirrorsets
-          verbs:
-          - get
-          - list
           - watch
         - apiGroups:
           - lca.openshift.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,13 +38,6 @@ rules:
   verbs:
   - get
   - list
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - imagedigestmirrorsets
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - lca.openshift.io

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -19,14 +19,13 @@ import (
 )
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 
 const (
 	pullSecretName                = "pull-secret"
 	configNamespace               = "openshift-config"
 	upgradeConfigurationNamespace = "upgrade-configuration"
 	clusterConfigDir              = "/opt/openshift/cluster-configuration"
-	imageSetName                  = "mirror-ocp"
 	clusterIDFileName             = "cluster-id-override.json"
 	pullSecretFileName            = "pullsecret.json"
 	clusterInfoFileName           = "clusterinfo/manifest.json"
@@ -58,17 +57,13 @@ func (r *UpgradeClusterConfigGather) FetchClusterConfig(ctx context.Context, ost
 		return err
 	}
 	clusterID := clusterVersion.Spec.ClusterID
-	ingress := &v1.Ingress{}
-	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, ingress); err != nil {
-		return err
-	}
-	r.Log.Info("Successfully fetched cluster config")
 
 	cmClient := clusterinfo.NewClusterInfoClient(r.Client)
 	clusterData, err := cmClient.CreateClusterInfo(ctx)
 	if err != nil {
 		return err
 	}
+	r.Log.Info("Successfully fetched cluster config")
 
 	if err := r.writeClusterConfig(pullSecret, clusterID, ostreeDir, clusterData); err != nil {
 		return err

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -80,7 +80,7 @@ var (
 )
 
 func init() {
-	testscheme.AddKnownTypes(ocpV1.GroupVersion, &ocpV1.ClusterVersion{}, &ocpV1.Ingress{},
+	testscheme.AddKnownTypes(ocpV1.GroupVersion, &ocpV1.ClusterVersion{},
 		&ocpV1.ImageDigestMirrorSet{})
 	testscheme.AddKnownTypes(cro.GroupVersion, &cro.ClusterRelocation{})
 }
@@ -95,7 +95,6 @@ func TestClusterConfig(t *testing.T) {
 		name           string
 		secret         client.Object
 		clusterVersion client.Object
-		ingress        client.Object
 		expectedErr    bool
 		validateFunc   func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather)
 	}{
@@ -115,12 +114,6 @@ func TestClusterConfig(t *testing.T) {
 				Spec: ocpV1.ClusterVersionSpec{
 					ClusterID: "1",
 				},
-			},
-			ingress: &ocpV1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: ocpV1.IngressSpec{Domain: "test.com"},
 			},
 			expectedErr: false,
 			validateFunc: func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather) {
@@ -173,12 +166,6 @@ func TestClusterConfig(t *testing.T) {
 					ClusterID: "1",
 				},
 			},
-			ingress: &ocpV1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: ocpV1.IngressSpec{Domain: "test.com"},
-			},
 			expectedErr: true,
 			validateFunc: func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather) {
 				assert.Equal(t, errors.IsNotFound(err), true)
@@ -194,37 +181,9 @@ func TestClusterConfig(t *testing.T) {
 				},
 			},
 			clusterVersion: &ocpV1.ClusterVersion{},
-			ingress: &ocpV1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: ocpV1.IngressSpec{Domain: "test.com"},
-			},
-			expectedErr: true,
+			expectedErr:    true,
 			validateFunc: func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather) {
 				assert.Equal(t, strings.Contains(err.Error(), "clusterversion"), true)
-			},
-		},
-		{
-			name: "ingress error",
-			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      pullSecretName,
-					Namespace: configNamespace,
-				},
-			},
-			clusterVersion: &ocpV1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "version",
-				},
-				Spec: ocpV1.ClusterVersionSpec{
-					ClusterID: "1",
-				},
-			},
-			ingress:     &ocpV1.Ingress{},
-			expectedErr: true,
-			validateFunc: func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather) {
-				assert.Equal(t, strings.Contains(err.Error(), "ingress"), true)
 			},
 		},
 	}
@@ -234,7 +193,7 @@ func TestClusterConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			installConfig := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: clusterinfo.InstallConfigCM,
 				Namespace: clusterinfo.InstallConfigCMNamespace}, Data: map[string]string{"install-config": clusterCmData}}
-			objs := []client.Object{tc.secret, tc.clusterVersion, tc.ingress, installConfig}
+			objs := []client.Object{tc.secret, tc.clusterVersion, installConfig}
 			fakeClient, err := getFakeClientFromObjects(objs...)
 			if err != nil {
 				t.Errorf("error in creating fake client")


### PR DESCRIPTION
Adding clusterversion watch to rbac, delete ingress as we don't need it currently