### PR TITLE
Enable additional golangci-lint plugins

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,12 +22,30 @@ linters:
     - unparam
     - gocyclo
     - unused
+    - errorlint
+    - loggercheck
 linters-settings:
   revive:
     rules:
       - name: if-return
         severity: warning
         disabled: true
+      - name: string-format
+        severity: warning
+        disabled: false
+        arguments:
+          - - 'core.WriteError[1].Message'
+            - '/^([^A-Z]|$)/'
+            - must not start with a capital letter
+          - - 'fmt.Errorf[0]'
+            - '/^([^A-Z]|$)/'
+            - must not start with a capital letter
+          - - 'fmt.Errorf[0]'
+            - '/(^|[^\.!?])$/'
+            - must not end in punctuation
+          - - panic
+            - '/^[^\n]*$/'
+            - must not contain line breaks
   gocritic:
     enabled-checks:
       # Diagnostic

--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -46,7 +46,7 @@ func (r *ImageBasedUpgradeReconciler) launchGetSeedImage(ctx context.Context, ib
 	err = os.WriteFile(common.PathOutsideChroot(scriptname), scriptcontent, 0o700)
 
 	if err != nil {
-		r.Log.Error(err, "Failed to write handler script", common.PathOutsideChroot(scriptname))
+		err = fmt.Errorf("failed to write handler script: %s, %w", common.PathOutsideChroot(scriptname), err)
 		return
 	}
 	r.Log.Info("Handler script written")
@@ -58,13 +58,13 @@ func (r *ImageBasedUpgradeReconciler) launchGetSeedImage(ctx context.Context, ib
 		var pullSecret string
 		pullSecret, err = utils.LoadSecretData(ctx, r.Client, ibu.Spec.SeedImageRef.PullSecretRef.Name, ibu.Namespace, corev1.DockerConfigJsonKey)
 		if err != nil {
-			err = fmt.Errorf("Failed to retrieve pull-secret from secret %s, err: %w", ibu.Spec.SeedImageRef.PullSecretRef.Name, err)
+			err = fmt.Errorf("failed to retrieve pull-secret from secret %s, err: %w", ibu.Spec.SeedImageRef.PullSecretRef.Name, err)
 			return
 		}
 
 		pullSecretFilename = filepath.Join(utils.IBUWorkspacePath, "seed-pull-secret")
 		if err = os.WriteFile(common.PathOutsideChroot(pullSecretFilename), []byte(pullSecret), 0o600); err != nil {
-			err = fmt.Errorf("Failed to write seed image pull-secret to file %s, err: %w", pullSecretFilename, err)
+			err = fmt.Errorf("failed to write seed image pull-secret to file %s, err: %w", pullSecretFilename, err)
 			return
 		}
 	}
@@ -98,7 +98,7 @@ func (r *ImageBasedUpgradeReconciler) launchPrecaching(ctx context.Context, imag
 
 	imageList, err := readPrecachingList(imageListFile)
 	if err != nil {
-		r.Log.Error(err, "Failed to read pre-caching image file", common.PathOutsideChroot(imageListFile))
+		err = fmt.Errorf("failed to read pre-caching image file: %s, %w", common.PathOutsideChroot(imageListFile), err)
 		return
 	}
 
@@ -185,7 +185,7 @@ func (r *ImageBasedUpgradeReconciler) launchSetupStateroot(
 	err = os.WriteFile(common.PathOutsideChroot(scriptname), scriptcontent, 0o700)
 
 	if err != nil {
-		r.Log.Error(err, "Failed to write handler script: %s", common.PathOutsideChroot(scriptname))
+		err = fmt.Errorf("failed to write handler script: %s, %w", common.PathOutsideChroot(scriptname), err)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (r *ImageBasedUpgradeReconciler) runCleanup(
 	err := os.WriteFile(common.PathOutsideChroot(scriptname), scriptcontent, 0o700)
 
 	if err != nil {
-		r.Log.Error(err, "Failed to write handler script: %s", common.PathOutsideChroot(scriptname))
+		r.Log.Error(err, fmt.Sprintf("failed to write handler script: %s", common.PathOutsideChroot(scriptname)))
 		return
 	}
 	r.Log.Info("Handler script written")

--- a/controllers/seedgen_controller.go
+++ b/controllers/seedgen_controller.go
@@ -163,7 +163,7 @@ func (r *SeedGeneratorReconciler) managedClusterExists(ctx context.Context, hubC
 	managedcluster := &clusterv1.ManagedCluster{}
 	if err := hubClient.Get(ctx, types.NamespacedName{Name: clusterName}, managedcluster); err != nil {
 		if client.IgnoreNotFound(err) != nil {
-			r.Log.Info("Error when checking managedcluster existence:", err.Error())
+			r.Log.Info(fmt.Sprintf("Error when checking managedcluster existence: %s", err.Error()))
 		}
 		return false
 	}
@@ -175,7 +175,7 @@ func (r *SeedGeneratorReconciler) currentAcmNamespaces(ctx context.Context) (acm
 	namespaces := &corev1.NamespaceList{}
 	if err := r.Client.List(ctx, namespaces); err != nil {
 		if client.IgnoreNotFound(err) != nil {
-			r.Log.Info("Error when checking namespaces: %w", err)
+			r.Log.Info(fmt.Sprintf("Error when checking namespaces: %s", err.Error()))
 		}
 		return
 	}
@@ -425,7 +425,7 @@ func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen
 			r.Log.Info("ManagedCluster does not exist on hub. Skipping cleanup")
 		}
 	} else {
-		r.Log.Info("No hubKubeconfig found in secret %s, skipping ACM", utils.SeedGenSecretName)
+		r.Log.Info(fmt.Sprintf("No hubKubeconfig found in secret %s, skipping ACM", utils.SeedGenSecretName))
 	}
 
 	// TODO: Can this be done cleanly via client? The client.DeleteAllOf seems to require a specified namespace, so maybe loop over the namespaces

--- a/ibu-imager/seedcreator/seedcreator.go
+++ b/ibu-imager/seedcreator/seedcreator.go
@@ -244,7 +244,7 @@ func (s *SeedCreator) createContainerList() error {
 func (s *SeedCreator) backupSeedCertificates(ctx context.Context) error {
 	s.log.Info("Backing up seed cluster certificates for recert tool")
 	if err := os.MkdirAll(common.BackupCertsDir, os.ModePerm); err != nil {
-		return fmt.Errorf("error creating %s: %v", common.BackupCertsDir, err)
+		return fmt.Errorf("error creating %s: %w", common.BackupCertsDir, err)
 	}
 
 	adminKubeConfigClientCA, err := s.manifestClient.GetConfigMapData(ctx, "admin-kubeconfig-client-ca", "openshift-config", "ca-bundle.crt")

--- a/ibu-imager/seedrestoration/seedcleanup.go
+++ b/ibu-imager/seedrestoration/seedcleanup.go
@@ -145,7 +145,7 @@ func (s *SeedRestoration) cleanupScriptFiles() error {
 
 		s.log.Infof("Removing script file %s", scriptName)
 		if err := os.Remove(filepath.Join("/var/usrlocal/bin/", scriptName)); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("error removing %s file: %v", scriptName, err)
+			return fmt.Errorf("error removing %s file: %w", scriptName, err)
 		}
 
 		return nil

--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -172,7 +172,7 @@ func SortByApplyWaveBackupCrs(resources []*velerov1.Backup) ([][]*velerov1.Backu
 
 		applyWaveInt, err := strconv.Atoi(applyWave)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to convert %s in Backup CR %s to interger: %s", applyWave, resource.GetName(), err)
+			return nil, fmt.Errorf("failed to convert %s in Backup CR %s to interger: %w", applyWave, resource.GetName(), err)
 		}
 		resourcesApplyWaveMap[applyWaveInt] = append(resourcesApplyWaveMap[applyWaveInt], resource)
 	}
@@ -439,7 +439,7 @@ func (h *BRHandler) ensureBackupsDeleted(ctx context.Context, backups []velerov1
 			return false, nil
 		})
 	if err != nil {
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			h.Log.Error(err, "Timeout waiting for backups to be deleted")
 			return false, nil
 		}

--- a/internal/backuprestore/restore_test.go
+++ b/internal/backuprestore/restore_test.go
@@ -506,7 +506,7 @@ func fakeBackupStorageBackendWithStatus(name string, phase velerov1.BackupStorag
 	}
 }
 
-func TestEnsureStorageBackendAvaialble(t *testing.T) {
+func TestEnsureStorageBackendAvailable(t *testing.T) {
 	testcases := []struct {
 		name     string
 		bsl      []client.Object
@@ -554,7 +554,7 @@ func TestEnsureStorageBackendAvaialble(t *testing.T) {
 				Log:    ctrl.Log.WithName("BackupRestore"),
 			}
 
-			ok, err := handler.ensureStorageBackendAvaialble(context.Background(), OadpNs)
+			ok, err := handler.ensureStorageBackendAvailable(context.Background(), OadpNs)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}

--- a/main/precache-workload/main.go
+++ b/main/precache-workload/main.go
@@ -94,7 +94,7 @@ func main() {
 
 	// Change root directory to /host
 	if err := syscall.Chroot(utils.Host); err != nil {
-		terminateOnError(fmt.Errorf("failed to chroot to %s, err: %s", utils.Host, err), Failure)
+		terminateOnError(fmt.Errorf("failed to chroot to %s, err: %w", utils.Host, err), Failure)
 	}
 	log.Infof("chroot %s successful", utils.Host)
 
@@ -107,7 +107,7 @@ func main() {
 	// Pre-cache images
 	status, err := workload.PullImages(precacheSpec)
 	if err != nil {
-		terminateOnError(fmt.Errorf("encountered error while pre-caching images, error: %v", err), Failure)
+		terminateOnError(fmt.Errorf("encountered error while pre-caching images, error: %w", err), Failure)
 	}
 	log.Info("Completed executing pre-caching, no errors encountered!")
 


### PR DESCRIPTION
Enabled the errorlint and loggercheck plugins, along with configuring the revive plugin to check for error messages that start with a capital letter.