### PR TITLE
Remove InfoClient and move its functions to utils/client_helper.go

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
-	"github.com/openshift-kni/lifecycle-agent/ibu-imager/clusterinfo"
 	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
 	rpmostreeclient "github.com/openshift-kni/lifecycle-agent/ibu-imager/ostreeclient"
 	"github.com/openshift-kni/lifecycle-agent/internal/backuprestore"
@@ -61,7 +60,6 @@ type ImageBasedUpgradeReconciler struct {
 	ExtraManifest   *extramanifest.EMHandler
 	RPMOstreeClient rpmostreeclient.IClient
 	Executor        ops.Execute
-	ManifestClient  *clusterinfo.InfoClient
 	OstreeClient    ostreeclient.IClient
 	Ops             ops.Ops
 	PrepTask        *Task

--- a/controllers/seedgen_controller.go
+++ b/controllers/seedgen_controller.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
-	"github.com/openshift-kni/lifecycle-agent/ibu-imager/clusterinfo"
 	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	"github.com/openshift-kni/lifecycle-agent/internal/healthcheck"
@@ -700,8 +699,7 @@ func (r *SeedGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Get the cluster name
-	cmClient := clusterinfo.NewClusterInfoClient(r.Client)
-	clusterData, err := cmClient.CreateClusterInfo(ctx)
+	clusterData, err := commonUtils.CreateClusterInfo(ctx, r.Client)
 	if err != nil {
 		return
 	}

--- a/ibu-imager/clusterinfo/clusterinfo.go
+++ b/ibu-imager/clusterinfo/clusterinfo.go
@@ -1,29 +1,7 @@
 package clusterinfo
 
 import (
-	"bytes"
-	"context"
-	"fmt"
-	"strings"
-
-	v1 "github.com/openshift/api/config/v1"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/openshift-kni/lifecycle-agent/utils"
-)
-
-const (
-	// InstallConfigCM cm name
-	InstallConfigCM = "cluster-config-v1"
-	// InstallConfigCMNamespace cm namespace
-	InstallConfigCMNamespace = "kube-system"
-
-	CsvDeploymentName      = "cluster-version-operator"
-	CsvDeploymentNamespace = "openshift-cluster-version"
 )
 
 // ClusterInfo struct that describe current cluster critical info
@@ -41,7 +19,7 @@ type installConfigMetadata struct {
 	Name string `json:"name"`
 }
 
-type basicInstallConfig struct {
+type BasicInstallConfig struct {
 	BaseDomain string                `json:"baseDomain"`
 	Metadata   installConfigMetadata `json:"metadata"`
 }
@@ -55,140 +33,4 @@ func NewClusterInfoClient(client runtimeclient.Client) *InfoClient {
 	return &InfoClient{
 		client: client,
 	}
-}
-
-// CreateClusterInfo create cluster info
-func (m *InfoClient) CreateClusterInfo(ctx context.Context) (*ClusterInfo, error) {
-	clusterVersion := &v1.ClusterVersion{}
-	if err := m.client.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
-		return nil, err
-	}
-
-	installConfig, err := m.getInstallConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	node, err := utils.GetSNOMasterNode(ctx, m.client)
-	if err != nil {
-		return nil, err
-	}
-	ip, err := m.getNodeInternalIP(*node)
-	if err != nil {
-		return nil, err
-	}
-	hostname, err := m.getNodeHostname(*node)
-	if err != nil {
-		return nil, err
-	}
-
-	releaseRegistry, err := m.GetReleaseRegistry(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ClusterInfo{
-		ClusterName:     installConfig.Metadata.Name,
-		Domain:          installConfig.BaseDomain,
-		Version:         clusterVersion.Status.Desired.Version,
-		ClusterID:       string(clusterVersion.Spec.ClusterID),
-		MasterIP:        ip,
-		ReleaseRegistry: releaseRegistry,
-		Hostname:        hostname,
-	}, nil
-}
-
-func (m *InfoClient) GetSecretData(ctx context.Context, name, namespace, key string) (string, error) {
-	secret := &corev1.Secret{}
-	if err := m.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, secret); err != nil {
-		return "", err
-	}
-
-	data, ok := secret.Data[key]
-	if !ok {
-		return "", fmt.Errorf("did not find key %s in Secret %s/%s", key, name, namespace)
-	}
-
-	return string(data), nil
-}
-
-func (m *InfoClient) GetConfigMapData(ctx context.Context, name, namespace, key string) (string, error) {
-	cm := &corev1.ConfigMap{}
-	if err := m.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cm); err != nil {
-		return "", err
-	}
-
-	data, ok := cm.Data[key]
-	if !ok {
-		return "", fmt.Errorf("did not find key %s in ConfigMap", key)
-	}
-
-	return data, nil
-}
-
-// TODO: add dual stuck support
-func (m *InfoClient) getNodeInternalIP(node corev1.Node) (string, error) {
-	for _, addr := range node.Status.Addresses {
-		if addr.Type == corev1.NodeInternalIP {
-			return addr.Address, nil
-		}
-	}
-	return "", fmt.Errorf("failed to find node internal ip address")
-}
-
-func (m *InfoClient) getNodeHostname(node corev1.Node) (string, error) {
-	for _, addr := range node.Status.Addresses {
-		if addr.Type == corev1.NodeHostName {
-			return addr.Address, nil
-		}
-	}
-	return "", fmt.Errorf("failed to find node hostname")
-}
-
-func (m *InfoClient) getInstallConfig(ctx context.Context) (*basicInstallConfig, error) {
-	cm := &corev1.ConfigMap{}
-	err := m.client.Get(ctx, types.NamespacedName{Name: InstallConfigCM, Namespace: InstallConfigCMNamespace}, cm)
-	if err != nil {
-		return nil, err
-	}
-
-	data, ok := cm.Data["install-config"]
-	if !ok {
-		return nil, fmt.Errorf("did not find key install-config in configmap")
-	}
-
-	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(data)), 4096)
-	instConf := &basicInstallConfig{}
-	if err := decoder.Decode(instConf); err != nil {
-		return nil, fmt.Errorf("failed to decode install config, err: %w", err)
-	}
-	return instConf, nil
-}
-
-func (m *InfoClient) GetCSVDeployment(ctx context.Context) (*appsv1.Deployment, error) {
-	deployment := &appsv1.Deployment{}
-	if err := m.client.Get(ctx,
-		types.NamespacedName{
-			Name:      CsvDeploymentName,
-			Namespace: CsvDeploymentNamespace},
-		deployment); err != nil {
-		return nil, fmt.Errorf("failed to get cluster version deployment, err: %w", err)
-	}
-
-	return deployment, nil
-}
-
-func (m *InfoClient) GetReleaseRegistry(ctx context.Context) (string, error) {
-	deployment, err := m.GetCSVDeployment(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	return strings.Split(deployment.Spec.Template.Spec.Containers[0].Image, "/")[0], nil
-}
-
-func ReadClusterInfoFromFile(path string) (*ClusterInfo, error) {
-	data := &ClusterInfo{}
-	err := utils.ReadYamlOrJSONFile(path, data)
-	return data, err
 }

--- a/ibu-imager/postpivot/postpivot.go
+++ b/ibu-imager/postpivot/postpivot.go
@@ -54,14 +54,14 @@ func NewPostPivot(scheme *runtime.Scheme, log *logrus.Logger, ops ops.Ops,
 
 func (p *PostPivot) PostPivotConfiguration(ctx context.Context) error {
 	p.log.Info("Reading cluster info")
-	clusterInfo, err := clusterinfo.ReadClusterInfoFromFile(
+	clusterInfo, err := utils.ReadClusterInfoFromFile(
 		path.Join(p.workingDir, common.ClusterConfigDir, common.ClusterInfoFileName))
 	if err != nil {
 		return fmt.Errorf("failed to get cluster info from %s, err: %w", "", err)
 	}
 
 	p.log.Info("Reading seed info")
-	seedClusterInfo, err := clusterinfo.ReadClusterInfoFromFile(path.Join(p.workingDir, common.SeedManifest))
+	seedClusterInfo, err := utils.ReadClusterInfoFromFile(path.Join(p.workingDir, common.SeedManifest))
 	if err != nil {
 		return fmt.Errorf("failed to get seed info from %s, err: %w", "", err)
 	}
@@ -287,8 +287,7 @@ func (p *PostPivot) changeRegistryInCSVDeployment(ctx context.Context, client ru
 	clusterInfo, seedInfo *clusterinfo.ClusterInfo) error {
 
 	p.log.Info("Changing release registry in csv deployment")
-	cmClient := clusterinfo.NewClusterInfoClient(client)
-	csvD, err := cmClient.GetCSVDeployment(ctx)
+	csvD, err := utils.GetCSVDeployment(ctx, client)
 	if err != nil {
 		return err
 	}

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openshift-kni/lifecycle-agent/ibu-imager/clusterinfo"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	"github.com/openshift-kni/lifecycle-agent/utils"
 )
@@ -203,8 +202,7 @@ func (r *UpgradeClusterConfigGather) fetchMachineConfigs(ctx context.Context, ma
 func (r *UpgradeClusterConfigGather) fetchClusterInfo(ctx context.Context, clusterConfigPath string) error {
 	r.Log.Info("Fetching ClusterInfo")
 
-	cmClient := clusterinfo.NewClusterInfoClient(r.Client)
-	clusterInfo, err := cmClient.CreateClusterInfo(ctx)
+	clusterInfo, err := utils.CreateClusterInfo(ctx, r.Client)
 	if err != nil {
 		return err
 	}

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -110,7 +110,7 @@ var (
 		},
 	}
 	csvDeployment = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-		Name: clusterinfo.CsvDeploymentName, Namespace: clusterinfo.CsvDeploymentNamespace},
+		Name: common.CsvDeploymentName, Namespace: common.CsvDeploymentNamespace},
 		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
 			Name:  "cluster-version-operator",
 			Image: "mirror.redhat.com:5005/openshift-release-dev/ocp-release@sha256:d6a7e20a8929a3ad985373f05472ea64bada8ff46f0beb89e1b6d04919affde3"}}}},
@@ -464,8 +464,8 @@ func TestClusterConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			installConfig := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterinfo.InstallConfigCM,
-					Namespace: clusterinfo.InstallConfigCMNamespace,
+					Name:      common.InstallConfigCM,
+					Namespace: common.InstallConfigCMNamespace,
 				},
 				Data: map[string]string{"install-config": clusterCmData},
 			}

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -48,8 +48,15 @@ const (
 	LvmDevicesPath                    = "/etc/lvm/devices/system.devices"
 	CABundleFilePath                  = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 
-	LcaNamespace        = "openshift-lifecycle-agent"
-	Host         string = "/host"
+	LcaNamespace = "openshift-lifecycle-agent"
+	Host         = "/host"
+
+	CsvDeploymentName      = "cluster-version-operator"
+	CsvDeploymentNamespace = "openshift-cluster-version"
+	// InstallConfigCM cm name
+	InstallConfigCM = "cluster-config-v1"
+	// InstallConfigCMNamespace cm namespace
+	InstallConfigCMNamespace = "kube-system"
 )
 
 // CertPrefixes is the list of certificate prefixes to be backed up

--- a/main/main.go
+++ b/main/main.go
@@ -57,7 +57,6 @@ import (
 
 	"github.com/openshift-kni/lifecycle-agent/controllers"
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
-	"github.com/openshift-kni/lifecycle-agent/ibu-imager/clusterinfo"
 	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
 	rpmostreeclient "github.com/openshift-kni/lifecycle-agent/ibu-imager/ostreeclient"
 	"github.com/openshift-kni/lifecycle-agent/internal/backuprestore"
@@ -161,7 +160,6 @@ func main() {
 		ExtraManifest:   &extramanifest.EMHandler{Client: mgr.GetClient(), Log: log.WithName("ExtraManifest")},
 		RPMOstreeClient: rpmOstreeClient,
 		Executor:        executor,
-		ManifestClient:  clusterinfo.NewClusterInfoClient(mgr.GetClient()),
 		OstreeClient:    ostreeClient,
 		Ops:             op,
 		PrepTask:        &controllers.Task{Active: false, Success: false, Cancel: nil, Progress: ""},

--- a/utils/client_helper.go
+++ b/utils/client_helper.go
@@ -1,0 +1,187 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/openshift-kni/lifecycle-agent/ibu-imager/clusterinfo"
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	v1 "github.com/openshift/api/config/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetSecretData(ctx context.Context, name, namespace, key string, client runtimeclient.Client) (string, error) {
+	secret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, secret); err != nil {
+		return "", err
+	}
+
+	data, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("did not find key %s in Secret %s/%s", key, name, namespace)
+	}
+
+	return string(data), nil
+}
+
+func GetConfigMapData(ctx context.Context, name, namespace, key string, client runtimeclient.Client) (string, error) {
+	cm := &corev1.ConfigMap{}
+	if err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cm); err != nil {
+		return "", err
+	}
+
+	data, ok := cm.Data[key]
+	if !ok {
+		return "", fmt.Errorf("did not find key %s in ConfigMap", key)
+	}
+
+	return data, nil
+}
+
+func BackupCertificates(ctx context.Context, client runtimeclient.Client, certDir string) error {
+	if err := os.MkdirAll(certDir, os.ModePerm); err != nil {
+		return fmt.Errorf("error creating %s: %w", certDir, err)
+	}
+
+	adminKubeConfigClientCA, err := GetConfigMapData(ctx, "admin-kubeconfig-client-ca", "openshift-config", "ca-bundle.crt", client)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path.Join(certDir, "admin-kubeconfig-client-ca.crt"), []byte(adminKubeConfigClientCA), 0o644); err != nil {
+		return err
+	}
+
+	for _, cert := range common.CertPrefixes {
+		servingSignerKey, err := GetSecretData(ctx, cert, "openshift-kube-apiserver-operator", "tls.key", client)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(path.Join(certDir, cert+".key"), []byte(servingSignerKey), 0o644); err != nil {
+			return err
+		}
+	}
+
+	ingressOperatorKey, err := GetSecretData(ctx, "router-ca", "openshift-ingress-operator", "tls.key", client)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path.Join(certDir, "ingresskey-ingress-operator.key"), []byte(ingressOperatorKey), 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CreateClusterInfo(ctx context.Context, client runtimeclient.Client) (*clusterinfo.ClusterInfo, error) {
+	clusterVersion := &v1.ClusterVersion{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+		return nil, err
+	}
+
+	installConfig, err := getInstallConfig(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := GetSNOMasterNode(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	ip, err := getNodeInternalIP(*node)
+	if err != nil {
+		return nil, err
+	}
+	hostname, err := getNodeHostname(*node)
+	if err != nil {
+		return nil, err
+	}
+
+	releaseRegistry, err := GetReleaseRegistry(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterinfo.ClusterInfo{
+		ClusterName:     installConfig.Metadata.Name,
+		Domain:          installConfig.BaseDomain,
+		Version:         clusterVersion.Status.Desired.Version,
+		ClusterID:       string(clusterVersion.Spec.ClusterID),
+		MasterIP:        ip,
+		ReleaseRegistry: releaseRegistry,
+		Hostname:        hostname,
+	}, nil
+}
+
+// TODO: add dual stuck support
+func getNodeInternalIP(node corev1.Node) (string, error) {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find node internal ip address")
+}
+
+func getNodeHostname(node corev1.Node) (string, error) {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeHostName {
+			return addr.Address, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find node hostname")
+}
+
+func getInstallConfig(ctx context.Context, client runtimeclient.Client) (*clusterinfo.BasicInstallConfig, error) {
+	cm := &corev1.ConfigMap{}
+	err := client.Get(ctx, types.NamespacedName{Name: common.InstallConfigCM, Namespace: common.InstallConfigCMNamespace}, cm)
+	if err != nil {
+		return nil, err
+	}
+
+	data, ok := cm.Data["install-config"]
+	if !ok {
+		return nil, fmt.Errorf("did not find key install-config in configmap")
+	}
+
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(data)), 4096)
+	instConf := &clusterinfo.BasicInstallConfig{}
+	if err := decoder.Decode(instConf); err != nil {
+		return nil, fmt.Errorf("failed to decode install config, err: %w", err)
+	}
+	return instConf, nil
+}
+
+func GetCSVDeployment(ctx context.Context, client runtimeclient.Client) (*appsv1.Deployment, error) {
+	deployment := &appsv1.Deployment{}
+	if err := client.Get(ctx,
+		types.NamespacedName{
+			Name:      common.CsvDeploymentName,
+			Namespace: common.CsvDeploymentNamespace},
+		deployment); err != nil {
+		return nil, fmt.Errorf("failed to get cluster version deployment, err: %w", err)
+	}
+
+	return deployment, nil
+}
+
+func GetReleaseRegistry(ctx context.Context, client runtimeclient.Client) (string, error) {
+	deployment, err := GetCSVDeployment(ctx, client)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Split(deployment.Spec.Template.Spec.Containers[0].Image, "/")[0], nil
+}
+
+func ReadClusterInfoFromFile(path string) (*clusterinfo.ClusterInfo, error) {
+	data := &clusterinfo.ClusterInfo{}
+	err := ReadYamlOrJSONFile(path, data)
+	return data, err
+}


### PR DESCRIPTION
InfoClient is a wrapper to runtimeclient.Client, we can remove
it and use runtimeclient.Client directly. Its functions are moved
to utils/client_helper.go
Doing this also enables us to use BackupCeritificates in the LCA