### PR TITLE
Cosmetic: rename `WriteToFile` function to `MarshalToFile`

### DIFF
--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -156,7 +156,7 @@ func (r *ImageBasedUpgradeReconciler) handleUpgrade(ctx context.Context, ibu *lc
 	// Temporarily empty resource version so the file can be used to restore status
 	rv := ibu.ResourceVersion
 	ibu.ResourceVersion = ""
-	if err := lcautils.WriteToFile(ibu, filePath); err != nil {
+	if err := lcautils.MarshalToFile(ibu, filePath); err != nil {
 		return doNotRequeue(), err
 	}
 	ibu.ResourceVersion = rv

--- a/ibu-imager/seedcreator/seedcreator.go
+++ b/ibu-imager/seedcreator/seedcreator.go
@@ -193,13 +193,13 @@ func (s *SeedCreator) gatherClusterInfo(ctx context.Context) error {
 	}
 
 	s.log.Info("Creating manifest.json")
-	if err := utils.WriteToFile(clusterManifest, path.Join(s.backupDir, "manifest.json")); err != nil {
+	if err := utils.MarshalToFile(clusterManifest, path.Join(s.backupDir, "manifest.json")); err != nil {
 		return err
 	}
 
 	// TODO: remove when we will drop it from preparation script
 	s.log.Info("Creating clusterversion.json")
-	if err := utils.WriteToFile(clusterVersion, path.Join(s.backupDir, "clusterversion.json")); err != nil {
+	if err := utils.MarshalToFile(clusterVersion, path.Join(s.backupDir, "clusterversion.json")); err != nil {
 		return err
 	}
 

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -121,7 +121,7 @@ func (r *UpgradeClusterConfigGather) fetchPullSecret(ctx context.Context, manife
 
 	filePath := filepath.Join(manifestsDir, pullSecretFileName)
 	r.Log.Info("Writing pull-secret to file", "path", filePath)
-	return utils.WriteToFile(s, filePath)
+	return utils.MarshalToFile(s, filePath)
 }
 
 func (r *UpgradeClusterConfigGather) fetchProxy(ctx context.Context, manifestsDir string) error {
@@ -146,7 +146,7 @@ func (r *UpgradeClusterConfigGather) fetchProxy(ctx context.Context, manifestsDi
 
 	filePath := filepath.Join(manifestsDir, proxyFileName)
 	r.Log.Info("Writing proxy to file", "path", filePath)
-	return utils.WriteToFile(p, filePath)
+	return utils.MarshalToFile(p, filePath)
 }
 
 func (r *UpgradeClusterConfigGather) fetchMachineConfigs(ctx context.Context, manifestsDir string) error {
@@ -173,7 +173,7 @@ func (r *UpgradeClusterConfigGather) fetchMachineConfigs(ctx context.Context, ma
 
 		filePath := filepath.Join(manifestsDir, machineConfig.Name+".json")
 		r.Log.Info("Writing MachineConfig to file", "path", filePath)
-		if err := utils.WriteToFile(mc, filePath); err != nil {
+		if err := utils.MarshalToFile(mc, filePath); err != nil {
 			return err
 		}
 	}
@@ -192,7 +192,7 @@ func (r *UpgradeClusterConfigGather) fetchClusterInfo(ctx context.Context, clust
 	filePath := filepath.Join(clusterConfigPath, common.ClusterInfoFileName)
 
 	r.Log.Info("Writing ClusterInfo to file", "path", filePath)
-	return utils.WriteToFile(clusterInfo, filePath)
+	return utils.MarshalToFile(clusterInfo, filePath)
 }
 
 func (r *UpgradeClusterConfigGather) fetchClusterVersion(ctx context.Context, manifestsDir string) error {
@@ -218,7 +218,7 @@ func (r *UpgradeClusterConfigGather) fetchClusterVersion(ctx context.Context, ma
 
 	filePath := filepath.Join(manifestsDir, clusterIDFileName)
 	r.Log.Info("Writing ClusterVersion with only the ClusterID field to file", "path", filePath)
-	return utils.WriteToFile(cv, filePath)
+	return utils.MarshalToFile(cv, filePath)
 }
 
 func (r *UpgradeClusterConfigGather) fetchIDMS(ctx context.Context, manifestsDir string) error {
@@ -235,7 +235,7 @@ func (r *UpgradeClusterConfigGather) fetchIDMS(ctx context.Context, manifestsDir
 
 	filePath := filepath.Join(manifestsDir, idmsFileName)
 	r.Log.Info("Writing IDMS to file", "path", filePath)
-	return utils.WriteToFile(idms, filePath)
+	return utils.MarshalToFile(idms, filePath)
 }
 
 // configDirs creates and returns the directory for the given cluster configuration.

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -375,7 +375,7 @@ func TestClusterConfig(t *testing.T) {
 			if err := os.MkdirAll(filepath.Join(tmpDir, common.OptOpenshift), 0o700); err != nil {
 				t.Errorf("failed to create opt dir, error: %v", err)
 			}
-			err = utils.WriteToFile(seedManifestData, filepath.Join(tmpDir, common.OptOpenshift, common.SeedManifest))
+			err = utils.MarshalToFile(seedManifestData, filepath.Join(tmpDir, common.OptOpenshift, common.SeedManifest))
 			if err != nil {
 				t.Errorf("failed to create seed manifest, error: %v", err)
 			}

--- a/internal/recert/recert.go
+++ b/internal/recert/recert.go
@@ -62,14 +62,14 @@ func CreateRecertConfigFile(clusterInfo, seedClusterInfo *clusterinfo.ClusterInf
 	}
 	config.UseCertRules = []string{filepath.Join(certsDir, "admin-kubeconfig-client-ca.crt")}
 
-	return utils.WriteToFile(config, filepath.Join(recertConfigFolder, RecertConfigFile))
+	return utils.MarshalToFile(config, filepath.Join(recertConfigFolder, RecertConfigFile))
 }
 
 func CreateRecertConfigFileForSeedCreation(path string) error {
 	config := createBasicEmptyRecertConfig()
 	config.SummaryFileClean = "/kubernetes/recert-seed-summary.yaml"
 	config.ForceExpire = true
-	return utils.WriteToFile(config, path)
+	return utils.MarshalToFile(config, path)
 }
 
 func createBasicEmptyRecertConfig() RecertConfig {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,8 +17,8 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// WriteToFile write interface to file
-func WriteToFile(data interface{}, filePath string) error {
+// MarshalToFile marshals anything and writes it to the given file path
+func MarshalToFile(data any, filePath string) error {
 	marshaled, err := json.Marshal(data)
 	if err != nil {
 		return err


### PR DESCRIPTION
I found the old name to be a bit confusing