### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 vendor/** linguist-generated=true
 bundle/** linguist-generated=true
-config/** linguist-generated=true
 internal/generated/** linguist-generated=true
 PROJECT linguist-generated=true


### PR DESCRIPTION
Files under config are mostly not generated. The CRD and role yaml, even though generated, are still easier to review than the kubebuilder annotation changes all over the go files.