### PR TITLE
MGMT-16155: Copy  cluster-wide proxy from original SNO to upgraded one

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -114,6 +114,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - proxies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - lca.openshift.io
           resources:
           - imagebasedupgrades

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -64,6 +64,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - lca.openshift.io
   resources:
   - imagebasedupgrades


### PR DESCRIPTION
This change is part of the cluster reconfiguration, which takes place after spinning up the seed image onto the target SNO. Cluster reconfiguration supports a predefined set of the original SNO cluster's configuration, e.g. IDMS, pull-secret, network configuration.

Specifically, this change addresses fetcing the [OCP cluster-wide proxy ](https://docs.openshift.com/container-platform/4.14/networking/enable-cluster-wide-proxy.html)  of the original SNO and creating the respective JSON manifest to be [applied](https://github.com/openshift-kni/lifecycle-agent/blob/main/ibu-imager/installation_configuration_files/scripts/installation-configuration.sh#L199) alongside the rest of the cluster reconfiguration manifests.
    
> The canonical name for the Proxy object is `cluster`. As per the respective API [doc](https://github.com/openshift/api/blob/master/config/v1/types_proxy.go#L11).