### PR TITLE
Recertify multus and ovn static dirs

### DIFF
--- a/ibu-imager/installation_configuration_files/scripts/installation-configuration.sh
+++ b/ibu-imager/installation_configuration_files/scripts/installation-configuration.sh
@@ -41,7 +41,7 @@ function recert {
     ETCD_IMAGE="$(jq -r '.spec.containers[] | select(.name == "etcd") | .image' </etc/kubernetes/manifests/etcd-pod.yaml)"
     local recert_tool_image=${RECERT_IMAGE:-quay.io/edge-infrastructure/recert:latest}
     local certs_dir=/var/opt/openshift/certs
-    local recert_cmd="sudo podman run --name recert --network=host --privileged --replace -v /var/opt/openshift:/var/opt/openshift -v /etc/kubernetes:/kubernetes -v /var/lib/kubelet:/kubelet -v /etc/machine-config-daemon:/machine-config-daemon -v /etc:/host-etc ${recert_tool_image} --etcd-endpoint localhost:2379 --static-dir /kubernetes --static-dir /kubelet --static-dir /machine-config-daemon --static-file /host-etc/mcs-machine-config-content.json --extend-expiration"
+    local recert_cmd="sudo podman run --name recert --network=host --privileged --replace -v /var/opt/openshift:/var/opt/openshift -v /etc/kubernetes:/kubernetes -v /var/lib/kubelet:/kubelet -v /etc/machine-config-daemon:/machine-config-daemon -v /etc/cni/multus:/multus -v /var/lib/ovn-ic:/ovn-ic -v /etc:/host-etc ${recert_tool_image} --etcd-endpoint localhost:2379 --static-dir /kubernetes --static-dir /kubelet --static-dir /machine-config-daemon --static-dir /multus --static-dir /ovn-ic --static-file /host-etc/mcs-machine-config-content.json --extend-expiration"
     sudo podman run --authfile=/var/lib/kubelet/config.json --name recert_etcd --detach --rm --network=host --replace --privileged --entrypoint etcd -v /var/lib/etcd:/store ${ETCD_IMAGE} --name editor --data-dir /store
     sleep 10 # TODO: wait for etcd
 


### PR DESCRIPTION
This PR adds the `multus` and `OVN` directories for certificate regeneration when running recert. Without the regeneration of these certs, an OpenShift 4.14 cluster will be stuck trying to create containers because networking will be broken (due to OVN and multus authentication errors). 

The respective directories added for recertification are:

- `/var/lib/ovn-ic`
- `/etc/cni/multus`

In OpenShift 4.14, `multus` and `OVN` have added per-node certificates. For more info please check [here](https://github.com/openshift/multus-cni/commit/30558b5e68d3fd316fefa35fa7d258b91773f8a0) and [here](https://github.com/openshift/ovn-kubernetes/commit/7dc48048a346f175772fe5c2839b083f7a20c597).