### PR TITLE
Add hostPID to LCA pod

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -282,6 +282,7 @@ spec:
                 - containerPort: 8443
                   name: https
                 resources: {}
+              hostPID: true
               serviceAccountName: lifecycle-agent-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,7 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      hostPID: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       volumes:


### PR DESCRIPTION
setting `hostPID: true` in the pod allows us to use `nsenter` within the pod