### PR TITLE
Update tar usage when saving /etc files

### DIFF
--- a/ibu-imager/seedcreator/seedcreator.go
+++ b/ibu-imager/seedcreator/seedcreator.go
@@ -380,8 +380,8 @@ func (s *SeedCreator) backupEtc() error {
 	}
 
 	args = []string{"admin", "config-diff", "|", "grep", "-v", "'cni/multus'",
-		"|", "awk", `'$1 != "D" {print "/etc/" $2}'`, "|", "xargs", "tar", "czf",
-		path.Join(s.backupDir + "/etc.tgz"), "--selinux"}
+		"|", "awk", `'$1 != "D" {print "/etc/" $2}'`, "|", "tar", "czf",
+		path.Join(s.backupDir + "/etc.tgz"), "--selinux", "-T", "-"}
 
 	_, err = s.ops.RunBashInHostNamespace("ostree", args...)
 	if err != nil {


### PR DESCRIPTION
In some cases when there is a large number of /etc files to save, the list of files gets truncated resulting in an incomplete arhive which later impacts the upgrade process as installation-configuration systemd service cannot start.

This change removes the xargs usage and uses tar's files-from option instead which seems to overcome the issues when having a large number of files.