### PR TITLE
CNF-10428: Add functionality to allow best-effort for pre-caching

### DIFF
--- a/internal/precache/constants.go
+++ b/internal/precache/constants.go
@@ -40,9 +40,10 @@ const StatusFile = utils.IBUWorkspacePath + "/precache_status.json"
 
 // Environment variable names
 const (
-	EnvLcaPrecacheImage string = "PRECACHE_WORKLOAD_IMG"
-	EnvPrecacheSpecFile string = "PRECACHE_SPEC_FILE"
-	EnvMaxPullThreads   string = "MAX_PULL_THREADS"
+	EnvLcaPrecacheImage   string = "PRECACHE_WORKLOAD_IMG"
+	EnvPrecacheSpecFile   string = "PRECACHE_SPEC_FILE"
+	EnvMaxPullThreads     string = "MAX_PULL_THREADS"
+	EnvPrecacheBestEffort string = "PRECACHE_BEST_EFFORT"
 )
 
 // Precaching job specs

--- a/main/main.go
+++ b/main/main.go
@@ -95,13 +95,14 @@ func main() {
 	le := leaderelection.LeaderElectionSNOConfig(configv1.LeaderElection{})
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "lca.openshift.io",
-		LeaseDuration:          &le.LeaseDuration.Duration,
-		RenewDeadline:          &le.RenewDeadline.Duration,
-		RetryPeriod:            &le.RetryPeriod.Duration,
+		Scheme:                        scheme,
+		HealthProbeBindAddress:        probeAddr,
+		LeaderElection:                enableLeaderElection,
+		LeaderElectionID:              "lca.openshift.io",
+		LeaseDuration:                 &le.LeaseDuration.Duration,
+		RenewDeadline:                 &le.RenewDeadline.Duration,
+		RetryPeriod:                   &le.RetryPeriod.Duration,
+		LeaderElectionReleaseOnCancel: true,
 		Metrics: server.Options{
 			BindAddress: metricsAddr,
 		},


### PR DESCRIPTION
This PR contains changes to allow a developer to configure pre-caching to `best-effort`, i.e. continue with Prep stage when the pre-caching job failed to pull one or more images.

/cc @donpenney @browsell 