### PR TITLE
[imager] Add restore cmd to expose cleanup workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,9 @@ catalog-push: ## Push a catalog image.
 imager-run: common-deps-update fmt vet ## Run the imager tool from your host.
 	go run main/ibu-imager/main.go
 
+imager-build: common-deps-update fmt vet ## Build the imager tool from your host.
+	go build -o bin/ibu-imager main/ibu-imager/main.go
+
 # Unittests variables
 TEST_FORMAT ?= standard-verbose
 GOTEST_FLAGS = --format=$(TEST_FORMAT)

--- a/ibu-imager/README.md
+++ b/ibu-imager/README.md
@@ -37,8 +37,8 @@ In that direction, the tool does the following at a high level:
 Building the binary locally.
 
 ```shell
--> make imager-build
-go mod tidy && go mod vendor
+-> make imager-build 
+go mod tidy
 Running go fmt
 go fmt ./...
 Running go vet
@@ -47,69 +47,6 @@ go build -o bin/ibu-imager main/ibu-imager/main.go
 ```
 
 > **Note:** The binary can be found in `./bin/ibu-imager`.
-
-Building and pushing the tool as container image.
-
-```shell
--> make imager-build-container imager-push
-podman build -t quay.io/lochoa/ibu-imager:4.14.0 -f Dockerfile .
-[1/2] STEP 1/9: FROM registry.hub.docker.com/library/golang:1.19 AS builder
-Trying to pull registry.hub.docker.com/library/golang:1.19...
-Getting image source signatures
-Copying blob 5ec11cb68eac done   |
-Copying blob 012c0b3e998c done   |
-Copying blob 9f13f5a53d11 done   |
-Copying blob 00046d1e755e done   |
-Copying blob 190fa1651026 done   |
-Copying blob 0808c6468790 done   |
-Copying config 80b76a6c91 done   |
-Writing manifest to image destination
-[1/2] STEP 2/9: ENV CRIO_VERSION="v1.28.0"
---> f33ad7e8ba50
-[1/2] STEP 3/9: WORKDIR /workspace
---> ea41fd2db1a9
-[1/2] STEP 4/9: COPY go.mod go.sum ./
---> 92a2056f63b9
-[1/2] STEP 5/9: COPY vendor/ vendor/
---> 10aaa8c0e678
-[1/2] STEP 6/9: COPY main.go main.go
---> bef5739828bf
-[1/2] STEP 7/9: COPY cmd/ cmd/
---> 6344ed52a7e9
-[1/2] STEP 8/9: RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o ibu-imager main.go
---> dbe5da0d5b09
-[1/2] STEP 9/9: RUN curl -sL https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRIO_VERSION/crictl-$CRIO_VERSION-linux-amd64.tar.gz         | tar xvzf - -C . && chmod +x ./crictl
-crictl
---> aece8a3afed3
-[2/2] STEP 1/6: FROM registry.access.redhat.com/ubi9/ubi:latest
-Trying to pull registry.access.redhat.com/ubi9/ubi:latest...
-Getting image source signatures
-Checking if image destination supports signatures
-Copying blob cc7c08d56aad done   |
-Copying config 20cef05760 done   |
-Writing manifest to image destination
-Storing signatures
-[2/2] STEP 2/6: WORKDIR /
---> dd42896a7332
-[2/2] STEP 3/6: COPY --from=builder /workspace/ibu-imager .
---> 2d4c7b6153c1
-[2/2] STEP 4/6: COPY --from=builder /workspace/crictl /usr/bin/
---> 7300e8f6820b
-[2/2] STEP 5/6: RUN yum -y install jq &&     yum clean all &&     rm -rf /var/cache/yum
-[2/2] STEP 6/6: ENTRYPOINT ["./ibu-imager"]
-[2/2] COMMIT quay.io/lochoa/ibu-imager:4.14.0
---> 4f070f5dc851
-Successfully tagged quay.io/lochoa/ibu-imager:4.14.0
-4f070f5dc851ef5476287fe4a8192f0d6969fc6471cb0e753d5cdd13b6a9c3b6
-podman push quay.io/lochoa/ibu-imager:4.14.0
-Getting image source signatures
-Copying blob 2b35b9c14c2a done   |
-Copying blob 6f740e943089 done   |
-Copying blob bcfbd6cf92f8 done   |
-Copying blob 13843eae2086 done   |
-Copying config 4f070f5dc8 done   |
-Writing manifest to image destination
-```
 
 ### Running the tool's help
 
@@ -125,7 +62,7 @@ To see the tool's help on your local host, run the following command:
 |___|____/ \___/           |___|_| |_| |_|\__,_|\__, |\___|_|
                                                 |___/
 
- A tool to assist building OCI seed images for Image Based Upgrades (IBU)
+ A tool to assist in building OCI seed images for Image Based Upgrades (IBU)
 
 Usage:
   ibu-imager [command]
@@ -134,6 +71,8 @@ Available Commands:
   completion  Generate the autocompletion script for the specified shell
   create      Create OCI image and push it to a container registry.
   help        Help about any command
+  post-pivot  post pivot configuration
+  restore     Restore seed cluster configurations
 
 Flags:
   -h, --help       help for ibu-imager
@@ -148,12 +87,21 @@ Use "ibu-imager [command] --help" for more information about a command.
 To create an IBU seed image out of your Single Node OpenShift (SNO), run the following command directly on the node:
 
 ```shell
+-> export LCA_IMAGE=$(oc get deployment -n openshift-lifecycle-agent lifecycle-agent-controller-manager -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].image}')
+
+-> export AUTHFILE=/path/to/pull-secret.json
+-> export SEED_IMG_REFSPEC=quay.io/${MY_REPO_ID}/${MY_REPO}:${MY_TAG}
+-> export IMG_RECERT_TOOL=quay.io/edge-infrastructure/recert:latest
+
 -> podman run --privileged --pid=host --rm --net=host \
-				-v /etc:/etc \
- 				-v /var:/var \
- 				-v /var/run:/var/run \
- 				-v /run/systemd/journal/socket:/run/systemd/journal/socket \
- 				quay.io/lochoa/ibu-imager:4.14.0 create --authfile /var/lib/kubelet/config.json --image quay.io/somewhere/ibu-seed-images:4.14.0-du
+    -v /etc:/etc \
+    -v /var:/var \
+    -v /var/run:/var/run \
+    -v /run/systemd/journal/socket:/run/systemd/journal/socket \
+    -v ${AUTHFILE}:${AUTHFILE} \
+    --entrypoint ibu-imager ${LCA_IMAGE} create --authfile ${AUTHFILE} \
+                                                 --image ${SEED_IMG_REFSPEC} \
+                                                 --recert-image ${IMG_RECERT_TOOL}
 
  ___ ____  _   _            ___
 |_ _| __ )| | | |          |_ _|_ __ ___   __ _  __ _  ___ _ __
@@ -164,22 +112,21 @@ To create an IBU seed image out of your Single Node OpenShift (SNO), run the fol
 
  A tool to assist building OCI seed images for Image Based Upgrades (IBU)
 
-time="2023-09-22 10:18:58" level=info msg="OCI image creation has started"
-time="2023-09-22 10:18:58" level=info msg="Saving list of running containers and clusterversion."
-time="2023-09-22 10:18:58" level=info msg="List of containers, catalogsources, and clusterversion saved successfully."
-time="2023-09-22 10:18:58" level=info msg="Stop kubelet service"
-time="2023-09-22 10:18:58" level=info msg="Stopping containers and CRI-O runtime."
-time="2023-09-22 10:18:58" level=info msg="Running containers and CRI-O engine stopped successfully."
-time="2023-09-22 10:18:58" level=info msg="Create backup datadir"
-time="2023-09-22 10:18:58" level=info msg="Backup of /var created successfully."
-time="2023-09-22 10:18:58" level=info msg="Backup of /etc created successfully."
-time="2023-09-22 10:18:58" level=info msg="Backup of ostree created successfully."
-time="2023-09-22 10:18:58" level=info msg="Backup of rpm-ostree.json created successfully."
-time="2023-09-22 10:18:58" level=info msg="Backup of mco-currentconfig created successfully."
-time="2023-09-22 10:19:05" level=info msg="Backup of .origin created successfully."
-time="2023-09-22 10:21:45" level=info msg="Encapsulate and push parent OCI image."
-time="2023-09-22 10:24:21" level=info msg="OCI image created successfully!"
+time="2023-11-28 11:50:12" level=info msg="OCI image creation has started"
+time="2023-11-28 11:50:12" level=info msg="Creating seed image"
+
+... TRUNCATED ...
+
+time="2023-11-28 11:55:25" level=info msg="OCI image created successfully!"
+time="2023-11-28 11:55:25" level=info msg="Cleaning up seed cluster"
+
+... TRUNCATED ...
+
+time="2023-11-28 11:56:37" level=info msg="Seed cluster restored successfully!"
 ```
 
-> **Note:** For a disconnected environment, first mirror the `ibu-imager` container image to your local registry using
-> [skopeo](https://github.com/containers/skopeo) or a similar tool.
+Notice that the `--recert-image` flag is optional (mainly used in disconnected environments), if not provided the
+tool will use `quay.io/edge-infrastructure/recert:latest` as the default recert image.
+
+> **Note:** For a disconnected environment, first mirror the `ibu-imager` and `recert` container images to your local 
+> registry using [skopeo](https://github.com/containers/skopeo) or a similar tool.

--- a/ibu-imager/cmd/create.go
+++ b/ibu-imager/cmd/create.go
@@ -70,14 +70,8 @@ func init() {
 	// Add create command
 	rootCmd.AddCommand(createCmd)
 
-	// Add flags to imager command
-	createCmd.Flags().StringVarP(&authFile, "authfile", "a", common.ImageRegistryAuthFile, "The path to the authentication file of the container registry.")
-	createCmd.Flags().StringVarP(&containerRegistry, "image", "i", "", "The full image name with the container registry to push the OCI image.")
-	createCmd.Flags().StringVarP(&recertContainerImage, "recert-image", "e", common.DefaultRecertImage, "The full image name for the recert container tool.")
-	createCmd.Flags().BoolVarP(&recertSkipValidation, "skip-recert-validation", "", false, "Skips the validations performed by the recert tool.")
-
-	// Mark flags as required
-	createCmd.MarkFlagRequired("image")
+	// Add flags to create command
+	addCommonFlags(createCmd)
 }
 
 func create() error {

--- a/ibu-imager/cmd/restore.go
+++ b/ibu-imager/cmd/restore.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
+	"github.com/openshift-kni/lifecycle-agent/ibu-imager/seedrestoration"
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+)
+
+var restoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore seed cluster configurations",
+	Run: func(cmd *cobra.Command, args []string) {
+		restore()
+	},
+}
+
+func init() {
+
+	// Add restore command
+	rootCmd.AddCommand(restoreCmd)
+
+	// Add flags to restore command
+	addCommonFlags(restoreCmd)
+}
+
+func restore() {
+	log.Info("Restore operation has started")
+
+	hostCommandsExecutor := ops.NewNsenterExecutor(log, true)
+	op := ops.NewOps(log, hostCommandsExecutor)
+
+	seedRestore := seedrestoration.NewSeedRestoration(log, op, common.BackupDir, containerRegistry,
+		authFile, recertContainerImage, recertSkipValidation)
+
+	if err := seedRestore.CleanupSeedCluster(); err != nil {
+		log.Fatalf("Failed to restore seed cluster: %v", err)
+	}
+
+	log.Info("Seed cluster restored successfully!")
+}

--- a/ibu-imager/cmd/root.go
+++ b/ibu-imager/cmd/root.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
 )
 
 // Create logger
@@ -38,6 +40,16 @@ var noColor bool
 
 // version is an optional command that will display the current release version
 var releaseVersion string
+
+func addCommonFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&authFile, "authfile", "a", common.ImageRegistryAuthFile, "The path to the authentication file of the container registry.")
+	cmd.Flags().StringVarP(&containerRegistry, "image", "i", "", "The full image name with the container registry to push the OCI image.")
+	cmd.Flags().StringVarP(&recertContainerImage, "recert-image", "e", common.DefaultRecertImage, "The full image name for the recert container tool.")
+	cmd.Flags().BoolVarP(&recertSkipValidation, "skip-recert-validation", "", false, "Skips the validations performed by the recert tool.")
+
+	// Mark flags as required
+	cmd.MarkFlagRequired("image")
+}
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Display verbose logs")

--- a/ibu-imager/seedcreator/seedcreator.go
+++ b/ibu-imager/seedcreator/seedcreator.go
@@ -467,12 +467,6 @@ func (s *SeedCreator) createAndPushSeedImage() error {
 		return fmt.Errorf("failed to push seed image: %w", err)
 	}
 
-	// Remove seed image from node
-	if _, err = s.ops.RunInHostNamespace(
-		"podman", []string{"rmi", s.containerRegistry}...); err != nil {
-		return fmt.Errorf("failed to remove seed image: %w", err)
-	}
-
 	return nil
 }
 

--- a/ibu-imager/seedrestoration/seedcleanup.go
+++ b/ibu-imager/seedrestoration/seedcleanup.go
@@ -68,6 +68,11 @@ func (s *SeedRestoration) CleanupSeedCluster() error {
 	// but still cleanup as much as possible.
 	var errors []error
 
+	if _, err := s.ops.RunInHostNamespace("podman", []string{"rmi", s.containerRegistry}...); err != nil {
+		s.log.Errorf("failed to remove seed image: %v", err)
+		errors = append(errors, err)
+	}
+
 	if err := s.cleanupServiceUnits(); err != nil {
 		s.log.Errorf("Error cleaning up systemd service files: %v", err)
 		errors = append(errors, err)


### PR DESCRIPTION
This exposes the cleanup workflow via a new restore cmd. Particularly handy when re-running such workflow is needed (e.g., after workflow failure).

Related to #79.