### PR TITLE
Move to RH go-toolset 1.20 base images

### DIFF
--- a/ibu-imager/Dockerfile
+++ b/ibu-imager/Dockerfile
@@ -1,5 +1,5 @@
 ########## Builder ##########
-FROM registry.hub.docker.com/library/golang:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
 
 ENV CRIO_VERSION="v1.28.0"
 


### PR DESCRIPTION
This PR replaces the dockerhub Go 1.20 base images with the [RH go-toolset 1.20](https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690?architecture=amd64&image=654387c17ea05ac1dd92a58a). It also adds source code layers explicitly, in order to leverage caching where possible.

Related PRs: 
- https://github.com/openshift-kni/lifecycle-agent/pull/39
- https://github.com/openshift-kni/lifecycle-agent/pull/43