### PR TITLE
Remove redundant metadata from pull-secret in cluster reconfiguration

### DIFF
--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -141,8 +141,15 @@ func (r *UpgradeClusterConfigGather) writeNamespaceToFile(filePath string) error
 func (r *UpgradeClusterConfigGather) writeSecretToFile(secret *corev1.Secret, filePath string) error {
 	// override namespace
 	r.Log.Info("Writing secret to file", "path", filePath)
-	secret.Namespace = upgradeConfigurationNamespace
-	return utils.WriteToFile(secret, filePath)
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret.Name,
+			Namespace: upgradeConfigurationNamespace,
+		},
+		Data: secret.Data,
+		Type: secret.Type,
+	}
+	return utils.WriteToFile(s, filePath)
 }
 
 func (r *UpgradeClusterConfigGather) typeMetaForObject(o runtime.Object) (*metav1.TypeMeta, error) {


### PR DESCRIPTION
This PR removes the original `pull-secret`s metadata from the respective manifest, which is applied as part of the cluster reconfiguration. 

This change fixes the following `installation-configuration.service` failure:

```shell
journalctl -f -u installation-configuration.service
Nov 17 13:54:21 sno1 installation-configuration.sh[64556]: Error from server (Conflict): error when applying patch:
Nov 17 13:54:21 sno1 installation-configuration.sh[64556]: {"metadata":{"creationTimestamp":"2023-11-16T14:58:57Z","managedFields":[{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1":{"f:data":{".":{},"f:.dockerconfigjson":{}},"f:type":{}},"manager":"cluster-bootstrap","operation":"Update","time":"2023-11-16T14:58:57Z"}],"resourceVersion":"1876","uid":"9849789b-d0f4-45fe-8108-3b690fec728b"}}
Nov 17 13:54:21 sno1 installation-configuration.sh[64556]: to:
Nov 17 13:54:21 sno1 installation-configuration.sh[64556]: Resource: "/v1, Resource=secrets", GroupVersionKind: "/v1, Kind=Secret"
Nov 17 13:54:21 sno1 installation-configuration.sh[64556]: Name: "pull-secret", Namespace: "upgrade-configuration"
Nov 17 13:54:21 sno1 installation-configuration.sh[64556]: for: "/opt/openshift/cluster-configuration/manifests/pullsecret.json": error when patching "/opt/openshift/cluster-configuration/manifests/pullsecret.json": Operation cannot be fulfilled on secrets "pull-secret": the object has been modified; please apply your changes to the latest version and try again
Nov 17 13:54:21 sno1 systemd[1]: installation-configuration.service: Main process exited, code=exited, status=1/FAILURE
Nov 17 13:54:21 sno1 systemd[1]: installation-configuration.service: Failed with result 'exit-code'.
```