### PR TITLE
Add pivot to Upgrade stage

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -282,6 +282,7 @@ spec:
                 - containerPort: 8443
                   name: https
                 resources: {}
+              hostPID: true
               serviceAccountName: lifecycle-agent-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,6 +66,7 @@ spec:
             cpu: 100m
             memory: 20Mi
       serviceAccountName: controller-manager
+      hostPID: true
       terminationGracePeriodSeconds: 10
       volumes:
       - hostPath:

--- a/internal/bindata/prepSetupStateroot.sh
+++ b/internal/bindata/prepSetupStateroot.sh
@@ -126,11 +126,8 @@ ostree pull-local "${ostree_repo}" || fatal "Failed: ostree pull-local ${ostree_
 ostree admin os-init "${new_osname}" || fatal "Failed: ostree admin os-init ${new_osname}"
 
 log_it "Creating new deployment ${new_osname}"
-# We should create the new deploy as not-default, and after the whole process is done, be able to switch to it for the next reboot
-# ostree admin deploy --os ${new_osname} $(build_kargs) --not-as-default ${upg_booted_ref}
-# Until I find how to do the switch, I'll deploy as default
 # shellcheck disable=SC2046
-ostree admin deploy --os "${new_osname}" $(build_kargs) "${upg_booted_ref}" || fatal "Failed ostree admin deploy"
+ostree admin deploy --not-as-default --os "${new_osname}" $(build_kargs) "${upg_booted_ref}" || fatal "Failed ostree admin deploy"
 ostree_deploy=$(ostree admin status | awk /"${new_osname}"/'{print $2}')
 if [ -z "${ostree_deploy}" ]; then
     fatal "Unable to determine deployment"

--- a/internal/generated/zz_generated.bindata.go
+++ b/internal/generated/zz_generated.bindata.go
@@ -444,11 +444,8 @@ ostree pull-local "${ostree_repo}" || fatal "Failed: ostree pull-local ${ostree_
 ostree admin os-init "${new_osname}" || fatal "Failed: ostree admin os-init ${new_osname}"
 
 log_it "Creating new deployment ${new_osname}"
-# We should create the new deploy as not-default, and after the whole process is done, be able to switch to it for the next reboot
-# ostree admin deploy --os ${new_osname} $(build_kargs) --not-as-default ${upg_booted_ref}
-# Until I find how to do the switch, I'll deploy as default
 # shellcheck disable=SC2046
-ostree admin deploy --os "${new_osname}" $(build_kargs) "${upg_booted_ref}" || fatal "Failed ostree admin deploy"
+ostree admin deploy --not-as-default --os "${new_osname}" $(build_kargs) "${upg_booted_ref}" || fatal "Failed ostree admin deploy"
 ostree_deploy=$(ostree admin status | awk /"${new_osname}"/'{print $2}')
 if [ -z "${ostree_deploy}" ]; then
     fatal "Unable to determine deployment"


### PR DESCRIPTION
This update includes:
- Add hostPID to pod.spec for manager, needed for rpm-ostree operations
- Add progress file to Upgrade handler for failure handling
- Add --not-as-default to deployment creation in Prep stage
- Add ostree deployment pivot to Upgrade handler