### PR TITLE
init upgradehandler (pre-pivot) and cleanup

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -203,6 +203,17 @@ spec:
         - apiGroups:
           - velero.io/v1
           resources:
+          - deletebackuprequests
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - velero.io/v1
+          resources:
           - restores
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -153,6 +153,17 @@ rules:
 - apiGroups:
   - velero.io/v1
   resources:
+  - deletebackuprequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - velero.io/v1
+  resources:
   - restores
   verbs:
   - create

--- a/internal/backuprestore/restore_test.go
+++ b/internal/backuprestore/restore_test.go
@@ -49,7 +49,7 @@ func fakeRestoreCr(name, applyWave, backupName string) *velerov1.Restore {
 		},
 	}
 	restore.SetName(name)
-	restore.SetNamespace(oadpNs)
+	restore.SetNamespace(OadpNs)
 	restore.SetAnnotations(map[string]string{applyWaveAnn: applyWave})
 
 	restore.Spec = velerov1.RestoreSpec{
@@ -272,7 +272,7 @@ func TestTriggerRestore(t *testing.T) {
 
 	ns := &corev1.Namespace{
 		ObjectMeta: v1.ObjectMeta{
-			Name: oadpNs,
+			Name: OadpNs,
 		},
 	}
 
@@ -309,7 +309,7 @@ func TestTriggerRestore(t *testing.T) {
 			assert.Equal(t, tc.expectedStatus, restoreStatus.Status)
 
 			restoreList := &velerov1.RestoreList{}
-			err = fakeClient.List(context.Background(), restoreList, client.InNamespace(oadpNs))
+			err = fakeClient.List(context.Background(), restoreList, client.InNamespace(OadpNs))
 			if err != nil {
 				t.Errorf("unexpected error: %v", err.Error())
 			}
@@ -448,7 +448,7 @@ func TestRestoreDataProtectionApplications(t *testing.T) {
 			"apiVersion": dpaGvk.Group + "/" + dpaGvk.Version,
 			"metadata": map[string]interface{}{
 				"name":      "oadp",
-				"namespace": oadpNs,
+				"namespace": OadpNs,
 			},
 		},
 	}
@@ -488,7 +488,7 @@ func TestRestoreDataProtectionApplications(t *testing.T) {
 	existingDpa := &unstructured.Unstructured{}
 	existingDpa.SetGroupVersionKind(dpaGvk)
 	err = fakeClient.Get(context.Background(), client.ObjectKey{
-		Name: "oadp", Namespace: "openshift-adp",
+		Name: "oadp", Namespace: OadpNs,
 	}, existingDpa)
 	assert.NoError(t, err)
 
@@ -498,7 +498,7 @@ func fakeBackupStorageBackendWithStatus(name string, phase velerov1.BackupStorag
 	return &velerov1.BackupStorageLocation{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
-			Namespace: oadpNs,
+			Namespace: OadpNs,
 		},
 		Status: velerov1.BackupStorageLocationStatus{
 			Phase: phase,
@@ -536,7 +536,7 @@ func TestEnsureStorageBackendAvaialble(t *testing.T) {
 	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: oadpNs,
+			Name: OadpNs,
 		},
 	}
 
@@ -554,7 +554,7 @@ func TestEnsureStorageBackendAvaialble(t *testing.T) {
 				Log:    ctrl.Log.WithName("BackupRestore"),
 			}
 
-			ok, err := handler.ensureStorageBackendAvaialble(context.Background(), oadpNs)
+			ok, err := handler.ensureStorageBackendAvaialble(context.Background(), OadpNs)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}

--- a/internal/extramanifest/extramanifest.go
+++ b/internal/extramanifest/extramanifest.go
@@ -48,13 +48,13 @@ func (h *EMHandler) ExportExtraManifestToDir(ctx context.Context, extraManifestC
 		return nil
 	}
 
-	// Create the directory for the extra manifests
-	if err := os.MkdirAll(filepath.Join(toDir, extraManifestPath), 0o700); err != nil {
+	configmaps, err := getManifestConfigmaps(ctx, h.Client, extraManifestCMs)
+	if err != nil {
 		return err
 	}
 
-	configmaps, err := getManifestConfigmaps(ctx, h.Client, extraManifestCMs)
-	if err != nil {
+	// Create the directory for the extra manifests
+	if err := os.MkdirAll(filepath.Join(toDir, extraManifestPath), 0o700); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- init code for upgrade prepivot
  - Call and backup and extra-manifest as needed and moved some of the functions to upgradeHandler
  - No requeue-ing when an error is caught
- an error msg for when ibu name is not what's expected
- CRs to quickly deploy minIO and other support CRs+doc to work with backup in HACKING.md
- include RBAC for deletebackuprequests