### PR TITLE
[Imager] Add recert steps to ops package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,29 +37,11 @@ COPY go.sum go.sum
 # Copy the go source
 COPY main main
 COPY utils utils
-COPY ibu-imager/clusterinfo ibu-imager/clusterinfo
-COPY ibu-imager/cmd ibu-imager/cmd
-COPY ibu-imager/ops ibu-imager/ops
-COPY ibu-imager/common ibu-imager/common
-COPY ibu-imager/seedcreator ibu-imager/seedcreator
-COPY ibu-imager/ostreeclient ibu-imager/ostreeclient
+COPY internal internal
+COPY ibu-imager ibu-imager
 
 # Build the binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/ibu-imager main/ibu-imager/main.go
-
-
-#####################################################################################################
-# Use this target to develop / test Imager only
-FROM registry.access.redhat.com/ubi9/ubi:latest as imager-dev
-
-RUN dnf -y install jq && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
-
-COPY --from=imager /opt/app-root/src/build/ibu-imager /usr/local/bin/ibu-imager
-COPY ibu-imager/installation_configuration_files/ /usr/local/installation_configuration_files/
-
-ENTRYPOINT ["/usr/local/bin/ibu-imager"]
 
 
 #####################################################################################################

--- a/ibu-imager/common/consts.go
+++ b/ibu-imager/common/consts.go
@@ -30,6 +30,7 @@ const (
 	DefaultRecertImage     = "quay.io/edge-infrastructure/recert:latest"
 	EtcdStaticPodFile      = "/etc/kubernetes/manifests/etcd-pod.yaml"
 	EtcdStaticPodContainer = "etcd"
+	EtcdDefaultEndpoint    = "http://localhost:2379"
 
 	InstallationConfigurationFilesDir = "/usr/local/installation_configuration_files"
 )

--- a/ibu-imager/ops/ops.go
+++ b/ibu-imager/ops/ops.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
+
+	"github.com/openshift-kni/lifecycle-agent/ibu-imager/common"
+	"github.com/openshift-kni/lifecycle-agent/internal/clusterconfig"
 )
 
 // Ops is an interface for executing commands and actions in the host namespace
@@ -18,8 +21,10 @@ type Ops interface {
 	SystemctlAction(action string, args ...string) (string, error)
 	RunInHostNamespace(command string, args ...string) (string, error)
 	RunBashInHostNamespace(command string, args ...string) (string, error)
-	WaitForEtcd(endpoint string) error
+
+	RunUnauthenticatedEtcdServer(etcdImage, authFile string) error
 	GetImageFromPodDefinition(etcdStaticPodFile, containerImage string) (string, error)
+	RunRecert(authFile, recertContainerImage string, additionalArgs ...string) error
 }
 
 type ops struct {
@@ -74,26 +79,6 @@ func (o *ops) RunBashInHostNamespace(command string, args ...string) (string, er
 	return o.RunInHostNamespace("bash", "-c", strings.Join(args, " "))
 }
 
-func (o *ops) WaitForEtcd(healthzEndpoint string) error {
-	for {
-		resp, err := http.Get(healthzEndpoint)
-		if err != nil {
-			o.log.Infof("Waiting for etcd: %s", err)
-			time.Sleep(1 * time.Second)
-			continue
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			o.log.Infof("Waiting for etcd, status: %d", resp.StatusCode)
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		return nil
-	}
-}
-
 func (o *ops) GetImageFromPodDefinition(podFile, containerImage string) (string, error) {
 	type PodConfig struct {
 		Spec struct {
@@ -123,4 +108,82 @@ func (o *ops) GetImageFromPodDefinition(podFile, containerImage string) (string,
 	}
 
 	return "", fmt.Errorf("no 'etcd' container found or no image specified in YAML definition: %w", err)
+}
+
+func (o *ops) RunUnauthenticatedEtcdServer(etcdImage, authFile string) error {
+	o.log.Info("Run unauthenticated etcd server for recert tool")
+
+	command := "podman"
+	args := append(clusterconfig.PodmanRecertArgs, authFile, "--name", "recert_etcd",
+		"--entrypoint", "etcd",
+		"-v", "/var/lib/etcd:/store",
+		etcdImage,
+		"--name", "editor", "--data-dir", "/store")
+
+	// Run the command and return an error if it occurs
+	_, err := o.RunInHostNamespace(command, args...)
+	if err != nil {
+		return err
+	}
+
+	o.log.Info("Waiting for unauthenticated etcd start serving for recert tool")
+	err = o.waitForEtcd(common.EtcdDefaultEndpoint + "/health")
+	if err != nil {
+		return fmt.Errorf("failed to wait for unauthenticated etcd server: %w", err)
+	}
+	o.log.Info("Unauthenticated etcd server for recert is up and running")
+
+	return nil
+}
+
+func (o *ops) waitForEtcd(healthzEndpoint string) error {
+	timeout := time.After(1 * time.Minute)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for etcd")
+		case <-ticker.C:
+			resp, err := http.Get(healthzEndpoint)
+			if err != nil {
+				o.log.Infof("Waiting for etcd: %s", err)
+				continue
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				o.log.Infof("Waiting for etcd, status: %d", resp.StatusCode)
+				continue
+			}
+
+			return nil
+		}
+	}
+}
+
+func (o *ops) RunRecert(recertContainerImage, authFile string, additionalArgs ...string) error {
+	command := "podman"
+	args := append(clusterconfig.PodmanRecertArgs, authFile, "--name", "recert",
+		"-v", "/etc:/host-etc",
+		"-v", "/etc/kubernetes:/kubernetes",
+		"-v", "/var/lib/kubelet:/kubelet",
+		"-v", common.BackupCertsDir+":/certs",
+		"-v", "/etc/machine-config-daemon:/machine-config-daemon",
+		recertContainerImage,
+		"--etcd-endpoint", "localhost:2379",
+		"--static-dir", "/kubernetes",
+		"--static-dir", "/kubelet",
+		"--static-dir", "/machine-config-daemon")
+
+	// Add additional arguments to the command
+	args = append(args, additionalArgs...)
+
+	_, err := o.RunInHostNamespace(command, args...)
+	if err != nil {
+		return fmt.Errorf("failed to run recert tool container: %w", err)
+	}
+
+	return nil
 }

--- a/internal/clusterconfig/recert.go
+++ b/internal/clusterconfig/recert.go
@@ -12,6 +12,19 @@ import (
 
 const recertConfigFile = "recert_config.json"
 
+// PodmanRecertArgs is the list of arguments to be used by podman when
+// calling the recert tool
+var PodmanRecertArgs = []string{
+	"run", "--detach", "--rm", "--network=host", "--privileged", "--replace", "--authfile",
+}
+
+// ForceExpireAdditionalFlags are the flags to be passed to recert
+// to force expiring of seed cluster certificates
+var ForceExpireAdditionalFlags = []string{
+	"--summary-file-clean", "/kubernetes/recert-seed-summary.yaml",
+	"--force-expire",
+}
+
 type recertConfig struct {
 	DryRun            bool     `json:"dry_run,omitempty"`
 	ExtendExpiration  bool     `json:"extend_expiration,omitempty"`


### PR DESCRIPTION
Having recert validation steps in ops will allow us to use the same steps in different workflows (e.g., seed image creation and cleanup) of the ibu-imager.