### PR TITLE
Create recert configuration file in LCA 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+vendor/*/** linguist-generated=true
+bundle/*/** linguist-generated=true
+config/*/** linguist-generated=true
+internal/generated/*/** linguist-generated=true

--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -82,6 +82,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - secrets
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,6 +32,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/ibu-imager/clusterinfo/clusterinfo.go
+++ b/ibu-imager/clusterinfo/clusterinfo.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/openshift-kni/lifecycle-agent/utils"
 
 	v1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +26,7 @@ type ClusterInfo struct {
 	Domain      string `json:"domain,omitempty"`
 	ClusterName string `json:"cluster_name,omitempty"`
 	ClusterID   string `json:"cluster_id,omitempty"`
+	MasterIP    string `json:"master_ip,omitempty"`
 }
 
 type installConfigMetadata struct {
@@ -54,16 +56,38 @@ func (m *InfoClient) CreateClusterInfo(ctx context.Context) (*ClusterInfo, error
 	if err := m.client.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
 		return nil, err
 	}
+
 	installConfig, err := m.getInstallConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	ip, err := m.getNodeInternalIP(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ClusterInfo{
 		ClusterName: installConfig.Metadata.Name,
 		Domain:      installConfig.BaseDomain,
 		Version:     clusterVersion.Status.Desired.Version,
 		ClusterID:   string(clusterVersion.Spec.ClusterID),
+		MasterIP:    ip,
 	}, nil
+}
+
+func (m *InfoClient) getNodeInternalIP(ctx context.Context) (string, error) {
+	node, err := utils.GetSNOMasterNode(ctx, m.client)
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find node internal ip address")
 }
 
 func (m *InfoClient) getInstallConfig(ctx context.Context) (*basicInstallConfig, error) {

--- a/ibu-imager/clusterinfo/clusterinfo.go
+++ b/ibu-imager/clusterinfo/clusterinfo.go
@@ -77,6 +77,7 @@ func (m *InfoClient) CreateClusterInfo(ctx context.Context) (*ClusterInfo, error
 	}, nil
 }
 
+// TODO: add dual stuck support
 func (m *InfoClient) getNodeInternalIP(ctx context.Context) (string, error) {
 	node, err := utils.GetSNOMasterNode(ctx, m.client)
 	if err != nil {

--- a/ibu-imager/clusterinfo/clusterinfo.go
+++ b/ibu-imager/clusterinfo/clusterinfo.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/openshift-kni/lifecycle-agent/utils"
 
 	v1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/lifecycle-agent/utils"
 )
 
 const (

--- a/ibu-imager/installation_configuration_files/scripts/installation-configuration.sh
+++ b/ibu-imager/installation_configuration_files/scripts/installation-configuration.sh
@@ -5,11 +5,13 @@ set -x ## Be more verbose
 
 echo "Reconfiguring single node OpenShift"
 
-mkdir -p /opt/openshift
-cd /opt/openshift
+OPT_DIR=/opt/openshift
 
-EXTRA_MANIFESTS_PATH=/opt/openshift/extra-manifests
-RELOCATION_CONFIG_PATH=/opt/openshift/cluster-configuration
+mkdir -p ${OPT_DIR}
+cd ${OPT_DIR}
+
+EXTRA_MANIFESTS_PATH=${OPT_DIR}/extra-manifests
+RELOCATION_CONFIG_PATH=${OPT_DIR}/cluster-configuration
 
 echo "Waiting for ${RELOCATION_CONFIG_PATH}"
 while [[ ! -d "${RELOCATION_CONFIG_PATH}" ]]; do
@@ -25,60 +27,33 @@ fi
 echo "${RELOCATION_CONFIG_PATH} has been found"
 # Replace this with a function that loads values from yaml file
 set +o allexport
-NEW_CLUSTER_NAME=$(jq -r '.cluster_name' "${RELOCATION_CONFIG_PATH}"/clusterinfo/manifest.json)
-NEW_CLUSTER_BASE_DOMAIN=$(jq -r '.domain' "${RELOCATION_CONFIG_PATH}"/clusterinfo/manifest.json)
-NEW_CLUSTER_FULL_DOMAIN="${NEW_CLUSTER_NAME}.${NEW_CLUSTER_BASE_DOMAIN}"
 
 # Recertify
 function recert {
     # shellcheck disable=SC1091
     source /etc/default/sno_dnsmasq_configuration_overrides
-    NEW_CLUSTER_FULL_DOMAIN="${SNO_CLUSTER_NAME_OVERRIDE}.${SNO_BASE_DOMAIN_OVERRIDE}"
-
-    NODE_IP=${SNO_DNSMASQ_IP_OVERRIDE:-}
-    OLD_IP=$(cat /etc/default/seed-ip)
+    NODE_IP=${SNO_DNSMASQ_IP_OVERRIDE}
+    OLD_IP=$(jq -r '.master_ip' "${OPT_DIR}/seed_manifest.json")
 
     ETCD_IMAGE="$(jq -r '.spec.containers[] | select(.name == "etcd") | .image' </etc/kubernetes/manifests/etcd-pod.yaml)"
     local recert_tool_image=${RECERT_IMAGE:-quay.io/edge-infrastructure/recert:latest}
-    local certs_dir=/var/opt/openshift/certs
-    local recert_cmd="sudo podman run --name recert --network=host --privileged --replace -v /var/opt/openshift:/var/opt/openshift -v /etc/kubernetes:/kubernetes -v /var/lib/kubelet:/kubelet -v /etc/machine-config-daemon:/machine-config-daemon -v /etc:/host-etc ${recert_tool_image} --etcd-endpoint localhost:2379 --static-dir /kubernetes --static-dir /kubelet --static-dir /machine-config-daemon --static-file /host-etc/mcs-machine-config-content.json --extend-expiration"
+    local recert_cmd="sudo podman run --name recert --network=host --privileged --replace -e RECERT_CONFIG="${RELOCATION_CONFIG_PATH}/recert_config.json" -v /var/tmp:/var/tmp -v /opt/openshift:/opt/openshift -v /etc/kubernetes:/kubernetes -v /var/lib/kubelet:/kubelet -v /etc/machine-config-daemon:/machine-config-daemon -v /etc:/host-etc ${recert_tool_image}"
+
+    # run etcd
     sudo podman run --authfile=/var/lib/kubelet/config.json --name recert_etcd --detach --rm --network=host --replace --privileged --entrypoint etcd -v /var/lib/etcd:/store ${ETCD_IMAGE} --name editor --data-dir /store
     sleep 10 # TODO: wait for etcd
 
-    # Recert node ip in order to support single ip
-    # remove this condition when we will support only single ip
-    if [[ -n "${NODE_IP}" ]]; then
-        recert_cmd="${recert_cmd} ""--cn-san-replace ${OLD_IP},${NODE_IP}"
-        if [[ -n "${SEED_FULL_DOMAIN}" ]]; then
-            recert_cmd="${recert_cmd} ""--cn-san-replace api.${SEED_FULL_DOMAIN},api.${NEW_CLUSTER_FULL_DOMAIN}"
-            recert_cmd="${recert_cmd} ""--cn-san-replace api-int.${SEED_FULL_DOMAIN},api-int.${NEW_CLUSTER_FULL_DOMAIN}"
-            recert_cmd="${recert_cmd} ""--cn-san-replace *.apps.${SEED_FULL_DOMAIN},*.apps.${NEW_CLUSTER_FULL_DOMAIN}"
-            recert_cmd="${recert_cmd} ""--cluster-rename ${NEW_CLUSTER_NAME}:${NEW_CLUSTER_BASE_DOMAIN}"
-        fi
-        if [[ ${NODE_IP} =~ .*:.* ]]; then
-            ETCD_NEW_IP="[${NODE_IP}]"
-        else
-            ETCD_NEW_IP=${NODE_IP}
-        fi
-
-        sudo podman exec -it recert_etcd bash -c "/usr/bin/etcdctl member list | cut -d',' -f1 | xargs -i etcdctl member update "{}" --peer-urls=http://${ETCD_NEW_IP}:2380"
-        sudo podman exec -it recert_etcd bash -c "/usr/bin/etcdctl del /kubernetes.io/configmaps/openshift-etcd/etcd-endpoints"
-        find /etc/kubernetes/ -type f -print0 | xargs -0 sed -i "s/${OLD_IP}/${NODE_IP}/g"
-    fi
-
-    # Use previous cluster certs if directory is present
-    if [[ -d $certs_dir ]]; then
-        ingress_key=$(readlink -f $certs_dir/ingresskey-*)
-        ingress_cn=$(basename $ingress_key | cut -d - -f 2-)
-        $recert_cmd \
-            --use-cert $certs_dir/admin-kubeconfig-client-ca.crt \
-            --use-key "kube-apiserver-lb-signer $certs_dir/loadbalancer-serving-signer.key" \
-            --use-key "kube-apiserver-localhost-signer $certs_dir/localhost-serving-signer.key" \
-            --use-key "kube-apiserver-service-network-signer $certs_dir/service-network-serving-signer.key" \
-            --use-key "$ingress_cn $ingress_key"
+    if [[ ${NODE_IP} =~ .*:.* ]]; then
+        ETCD_NEW_IP="[${NODE_IP}]"
     else
-        $recert_cmd
+        ETCD_NEW_IP=${NODE_IP}
     fi
+    # TODO: remove after https://issues.redhat.com/browse/ETCD-503
+    sudo podman exec -it recert_etcd bash -c "/usr/bin/etcdctl member list | cut -d',' -f1 | xargs -i etcdctl member update "{}" --peer-urls=http://${ETCD_NEW_IP}:2380"
+    sudo podman exec -it recert_etcd bash -c "/usr/bin/etcdctl del /kubernetes.io/configmaps/openshift-etcd/etcd-endpoints"
+    find /etc/kubernetes/ -type f -print0 | xargs -0 sed -i "s/${OLD_IP}/${NODE_IP}/g"
+
+    $recert_cmd
 
     # TODO: uncomment this once recert is stable
     # sudo podman rm recert
@@ -123,107 +98,20 @@ wait_approve_csr() {
 }
 
 wait_for_api
-wait_approve_csr "kube-apiserver-client-kubelet"
-wait_approve_csr "kubelet-serving"
 
-verify_csr_subject() {
-    local csr=${1}
-    local subject
-
-    subject="$(oc get csr -ojsonpath='{.spec.request}' "${csr}" |base64 -d | openssl req -noout -subject -nameopt multiline)"
-
-    if [ "$(echo "${subject}" |grep commonName |awk '{print $3}')" != "system:node:$(hostname)" ]; then
-        echo "CommonName is not 'system:node:master1'"
-        return
-    fi
-
-    if [ "$(echo "${subject}" |grep organizationName |awk '{print $3}')" != "system:nodes" ]; then
-        echo "Organization is not 'system:nodes'"
-        return
-    fi
-}
-
-# If the kubelet API server client certificate has expired:
-#   1. wait for the respective CSR to be created
-#   2. verify it
-#   3. approve it
-#   4. wait for the certificate to be issued
-KUBELET_CLIENT_CERTIFICATE=/var/lib/kubelet/pki/kubelet-client-current.pem
-until openssl x509 -in ${KUBELET_CLIENT_CERTIFICATE} -checkend 30 &> /dev/null; do
-    echo "${KUBELET_CLIENT_CERTIFICATE} has expired, waiting for new one to be issued..."
-
-    csr=$(oc get csr -o go-template='{{range .items}}{{if and (not .status) (eq .spec.signerName "kubernetes.io/kube-apiserver-client-kubelet") (eq .spec.username "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper")}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}' | head -1 || true)
-    if [ -z "${csr}" ]; then
-        sleep 5
-        continue
-    fi
-
-    echo "${csr} is pending. Verifying CSR before approving it..."
-    err=$(verify_csr_subject "${csr}")
-    if [ -n "${err}" ]; then
-        echo "${csr} could not be verified: ${err}"
-        break
-    fi
-
-    echo "${csr} successfully verified. Approving it..."
-    oc adm certificate approve "${csr}"
-done
-echo "${KUBELET_CLIENT_CERTIFICATE} is valid."
+# skip waiting for csrs in case node was already approved
+if [[ "$(oc get nodes -o jsonpath='{range .items[0]}{.status.conditions[?(@.type=="Ready")].status}')" != "True" ]]; then
+    wait_approve_csr "kube-apiserver-client-kubelet"
+    wait_approve_csr "kubelet-serving"
+fi
 
 echo "Applying cluster configuration"
-oc apply -f "${RELOCATION_CONFIG_PATH}"
+oc apply -f "${RELOCATION_CONFIG_PATH}/manifests"
 
 if [ -d ${EXTRA_MANIFESTS_PATH} ]; then
     echo "Applying extra-manifests"
     oc apply -f "${EXTRA_MANIFESTS_PATH}"
 fi
-
-verify_csr_addresses() {
-    local csr=${1}
-    local addresses=${2}
-    local csr_san_content
-
-    csr_san_content=$(oc get csr -ojsonpath='{.spec.request}' "${csr}" |base64 -d | openssl req -noout -text |grep DNS)
-    for address in "${addresses[@]}"; do
-        if [[ "${csr_san_content}" != *"${address}"* ]]; then
-            echo "${address} not in CSR DNS or IP addresses"
-            return
-        fi
-    done
-}
-# If the kubelet serving certificate has expired:
-#   1. wait for the respective CSR to be created
-#   2. verify it
-#   3. approve it
-#   4. wait for the certificate to be issued
-KUBELET_SERVING_CERTIFICATE=/var/lib/kubelet/pki/kubelet-server-current.pem
-until openssl x509 -in ${KUBELET_SERVING_CERTIFICATE} -checkend 30 &> /dev/null; do
-    echo "${KUBELET_SERVING_CERTIFICATE} has expired, waiting for new one to be issued..."
-
-    csr=$(oc get csr -o go-template='{{range .items}}{{if and (not .status) (eq .spec.signerName "kubernetes.io/kubelet-serving") (eq .spec.username "system:node:'"$(hostname)"'")}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}' | head -1 || true)
-    if [ -z "${csr}" ]; then
-        sleep 5
-        continue
-    fi
-
-    echo "${csr} is pending. Verifying CSR before approving it..."
-    err=$(verify_csr_subject "${csr}")
-    if [ -n "${err}" ]; then
-        echo "${csr} could not be verified: ${err}"
-        break
-    fi
-
-    IFS=$' ' read -r -d '' -a addresses < <( oc get nodes "$(hostname)" -ojsonpath='{.status.addresses[*].address}'  && printf '\0' )
-    err=$(verify_csr_addresses "${csr}" "${addresses}")
-    if [ -n "${err}" ]; then
-        echo "${csr} addresses could not be verified: ${err}"
-        break
-    fi
-
-    echo "${csr} successfully verified. Approving it..."
-    oc adm certificate approve "${csr}"
-done
-echo "${KUBELET_SERVING_CERTIFICATE} is valid."
 
 rm -rf /opt/openshift
 systemctl disable installation-configuration.service

--- a/ibu-imager/installation_configuration_files/scripts/prepare-installation-configuration.sh
+++ b/ibu-imager/installation_configuration_files/scripts/prepare-installation-configuration.sh
@@ -62,13 +62,11 @@ if [[ -f "${NETWORK_CONFIG_PATH}"/primary-ip ]]; then
     cp "${NETWORK_CONFIG_PATH}"/primary-ip /etc/default/node-ip
 fi
 
-# TODO: change after adding ip to manifest.json
-cp "${NETWORK_CONFIG_PATH}"/primary-ip /etc/default/node-ip
-
 RELOCATION_CONFIG_PATH=/opt/openshift/cluster-configuration
-NEW_CLUSTER_NAME=$(jq -r '.cluster_name' "${RELOCATION_CONFIG_PATH}"/clusterinfo/manifest.json)
-NEW_BASE_DOMAIN=$(jq -r '.domain' "${RELOCATION_CONFIG_PATH}"/clusterinfo/manifest.json)
-NEW_HOST_IP=$(cat /etc/default/node-ip)
+CLUSTER_CONFIG_FILE="${RELOCATION_CONFIG_PATH}"/clusterinfo/manifest.json
+NEW_CLUSTER_NAME=$(jq -r '.cluster_name' "${CLUSTER_CONFIG_FILE}")
+NEW_BASE_DOMAIN=$(jq -r '.domain' "${CLUSTER_CONFIG_FILE}")
+NEW_HOST_IP=$(jq -r '.master_ip' "${CLUSTER_CONFIG_FILE}")
 
 cat << EOF > /etc/default/sno_dnsmasq_configuration_overrides
 SNO_CLUSTER_NAME_OVERRIDE=${NEW_CLUSTER_NAME}

--- a/ibu-imager/installation_configuration_files/scripts/prepare-installation-configuration.sh
+++ b/ibu-imager/installation_configuration_files/scripts/prepare-installation-configuration.sh
@@ -58,12 +58,8 @@ if [[ -f "${NETWORK_CONFIG_PATH}"/hostname ]]; then
     cp "${NETWORK_CONFIG_PATH}"/hostname /etc/hostname
 fi
 
-if [[ -f "${NETWORK_CONFIG_PATH}"/primary-ip ]]; then
-    cp "${NETWORK_CONFIG_PATH}"/primary-ip /etc/default/node-ip
-fi
-
 RELOCATION_CONFIG_PATH=/opt/openshift/cluster-configuration
-CLUSTER_CONFIG_FILE="${RELOCATION_CONFIG_PATH}"/clusterinfo/manifest.json
+CLUSTER_CONFIG_FILE="${RELOCATION_CONFIG_PATH}"/manifest.json
 NEW_CLUSTER_NAME=$(jq -r '.cluster_name' "${CLUSTER_CONFIG_FILE}")
 NEW_BASE_DOMAIN=$(jq -r '.domain' "${CLUSTER_CONFIG_FILE}")
 NEW_HOST_IP=$(jq -r '.master_ip' "${CLUSTER_CONFIG_FILE}")

--- a/ibu-imager/seedcreator/seedcreator.go
+++ b/ibu-imager/seedcreator/seedcreator.go
@@ -14,7 +14,6 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	cp "github.com/otiai10/copy"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	runtime "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -513,21 +512,15 @@ func (s *SeedCreator) deleteNode(ctx context.Context) error {
 	}
 
 	s.log.Println("Deleting node")
-	nodesList := &corev1.NodeList{}
-	err = s.client.List(context.TODO(), nodesList)
+	node, err := utils.GetSNOMasterNode(ctx, s.client)
 	if err != nil {
 		return err
 	}
-	if len(nodesList.Items) > 1 {
-		return fmt.Errorf("we should have only one node in sno cluster to run seed image creation")
-	}
 
-	if len(nodesList.Items) > 0 {
-		s.log.Println("Deleting node ", nodesList.Items[0].Name)
-		err = s.client.Delete(ctx, &nodesList.Items[0])
-		if err != nil {
-			return err
-		}
+	s.log.Println("Deleting node ", node.Name)
+	err = s.client.Delete(ctx, node)
+	if err != nil {
+		return err
 	}
 
 	_, err = os.Create(doneFile)

--- a/internal/bindata/prepSetupStateroot.sh
+++ b/internal/bindata/prepSetupStateroot.sh
@@ -110,7 +110,7 @@ if [ -z "${upg_booted_id}" ] || [ -z "${upg_booted_deployment}" ] || [ -z "${upg
     fatal "Failed to identify deployment from seed image"
 fi
 
-up_ver=$(jq -r '.status.desired.version' "${img_mnt}/clusterversion.json")
+up_ver=$(jq -r '.version' "${img_mnt}/manifest.json")
 if [ -z "${up_ver}" ]; then
     fatal "Failed to identify version from seed image"
 fi
@@ -166,6 +166,9 @@ if [ -z "${ingress_cn}" ]; then
 fi
 oc extract -n openshift-ingress-operator secret/router-ca --keys=tls.key --to=- > "${certs_dir}/ingresskey-${ingress_cn}" \
     || fatal "Failed: oc extract -n openshift-ingress-operator secret/router-ca --keys=tls.key"
+
+log_it "Providing seed manifest.json"
+cp "${img_mnt}/manifest.json" "/ostree/deploy/${new_osname}/var/opt/openshift/seed_manifest.json"
 
 set_progress "completed-stateroot"
 

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -19,6 +19,7 @@ import (
 )
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=get;list;watch
 

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -28,10 +28,13 @@ const (
 	configNamespace               = "openshift-config"
 	upgradeConfigurationNamespace = "upgrade-configuration"
 	clusterConfigDir              = "/opt/openshift/cluster-configuration"
+	manifestDir                   = "manifests"
 	clusterIDFileName             = "cluster-id-override.json"
 	pullSecretFileName            = "pullsecret.json"
-	clusterInfoFileName           = "clusterinfo/manifest.json"
+	clusterInfoFileName           = "manifest.json"
 	idmsFIlePath                  = "image-digest-mirror-set.json"
+	certsDir                      = "/opt/openshift/certs"
+	seedManifest                  = "seed_manifest.json"
 )
 
 // UpgradeClusterConfigGather Gather ClusterConfig attributes from the kube-api
@@ -80,10 +83,10 @@ func (r *UpgradeClusterConfigGather) FetchClusterConfig(ctx context.Context, ost
 }
 
 // configDirs returns the files directory for the given cluster config
-func (r *UpgradeClusterConfigGather) configDirs(dir string) (string, error) {
-	filesDir := filepath.Join(dir, clusterConfigDir)
-	r.Log.Info("Creating cluster configuration folder", "folder", filesDir)
-	if err := os.MkdirAll(filepath.Join(filesDir, filepath.Dir(clusterInfoFileName)), 0o700); err != nil {
+func (r *UpgradeClusterConfigGather) configDirs(ostreeDir string) (string, error) {
+	filesDir := filepath.Join(ostreeDir, clusterConfigDir)
+	r.Log.Info("Creating cluster configuration folder and subfolder", "folder", filesDir)
+	if err := os.MkdirAll(filepath.Join(filesDir, manifestDir), 0o700); err != nil {
 		return "", err
 	}
 	return filesDir, nil
@@ -91,25 +94,30 @@ func (r *UpgradeClusterConfigGather) configDirs(dir string) (string, error) {
 
 // writeClusterConfig writes the required info based on the cluster config to the config cache dir
 func (r *UpgradeClusterConfigGather) writeClusterConfig(pullSecret *corev1.Secret,
-	clusterID v1.ClusterID, dir string, clusterData *clusterinfo.ClusterInfo, idmsList *v1.ImageDigestMirrorSetList) error {
-	clusterConfigPath, err := r.configDirs(dir)
+	clusterID v1.ClusterID, ostreeDir string, clusterData *clusterinfo.ClusterInfo, idmsList *v1.ImageDigestMirrorSetList) error {
+	clusterConfigPath, err := r.configDirs(ostreeDir)
 	if err != nil {
 		return err
 	}
 
-	if err := r.writeNamespaceToFile(filepath.Join(clusterConfigPath, "namespace.json")); err != nil {
+	manifestsDir := filepath.Join(clusterConfigPath, manifestDir)
+
+	if err := r.writeNamespaceToFile(filepath.Join(manifestsDir, "namespace.json")); err != nil {
 		return err
 	}
-	if err := r.writeSecretToFile(pullSecret, filepath.Join(clusterConfigPath, pullSecretFileName)); err != nil {
+	if err := r.writeSecretToFile(pullSecret, filepath.Join(manifestsDir, pullSecretFileName)); err != nil {
 		return err
 	}
-	if err := r.writeClusterIDToFile(clusterID, filepath.Join(clusterConfigPath, clusterIDFileName)); err != nil {
+	if err := r.writeClusterIDToFile(clusterID, filepath.Join(manifestsDir, clusterIDFileName)); err != nil {
+		return err
+	}
+	if err := r.writeIDMSsToFile(idmsList, filepath.Join(manifestsDir, idmsFIlePath)); err != nil {
 		return err
 	}
 	if err := utils.WriteToFile(clusterData, filepath.Join(clusterConfigPath, clusterInfoFileName)); err != nil {
 		return err
 	}
-	if err := r.writeIDMSsToFile(idmsList, filepath.Join(clusterConfigPath, idmsFIlePath)); err != nil {
+	if err := CreateRecertConfigFile(clusterData, clusterConfigPath, ostreeDir); err != nil {
 		return err
 	}
 

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -179,6 +179,7 @@ func TestClusterConfig(t *testing.T) {
 				assert.Equal(t, rConfig.ClusterRename, "test-infra-cluster:redhat.com")
 				assert.Equal(t, len(rConfig.CNSanReplaceRules), 4)
 				assert.Contains(t, rConfig.CNSanReplaceRules, fmt.Sprintf("%s,%s", seedManifestData.MasterIP, clusterInfo.MasterIP))
+				assert.Contains(t, rConfig.UseKey, "ingress@test /opt/openshift/certs/ingresskey-ingress@test")
 
 			},
 		},
@@ -301,6 +302,14 @@ func TestClusterConfig(t *testing.T) {
 			err = utils.WriteToFile(seedManifestData, filepath.Join(tmpDir, filepath.Dir(clusterConfigDir), seedManifest))
 			if err != nil {
 				t.Errorf("failed to create seed manifest, error: %v", err)
+			}
+
+			if err := os.MkdirAll(filepath.Join(tmpDir, certsDir), 0o700); err != nil {
+				t.Errorf("failed to create opt dir, error: %v", err)
+			}
+			_, err = os.Create(filepath.Join(tmpDir, certsDir, "ingresskey-ingress@test"))
+			if err != nil {
+				t.Errorf("failed to create ingress file, error: %v", err)
 			}
 
 			err = ucc.FetchClusterConfig(context.TODO(), tmpDir)

--- a/internal/clusterconfig/networkconfig.go
+++ b/internal/clusterconfig/networkconfig.go
@@ -2,8 +2,6 @@ package clusterconfig
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 
@@ -12,8 +10,7 @@ import (
 )
 
 const (
-	networkDir    = "/opt/openshift/network-configuration"
-	ipAddressFile = "/var/run/nodeip-configuration/primary-ip"
+	networkDir = "/opt/openshift/network-configuration"
 )
 
 // UpgradeNetworkConfigGather Gather network config files from host
@@ -26,18 +23,12 @@ var hostPath = "/host"
 var listOfPaths = []string{
 	"/etc/hostname",
 	"/etc/NetworkManager/system-connections",
-	ipAddressFile,
 }
 
 // FetchNetworkConfig gather network files and copy them
 func (r *UpgradeNetworkConfigGather) FetchNetworkConfig(ctx context.Context, ostreeDir string) error {
 	r.Log.Info("Fetching node network files")
 	dir, err := r.configDir(ostreeDir)
-	if err != nil {
-		return err
-	}
-
-	err = r.validateIPAddressFile()
 	if err != nil {
 		return err
 	}
@@ -51,21 +42,6 @@ func (r *UpgradeNetworkConfigGather) FetchNetworkConfig(ctx context.Context, ost
 	}
 	r.Log.Info("Done fetching node network files")
 	return nil
-}
-
-// validateIpAddressFile validates ip file has valid ip
-func (r *UpgradeNetworkConfigGather) validateIPAddressFile() error {
-	filePath := filepath.Join(hostPath, ipAddressFile)
-	hostIP, err := os.ReadFile(filePath)
-	if err != nil {
-		return fmt.Errorf("failed to read ip from file %s: %w", filePath, err)
-	}
-
-	ip := net.ParseIP(string(hostIP))
-	if ip == nil {
-		return fmt.Errorf("failed to parse ip %s from file %s", string(hostIP), filePath)
-	}
-	return err
 }
 
 // configDir returns the files directory for the given cluster config

--- a/internal/clusterconfig/networkconfig_test.go
+++ b/internal/clusterconfig/networkconfig_test.go
@@ -28,18 +28,16 @@ import (
 
 func TestNetworkConfig(t *testing.T) {
 	testcases := []struct {
-		name                 string
-		filesToCreate        []string
-		ipAddressFileContent string
-		expectedErr          bool
-		validateFunc         func(t *testing.T, tmpDir string, err error, files []string, unc UpgradeNetworkConfigGather)
+		name          string
+		filesToCreate []string
+		expectedErr   bool
+		validateFunc  func(t *testing.T, tmpDir string, err error, files []string, unc UpgradeNetworkConfigGather)
 	}{
 		{
 			name: "Validate success flow",
 			filesToCreate: []string{"/etc/hostname", "/etc/NetworkManager/system-connections/test1.txt",
-				"/etc/NetworkManager/system-connections/scripts/test1.txt", ipAddressFile},
-			expectedErr:          false,
-			ipAddressFileContent: "192.168.127.10",
+				"/etc/NetworkManager/system-connections/scripts/test1.txt"},
+			expectedErr: false,
 			validateFunc: func(t *testing.T, tmpDir string, err error, files []string, unc UpgradeNetworkConfigGather) {
 				dir, err := unc.configDir(tmpDir)
 				if err != nil {
@@ -60,26 +58,6 @@ func TestNetworkConfig(t *testing.T) {
 				assert.Equal(t, len(files), counter)
 			},
 		},
-		{
-			name: "No ip address file should fail",
-			filesToCreate: []string{"/etc/hostname", "/etc/NetworkManager/system-connections/test1.txt",
-				"/etc/NetworkManager/system-connections/scripts/test1.txt"},
-			expectedErr:          true,
-			ipAddressFileContent: "",
-			validateFunc: func(t *testing.T, tmpDir string, err error, files []string, unc UpgradeNetworkConfigGather) {
-				assert.Equal(t, err != nil, true)
-			},
-		},
-		{
-			name: "Bad ip address found, should fail",
-			filesToCreate: []string{"/etc/hostname", "/etc/NetworkManager/system-connections/test1.txt",
-				"/etc/NetworkManager/system-connections/scripts/test1.txt", ipAddressFile},
-			expectedErr:          true,
-			ipAddressFileContent: "bad ip",
-			validateFunc: func(t *testing.T, tmpDir string, err error, files []string, unc UpgradeNetworkConfigGather) {
-				assert.Equal(t, err != nil, true)
-			},
-		},
 	}
 
 	for _, tc := range testcases {
@@ -97,12 +75,6 @@ func TestNetworkConfig(t *testing.T) {
 				f, err := os.Create(newPath)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
-				}
-				if path == ipAddressFile {
-					_, err = f.WriteString(tc.ipAddressFileContent)
-					if err != nil {
-						t.Errorf("unexpected error: %v", err)
-					}
 				}
 
 				_ = f.Close()

--- a/internal/clusterconfig/recert.go
+++ b/internal/clusterconfig/recert.go
@@ -1,0 +1,91 @@
+package clusterconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift-kni/lifecycle-agent/ibu-imager/clusterinfo"
+	"github.com/openshift-kni/lifecycle-agent/utils"
+)
+
+const recertConfigFile = "recert_config.json"
+
+type recertConfig struct {
+	DryRun            bool     `json:"dry_run,omitempty"`
+	ExtendExpiration  bool     `json:"extend_expiration,omitempty"`
+	EtcdEndpoint      string   `json:"etcd_endpoint,omitempty"`
+	ClusterRename     string   `json:"cluster_rename,omitempty"`
+	SummaryFile       string   `json:"summary_file,omitempty"`
+	StaticDirs        []string `json:"static_dirs,omitempty"`
+	StaticFiles       []string `json:"static_files,omitempty"`
+	CNSanReplaceRules []string `json:"cn_san_replace_rules,omitempty"`
+	UseKey            []string `json:"use_key,omitempty"`
+	UseCert           string   `json:"use_cert,omitempty"`
+}
+
+// CreateRecertConfigFile function to create recert config file
+// those params will be provided to an installation script after reboot
+// that will run recert command with them
+func CreateRecertConfigFile(clusterData *clusterinfo.ClusterInfo,
+	clusterConfigPath string, ostreeDir string) error {
+	// read seed manifest json
+	seedManifestFile := filepath.Join(filepath.Dir(clusterConfigPath), seedManifest)
+	seedClusterInfo := &clusterinfo.ClusterInfo{}
+	err := utils.ReadYamlOrJSONFile(seedManifestFile, seedClusterInfo)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s data, error: %w", seedManifestFile, err)
+	}
+
+	config := recertConfig{
+		DryRun:           false,
+		EtcdEndpoint:     "localhost:2379",
+		ExtendExpiration: true,
+		StaticDirs:       []string{"/kubelet", "/kubernetes", "/machine-config-daemon"},
+		StaticFiles:      []string{"/host-etc/mcs-machine-config-content.json"},
+		ClusterRename:    fmt.Sprintf("%s:%s", clusterData.ClusterName, clusterData.Domain),
+		SummaryFile:      "/var/tmp/recert-summary.yaml",
+	}
+
+	seedFullDomain := fmt.Sprintf("%s.%s", seedClusterInfo.ClusterName, seedClusterInfo.Domain)
+	clusterFullDomain := fmt.Sprintf("%s.%s", clusterData.ClusterName, clusterData.Domain)
+
+	config.CNSanReplaceRules = []string{
+		fmt.Sprintf("%s,%s", seedClusterInfo.MasterIP, clusterData.MasterIP),
+		fmt.Sprintf("api.%s,api.%s", seedFullDomain, clusterFullDomain),
+		fmt.Sprintf("api-int.%s,api-int.%s", seedFullDomain, clusterFullDomain),
+		fmt.Sprintf("*.apps.%s,*.apps.%s", seedFullDomain, clusterFullDomain),
+	}
+
+	if _, err := os.Stat(filepath.Join(ostreeDir, certsDir)); err == nil {
+		ingressFile, ingressCN, err := getIngressCNAndFile(filepath.Join(ostreeDir, certsDir))
+		if err != nil {
+			return err
+		}
+		config.UseKey = []string{
+			fmt.Sprintf("kube-apiserver-lb-signer %s/loadbalancer-serving-signer.key", certsDir),
+			fmt.Sprintf("kube-apiserver-localhost-signer %s/localhost-serving-signer.key", certsDir),
+			fmt.Sprintf("kube-apiserver-service-network-signer %s/service-network-serving-signer.key", certsDir),
+			fmt.Sprintf("%s %s/%s", ingressCN, certsDir, ingressFile),
+		}
+
+		config.UseCert = filepath.Join(certsDir, "admin-kubeconfig-client-ca.crt")
+	}
+	return utils.WriteToFile(config, filepath.Join(clusterConfigPath, recertConfigFile))
+}
+
+func getIngressCNAndFile(certsFolder string) (string, string, error) {
+	certsFiles, err := os.ReadDir(certsFolder)
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, path := range certsFiles {
+		if strings.HasPrefix(path.Name(), "ingresskey-") {
+			return path.Name(), strings.Replace(path.Name(), "ingresskey-", "", 1), nil
+		}
+
+	}
+	return "", "", fmt.Errorf("failed to find ingress key file")
+}

--- a/internal/generated/zz_generated.bindata.go
+++ b/internal/generated/zz_generated.bindata.go
@@ -428,7 +428,7 @@ if [ -z "${upg_booted_id}" ] || [ -z "${upg_booted_deployment}" ] || [ -z "${upg
     fatal "Failed to identify deployment from seed image"
 fi
 
-up_ver=$(jq -r '.status.desired.version' "${img_mnt}/clusterversion.json")
+up_ver=$(jq -r '.version' "${img_mnt}/manifest.json")
 if [ -z "${up_ver}" ]; then
     fatal "Failed to identify version from seed image"
 fi
@@ -484,6 +484,9 @@ if [ -z "${ingress_cn}" ]; then
 fi
 oc extract -n openshift-ingress-operator secret/router-ca --keys=tls.key --to=- > "${certs_dir}/ingresskey-${ingress_cn}" \
     || fatal "Failed: oc extract -n openshift-ingress-operator secret/router-ca --keys=tls.key"
+
+log_it "Providing seed manifest.json"
+cp "${img_mnt}/manifest.json" "/ostree/deploy/${new_osname}/var/opt/openshift/seed_manifest.json"
 
 set_progress "completed-stateroot"
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,9 +2,13 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"os"
+	runtime "sigs.k8s.io/controller-runtime/pkg/client"
 	"text/template"
 )
 
@@ -35,4 +39,20 @@ func RenderTemplateFile(srcTemplate string, params map[string]any, dest string, 
 		return fmt.Errorf("error occurred while trying to write rendered data to %s: %w", dest, err)
 	}
 	return nil
+}
+
+func GetSNOMasterNode(ctx context.Context, client runtime.Client) (*corev1.Node, error) {
+	nodesList := &corev1.NodeList{}
+	err := client.List(ctx, nodesList, &runtime.ListOptions{LabelSelector: labels.SelectorFromSet(
+		labels.Set{
+			"node-role.kubernetes.io/master": "",
+		},
+	)})
+	if err != nil {
+		return nil, err
+	}
+	if len(nodesList.Items) != 1 {
+		return nil, fmt.Errorf("we should have one master node in sno cluster, current number is %d", len(nodesList.Items))
+	}
+	return &nodesList.Items[0], nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -43,7 +43,6 @@ func RenderTemplateFile(srcTemplate string, params map[string]any, dest string, 
 	return nil
 }
 
-// GetSNOMasterNode get master node of sno cluster
 func GetSNOMasterNode(ctx context.Context, client runtime.Client) (*corev1.Node, error) {
 	nodesList := &corev1.NodeList{}
 	err := client.List(ctx, nodesList, &runtime.ListOptions{LabelSelector: labels.SelectorFromSet(
@@ -60,7 +59,6 @@ func GetSNOMasterNode(ctx context.Context, client runtime.Client) (*corev1.Node,
 	return &nodesList.Items[0], nil
 }
 
-// ReadYamlOrJSONFile read json/yaml file into struct
 func ReadYamlOrJSONFile(filePath string, into interface{}) error {
 	data, err := os.ReadFile(filePath)
 	if err != nil {


### PR DESCRIPTION
Create recert configuration file in LCA: 
1. Adding host  ip to clusterInfo in order to use it for recert config
2. Moving recert configuration creation to LCA in order to remove this logic from installation script that will only run recert without decision making
3. LCA will create recert_config.json that will be provided to recert command
4. Installation script cleanup and impromevents
5. Moving get node ip to kube command