### PR TITLE
    Add ExecuteWithLiveLogger and stop logging commands output by default

### DIFF
--- a/ibu-imager/ops/execute.go
+++ b/ibu-imager/ops/execute.go
@@ -103,9 +103,17 @@ func NewChrootExecutor(logger *logrus.Logger, verbose bool, root string) Execute
 	return &chrootExecutor{executor: executor{logger, verbose}, root: root}
 }
 
-func (e *chrootExecutor) Execute(command string, args ...string) (string, error) {
+func (e *chrootExecutor) baseExecute(writer io.Writer, command string, args ...string) (string, error) {
 	commandBase := "/usr/bin/env"
 	args = append([]string{command}, args...)
 	arguments := []string{"--", "bash", "-c", strings.Join(args, " ")}
-	return e.executor.execute(e.executor.log.Writer(), e.root, commandBase, arguments...)
+	return e.executor.execute(writer, e.root, commandBase, arguments...)
+}
+
+func (e *chrootExecutor) Execute(command string, args ...string) (string, error) {
+	return e.baseExecute(nil, command, args...)
+}
+
+func (e *chrootExecutor) ExecuteWithLiveLogger(command string, args ...string) (string, error) {
+	return e.baseExecute(e.executor.log.Writer(), command, args...)
 }

--- a/main/main.go
+++ b/main/main.go
@@ -65,11 +65,6 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-var logger = &logrus.Logger{
-	Out:   os.Stdout,
-	Level: logrus.InfoLevel,
-}
-
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
@@ -134,11 +129,6 @@ func main() {
 	// We want to remove logr.Logger first step to move to logrus
 	// in the future we will have only one of them
 	newLogger := logrus.New()
-	logger.SetFormatter(&logrus.TextFormatter{
-		DisableColors:   true,
-		TimestampFormat: "2006-01-02 15:04:05",
-		FullTimestamp:   true,
-	})
 	log := ctrl.Log.WithName("controllers").WithName("ImageBasedUpgrade")
 
 	executor := ops.NewChrootExecutor(newLogger, true, utils.Host)


### PR DESCRIPTION
logging output of every `ChrootExecutor.Execute` is cluttering the log,
log the output of commands explicitly if needed by calling `ExecuteWithLiveLogger`
Also removed unused logger