### PR TITLE
Add handleFinalize and perform backup cleanups

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -205,28 +205,10 @@ func (r *ImageBasedUpgradeReconciler) handleAbortOrFinalize(ctx context.Context,
 		switch idleCondition.Reason {
 		case string(utils.ConditionReasons.Aborting):
 			nextReconcile, err = r.handleAbort(ctx, ibu)
-			if err != nil {
-				utils.SetStatusCondition(&ibu.Status.Conditions,
-					utils.ConditionTypes.Idle,
-					utils.ConditionReasons.AbortFailed,
-					metav1.ConditionFalse,
-					"Error occurred during abort",
-					ibu.Generation,
-				)
-			}
 		case string(utils.ConditionReasons.AbortFailed):
 			nextReconcile, err = r.handleAbortFailure(ctx, ibu)
 		case string(utils.ConditionReasons.Finalizing):
 			nextReconcile, err = r.handleFinalize(ctx, ibu)
-			if err != nil {
-				utils.SetStatusCondition(&ibu.Status.Conditions,
-					utils.ConditionTypes.Idle,
-					utils.ConditionReasons.FinalizeFailed,
-					metav1.ConditionFalse,
-					"Error occurred during finalize",
-					ibu.Generation,
-				)
-			}
 		case string(utils.ConditionReasons.FinalizeFailed):
 			nextReconcile, err = r.handleFinalizeFailure(ctx, ibu)
 		}

--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -205,10 +205,28 @@ func (r *ImageBasedUpgradeReconciler) handleAbortOrFinalize(ctx context.Context,
 		switch idleCondition.Reason {
 		case string(utils.ConditionReasons.Aborting):
 			nextReconcile, err = r.handleAbort(ctx, ibu)
+			if err != nil {
+				utils.SetStatusCondition(&ibu.Status.Conditions,
+					utils.ConditionTypes.Idle,
+					utils.ConditionReasons.AbortFailed,
+					metav1.ConditionFalse,
+					"Error occurred during abort",
+					ibu.Generation,
+				)
+			}
 		case string(utils.ConditionReasons.AbortFailed):
 			nextReconcile, err = r.handleAbortFailure(ctx, ibu)
 		case string(utils.ConditionReasons.Finalizing):
 			nextReconcile, err = r.handleFinalize(ctx, ibu)
+			if err != nil {
+				utils.SetStatusCondition(&ibu.Status.Conditions,
+					utils.ConditionTypes.Idle,
+					utils.ConditionReasons.FinalizeFailed,
+					metav1.ConditionFalse,
+					"Error occurred during finalize",
+					ibu.Generation,
+				)
+			}
 		case string(utils.ConditionReasons.FinalizeFailed):
 			nextReconcile, err = r.handleFinalizeFailure(ctx, ibu)
 		}

--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -80,9 +81,12 @@ func (r *ImageBasedUpgradeReconciler) cleanup(
 		successful = false
 		r.Log.Error(err, "failed to cleanup precaching resources")
 	}
-	if _, err := r.BackupRestore.CleanupBackups(ctx); err != nil {
+	if allRemoved, err := r.BackupRestore.CleanupBackups(ctx); err != nil {
 		successful = false
 		r.Log.Error(err, "failed to cleanup backups")
+	} else if !allRemoved {
+		successful = false
+		r.Log.Error(errors.New("failed to delete all the backup CRs"), "")
 	}
 	if err := r.BackupRestore.DeleteOadpOperator(ctx, backuprestore.OadpNs); err != nil {
 		successful = false

--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -26,12 +26,14 @@ import (
 	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
 	"github.com/openshift-kni/lifecycle-agent/internal/backuprestore"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lcav1alpha1 "github.com/openshift-kni/lifecycle-agent/api/v1alpha1"
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+//nolint:unparam
 func (r *ImageBasedUpgradeReconciler) handleAbort(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
 	r.Log.Info("Starting handleAbort")
 
@@ -39,7 +41,15 @@ func (r *ImageBasedUpgradeReconciler) handleAbort(ctx context.Context, ibu *lcav
 		r.Log.Info("Finished handleAbort")
 		return doNotRequeue(), nil
 	}
-	return requeueWithError(fmt.Errorf("failed handelAbort"))
+
+	utils.SetStatusCondition(&ibu.Status.Conditions,
+		utils.ConditionTypes.Idle,
+		utils.ConditionReasons.AbortFailed,
+		metav1.ConditionFalse,
+		"Unable to cleanup successfully",
+		ibu.Generation,
+	)
+	return doNotRequeue(), nil
 }
 
 //nolint:unparam
@@ -47,6 +57,7 @@ func (r *ImageBasedUpgradeReconciler) handleAbortFailure(ctx context.Context, ib
 	return doNotRequeue(), nil
 }
 
+//nolint:unparam
 func (r *ImageBasedUpgradeReconciler) handleFinalize(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
 	r.Log.Info("Starting handleFinalize")
 
@@ -54,7 +65,14 @@ func (r *ImageBasedUpgradeReconciler) handleFinalize(ctx context.Context, ibu *l
 		r.Log.Info("Finished handleFinalize")
 		return doNotRequeue(), nil
 	}
-	return requeueWithError(fmt.Errorf("failed handleFinalize"))
+	utils.SetStatusCondition(&ibu.Status.Conditions,
+		utils.ConditionTypes.Idle,
+		utils.ConditionReasons.FinalizeFailed,
+		metav1.ConditionFalse,
+		"Unable to cleanup successfully",
+		ibu.Generation,
+	)
+	return doNotRequeue(), nil
 }
 
 //nolint:unparam

--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -22,12 +22,136 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
+	"github.com/openshift-kni/lifecycle-agent/internal/backuprestore"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 
 	lcav1alpha1 "github.com/openshift-kni/lifecycle-agent/api/v1alpha1"
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
+
+func (r *ImageBasedUpgradeReconciler) handleAbort(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
+	r.Log.Info("Starting handleAbort")
+
+	if r.cleanup(ctx, false, ibu) {
+		r.Log.Info("Finished handleAbort")
+		return doNotRequeue(), nil
+	}
+	return requeueWithError(fmt.Errorf("failed handelAbort"))
+}
+
+//nolint:unparam
+func (r *ImageBasedUpgradeReconciler) handleAbortFailure(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
+	return doNotRequeue(), nil
+}
+
+func (r *ImageBasedUpgradeReconciler) handleFinalize(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
+	r.Log.Info("Starting handleFinalize")
+
+	if r.cleanup(ctx, true, ibu) {
+		r.Log.Info("Finished handleFinalize")
+		return doNotRequeue(), nil
+	}
+	return requeueWithError(fmt.Errorf("failed handleFinalize"))
+}
+
+//nolint:unparam
+func (r *ImageBasedUpgradeReconciler) handleFinalizeFailure(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
+
+	// TODO actual steps
+	// If succeeds, return doNotRequeue
+	return doNotRequeue(), nil
+}
+
+// cleanup cleans stateroots, precache, backup, ibu files and OADP operator
+// returns true if all cleanup tasks were successful
+func (r *ImageBasedUpgradeReconciler) cleanup(
+	ctx context.Context, allUnbootedStateroots bool, ibu *lcav1alpha1.ImageBasedUpgrade) bool {
+	// try to clean up as much as possible and avoid returning when one of the cleanup tasks fails
+	// successful means that all the cleanup tasks completed without any error
+	successful := true
+
+	if err := r.cleanupStateroots(allUnbootedStateroots, ibu); err != nil {
+		successful = false
+		r.Log.Error(err, "failed to cleanup stateroots")
+	}
+	if err := r.Precache.Cleanup(ctx); err != nil {
+		successful = false
+		r.Log.Error(err, "failed to cleanup precaching resources")
+	}
+	if _, err := r.BackupRestore.CleanupBackups(ctx); err != nil {
+		successful = false
+		r.Log.Error(err, "failed to cleanup backups")
+	}
+	if err := r.BackupRestore.DeleteOadpOperator(ctx, backuprestore.OadpNs); err != nil {
+		successful = false
+		r.Log.Error(err, "failed to delete OADP operator")
+	}
+	if err := cleanupIBUFiles(); err != nil {
+		successful = false
+		r.Log.Error(err, "failed to cleanup ibu files")
+	}
+
+	return successful
+}
+
+// cleanupStateroot cleans all unbooted stateroots or desired stateroot
+// depending on allUnbootedStateroots argumennt
+func (r *ImageBasedUpgradeReconciler) cleanupStateroots(
+	allUnbootedStateroots bool, ibu *lcav1alpha1.ImageBasedUpgrade) error {
+	if allUnbootedStateroots {
+		return r.cleanupUnbootedStateroots()
+	}
+	return r.cleanupUnbootedStateroot(getDesiredStaterootName(ibu))
+}
+
+func cleanupIBUFiles() error {
+	if _, err := os.Stat(common.PathOutsideChroot(utils.IBUWorkspacePath)); err != nil {
+		return nil
+	}
+	if err := os.RemoveAll(filepath.Join(utils.Host, utils.IBUWorkspacePath)); err != nil {
+		return fmt.Errorf("removing %s failed: %w", utils.IBUWorkspacePath, err)
+	}
+	return nil
+}
+
+func (r *ImageBasedUpgradeReconciler) cleanupUnbootedStateroots() error {
+	status, err := r.RPMOstreeClient.QueryStatus()
+	if err != nil {
+		return err
+	}
+
+	undeployIndices := make([]int, 0)
+	undeployStateroots := make([]string, 0)
+	for index, deployment := range status.Deployments {
+		if deployment.Booted {
+			continue
+		}
+		undeployIndices = append(undeployIndices, index)
+		undeployStateroots = append(undeployStateroots, deployment.OSName)
+	}
+	// since undeploy shifts the order, undeploy in the reverse order
+	for i := len(undeployIndices) - 1; i >= 0; i-- {
+		_, err = r.Executor.Execute("ostree", "admin", "undeploy", fmt.Sprint(i))
+		if err != nil {
+			return fmt.Errorf("ostree undeploy %d failed: %w", i, err)
+		}
+	}
+
+	failures := 0
+	for _, stateroot := range undeployStateroots {
+		if err = removeStateroot(r.Executor, stateroot); err != nil {
+			r.Log.Error(err, "failed to remove stateroot", "stateroot", stateroot)
+			failures += 1
+		}
+	}
+
+	if failures == 0 {
+		return nil
+	}
+	return fmt.Errorf("failed to remove %d stateroots", failures)
+}
 
 func (r *ImageBasedUpgradeReconciler) cleanupUnbootedStateroot(stateroot string) error {
 	status, err := r.RPMOstreeClient.QueryStatus()
@@ -54,67 +178,18 @@ func (r *ImageBasedUpgradeReconciler) cleanupUnbootedStateroot(stateroot string)
 		}
 	}
 
-	// remove stateroot
-	sysrootPath := fmt.Sprintf("/sysroot/ostree/deploy/%s", stateroot)
-	if _, err := os.Stat(common.PathOutsideChroot(sysrootPath)); err == nil {
-		_, err = r.Executor.Execute("unshare", "-m", "/bin/sh", "-c",
-			fmt.Sprintf("\"mount -o remount,rw /sysroot && rm -rf %s\"", sysrootPath))
-		if err != nil {
-			return fmt.Errorf("removing stateroot failed: %w", err)
-		}
+	return removeStateroot(r.Executor, stateroot)
+}
+
+func removeStateroot(executor ops.Execute, stateroot string) error {
+	staterootPath := fmt.Sprintf("/sysroot/ostree/deploy/%s", stateroot)
+	if _, err := os.Stat(common.PathOutsideChroot(staterootPath)); err != nil {
+		return nil
 	}
 
-	return nil
-}
-
-//nolint:unparam
-func (r *ImageBasedUpgradeReconciler) handleAbort(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
-	// Cleanup precaching resources
-	r.Log.Info("Cleanup precaching resources")
-	if err := r.Precache.Cleanup(ctx); err != nil {
-		r.Log.Info("Failed to cleanup precaching resources")
-		return requeueWithError(err)
-	}
-
-	stateroot := getDesiredStaterootName(ibu)
-	r.Log.Info("Cleanup stateroot", "stateroot", stateroot)
-	err := r.cleanupUnbootedStateroot(stateroot)
-	if err != nil {
-		return requeueWithError(err)
-	}
-	err = cleanupIBUFiles()
-	return requeueWithError(err)
-}
-
-//nolint:unparam
-func (r *ImageBasedUpgradeReconciler) handleAbortFailure(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
-
-	// TODO actual steps
-	// If succeeds, return doNotRequeue
-	return doNotRequeue(), nil
-}
-
-//nolint:unparam
-func (r *ImageBasedUpgradeReconciler) handleFinalize(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
-
-	// TODO actual steps
-	// If succeeds, return doNotRequeue
-	return doNotRequeue(), nil
-}
-
-//nolint:unparam
-func (r *ImageBasedUpgradeReconciler) handleFinalizeFailure(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
-
-	// TODO actual steps
-	// If succeeds, return doNotRequeue
-	return doNotRequeue(), nil
-}
-
-func cleanupIBUFiles() error {
-	if _, err := os.Stat(common.PathOutsideChroot(utils.IBUWorkspacePath)); err == nil {
-		if err := os.RemoveAll(filepath.Join(utils.Host, utils.IBUWorkspacePath)); err != nil {
-			return fmt.Errorf("removing %s failed: %w", utils.IBUWorkspacePath, err)
-		}
+	if _, err := executor.Execute("unshare", "-m", "/bin/sh", "-c",
+		fmt.Sprintf("\"mount -o remount,rw /sysroot && rm -rf %s\"", staterootPath)); err != nil {
+		return fmt.Errorf("removing stateroot %s failed: %w", stateroot, err)
 	}
 	return nil
 }

--- a/controllers/idle_handlers_test.go
+++ b/controllers/idle_handlers_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
+	rpmostreeclient "github.com/openshift-kni/lifecycle-agent/ibu-imager/ostreeclient"
+	"github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
+	"go.uber.org/mock/gomock"
+)
+
+func TestImageBasedUpgradeReconciler_cleanupUnbootedStateroot(t *testing.T) {
+	tests := []struct {
+		name            string
+		wantErr         bool
+		deployments     []rpmostreeclient.Deployment
+		undeployIndices []int
+		input           string
+		expectToRemove  string
+	}{
+		{
+			name:           "no deployments",
+			wantErr:        false,
+			deployments:    []rpmostreeclient.Deployment{},
+			input:          "rhcos",
+			expectToRemove: "rhcos",
+		},
+		{
+			name:        "one deployment",
+			wantErr:     true,
+			deployments: []rpmostreeclient.Deployment{{OSName: "rhcos_4.10.15", Booted: true}},
+			input:       "rhcos_4.10.15",
+		},
+		{
+			name:    "two deployments, remove second",
+			wantErr: false,
+			deployments: []rpmostreeclient.Deployment{
+				{OSName: "rhcos_4.10.15", Booted: true},
+				{OSName: "rhcos", Booted: false},
+			},
+			undeployIndices: []int{1},
+			input:           "rhcos",
+			expectToRemove:  "rhcos",
+		},
+		{
+			name:    "two deployments, remove first",
+			wantErr: false,
+			deployments: []rpmostreeclient.Deployment{
+				{OSName: "rhcos_4.10.15", Booted: false},
+				{OSName: "rhcos", Booted: true},
+			},
+			undeployIndices: []int{0},
+			input:           "rhcos_4.10.15",
+			expectToRemove:  "rhcos_4.10.15",
+		},
+		{
+			name:    "three deployments",
+			wantErr: false,
+			deployments: []rpmostreeclient.Deployment{
+				{OSName: "rhcos_4.10.11", Booted: false},
+				{OSName: "rhcos_4.10.15", Booted: true},
+				{OSName: "rhcos", Booted: false},
+			},
+			undeployIndices: []int{0},
+			input:           "rhcos_4.10.11",
+			expectToRemove:  "rhcos_4.10.11",
+		},
+		{
+			// two deployments in one stateroot, one of them is booted.
+			// we should not remove stateroot
+			name:    "don't remove booted stateroot",
+			wantErr: true,
+			deployments: []rpmostreeclient.Deployment{
+				{OSName: "rhcos_4.10.11", Booted: false},
+				{OSName: "rhcos", Booted: true},
+				{OSName: "rhcos", Booted: false},
+			},
+			undeployIndices: []int{},
+			input:           "rhcos",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ostreeclientMock := ostreeclient.NewMockIClient(ctrl)
+			rpmostreeclientMock := rpmostreeclient.NewMockIClient(ctrl)
+			executorMock := ops.NewMockExecute(ctrl)
+
+			rpmostreeclientMock.EXPECT().QueryStatus().Return(&rpmostreeclient.Status{
+				Deployments: tt.deployments}, nil)
+			for _, x := range tt.undeployIndices {
+				ostreeclientMock.EXPECT().Undeploy(x)
+			}
+			if tt.expectToRemove != "" {
+				executorMock.EXPECT().Execute("unshare", "-m", "/bin/sh", "-c",
+					fmt.Sprintf("\"mount -o remount,rw /sysroot && rm -rf /ostree/deploy/%s\"",
+						tt.expectToRemove))
+			}
+			r := &ImageBasedUpgradeReconciler{
+				Log:             logr.Discard(),
+				RPMOstreeClient: rpmostreeclientMock,
+				Executor:        executorMock,
+				OstreeClient:    ostreeclientMock,
+			}
+			osStat = func(name string) (os.FileInfo, error) {
+				return os.Stat(".")
+			}
+
+			if err := r.cleanupUnbootedStateroot(tt.input); (err != nil) != tt.wantErr {
+				t.Errorf("ImageBasedUpgradeReconciler.cleanupUnbootedStateroot() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestImageBasedUpgradeReconciler_cleanupUnbootedStateroots(t *testing.T) {
+	tests := []struct {
+		name               string
+		wantErr            bool
+		deployments        []rpmostreeclient.Deployment
+		undeployIndices    []int
+		staterootsToRemove []string
+	}{
+		{
+			name:        "no deployments",
+			wantErr:     false,
+			deployments: []rpmostreeclient.Deployment{},
+		},
+		{
+			name:        "one deployment",
+			wantErr:     false,
+			deployments: []rpmostreeclient.Deployment{{OSName: "rhcos_4.10.15", Booted: true}},
+		},
+		{
+			name:    "two deployments, remove second",
+			wantErr: false,
+			deployments: []rpmostreeclient.Deployment{
+				{OSName: "rhcos_4.10.15", Booted: true},
+				{OSName: "rhcos", Booted: false},
+			},
+			undeployIndices:    []int{1},
+			staterootsToRemove: []string{"rhcos"},
+		},
+		{
+			name:    "two deployments, remove first",
+			wantErr: false,
+			deployments: []rpmostreeclient.Deployment{
+				{OSName: "rhcos_4.10.15", Booted: false},
+				{OSName: "rhcos", Booted: true},
+			},
+			undeployIndices:    []int{0},
+			staterootsToRemove: []string{"rhcos_4.10.15"},
+		},
+		{
+			name:    "three deployments",
+			wantErr: false,
+			deployments: []rpmostreeclient.Deployment{
+				{OSName: "rhcos_4.10.11", Booted: false},
+				{OSName: "rhcos_4.10.15", Booted: true},
+				{OSName: "rhcos", Booted: false},
+			},
+			undeployIndices:    []int{2, 0},
+			staterootsToRemove: []string{"rhcos", "rhcos_4.10.11"},
+		},
+		{
+			// two deployments in one stateroot, one of them is booted.
+			// we should not remove stateroot
+			name:    "don't remove booted stateroot",
+			wantErr: false,
+			deployments: []rpmostreeclient.Deployment{
+				{OSName: "rhcos_4.10.11", Booted: false},
+				{OSName: "rhcos", Booted: true},
+				{OSName: "rhcos", Booted: false},
+			},
+			undeployIndices:    []int{0},
+			staterootsToRemove: []string{"rhcos_4.10.11"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ostreeclientMock := ostreeclient.NewMockIClient(ctrl)
+			rpmostreeclientMock := rpmostreeclient.NewMockIClient(ctrl)
+			executorMock := ops.NewMockExecute(ctrl)
+
+			rpmostreeclientMock.EXPECT().QueryStatus().Return(&rpmostreeclient.Status{
+				Deployments: tt.deployments}, nil)
+			for _, x := range tt.undeployIndices {
+				ostreeclientMock.EXPECT().Undeploy(x)
+			}
+			for _, stateroot := range tt.staterootsToRemove {
+				rpmostreeclientMock.EXPECT().QueryStatus().Return(&rpmostreeclient.Status{
+					Deployments: tt.deployments}, nil)
+				executorMock.EXPECT().Execute("unshare", "-m", "/bin/sh", "-c",
+					fmt.Sprintf("\"mount -o remount,rw /sysroot && rm -rf /ostree/deploy/%s\"",
+						stateroot))
+			}
+			r := &ImageBasedUpgradeReconciler{
+				Log:             logr.Discard(),
+				RPMOstreeClient: rpmostreeclientMock,
+				Executor:        executorMock,
+				OstreeClient:    ostreeclientMock,
+			}
+			osStat = func(name string) (os.FileInfo, error) {
+				return os.Stat(".")
+			}
+
+			if err := r.cleanupUnbootedStateroots(); (err != nil) != tt.wantErr {
+				t.Errorf("ImageBasedUpgradeReconciler.cleanupUnbootedStateroots() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -382,6 +382,11 @@ func (h *BRHandler) CleanupBackups(ctx context.Context) (bool, error) {
 	if err := h.List(ctx, backupList, client.MatchingLabels{
 		clusterIDLabel: clusterID,
 	}); err != nil {
+		var groupDiscoveryErr *discovery.ErrGroupDiscoveryFailed
+		if errors.As(err, &groupDiscoveryErr) {
+			h.Log.Info("Backup CR is not installed, nothing to cleanup")
+			return true, nil
+		}
 		return false, err
 	}
 

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -279,6 +279,12 @@ func (h *BRHandler) DeleteOadpOperator(ctx context.Context, namespace string) er
 		}
 	}
 
-	h.Log.Info("OADP operator has deleted", "name", oadpSub.Items[0].Name, "namespace", namespace)
+	if len(oadpSub.Items) == 0 {
+		h.Log.Info("Found no OADP operator to delete")
+	} else if len(oadpSub.Items) == 1 {
+		h.Log.Info("OADP operator has been deleted", "name", oadpSub.Items[0].Name, "namespace", namespace)
+	} else {
+		h.Log.Info("WARN: Found more than 1 OADP operator. Deleted all OADP operators.")
+	}
 	return nil
 }

--- a/internal/ostreeclient/mock_ostreeclient.go
+++ b/internal/ostreeclient/mock_ostreeclient.go
@@ -78,3 +78,17 @@ func (mr *MockIClientMockRecorder) PullLocal(repoPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullLocal", reflect.TypeOf((*MockIClient)(nil).PullLocal), repoPath)
 }
+
+// Undeploy mocks base method.
+func (m *MockIClient) Undeploy(ostreeIndex int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Undeploy", ostreeIndex)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Undeploy indicates an expected call of Undeploy.
+func (mr *MockIClientMockRecorder) Undeploy(ostreeIndex any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Undeploy", reflect.TypeOf((*MockIClient)(nil).Undeploy), ostreeIndex)
+}

--- a/internal/ostreeclient/ostreeclient.go
+++ b/internal/ostreeclient/ostreeclient.go
@@ -1,6 +1,8 @@
 package ostreeclient
 
 import (
+	"fmt"
+
 	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
 )
 
@@ -9,6 +11,7 @@ type IClient interface {
 	PullLocal(repoPath string) error
 	OSInit(osname string) error
 	Deploy(osname, refsepc string, kargs []string) error
+	Undeploy(ostreeIndex int) error
 }
 
 type Client struct {
@@ -36,5 +39,10 @@ func (c *Client) Deploy(osname, refsepc string, kargs []string) error {
 	args = append(args, kargs...)
 	args = append(args, refsepc)
 	_, err := c.executor.Execute("ostree", args...)
+	return err
+}
+
+func (c *Client) Undeploy(ostreeIndex int) error {
+	_, err := c.executor.Execute("ostree", "admin", "undeploy", fmt.Sprint(ostreeIndex))
 	return err
 }


### PR DESCRIPTION
- Add function to remove all unbooted stateroots
- Try to run all cleanup functions even if one of them returns an error
- Run backup cleanup and delete OADP operator in abort and finalize