### PR TITLE
OCPEDGE-664: Pregenerate kubelet certs to skip post-pivot CSR approvals

### DIFF
--- a/ibu-imager/clusterinfo/clusterinfo.go
+++ b/ibu-imager/clusterinfo/clusterinfo.go
@@ -69,12 +69,15 @@ func (m *InfoClient) CreateClusterInfo(ctx context.Context) (*ClusterInfo, error
 		return nil, err
 	}
 
-	ip, err := m.getNodeInternalIP(ctx)
+	node, err := utils.GetSNOMasterNode(ctx, m.client)
 	if err != nil {
 		return nil, err
 	}
-
-	hostname, err := m.getNodeHostname(ctx)
+	ip, err := m.getNodeInternalIP(*node)
+	if err != nil {
+		return nil, err
+	}
+	hostname, err := m.getNodeHostname(*node)
 	if err != nil {
 		return nil, err
 	}
@@ -124,31 +127,21 @@ func (m *InfoClient) GetConfigMapData(ctx context.Context, name, namespace, key 
 }
 
 // TODO: add dual stuck support
-func (m *InfoClient) getNodeInternalIP(ctx context.Context) (string, error) {
-	node, err := utils.GetSNOMasterNode(ctx, m.client)
-	if err != nil {
-		return "", err
-	}
+func (m *InfoClient) getNodeInternalIP(node corev1.Node) (string, error) {
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == corev1.NodeInternalIP {
 			return addr.Address, nil
 		}
 	}
-
 	return "", fmt.Errorf("failed to find node internal ip address")
 }
 
-func (m *InfoClient) getNodeHostname(ctx context.Context) (string, error) {
-	node, err := utils.GetSNOMasterNode(ctx, m.client)
-	if err != nil {
-		return "", err
-	}
+func (m *InfoClient) getNodeHostname(node corev1.Node) (string, error) {
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == corev1.NodeHostName {
 			return addr.Address, nil
 		}
 	}
-
 	return "", fmt.Errorf("failed to find node hostname")
 }
 

--- a/ibu-imager/clusterinfo/clusterinfo.go
+++ b/ibu-imager/clusterinfo/clusterinfo.go
@@ -34,6 +34,7 @@ type ClusterInfo struct {
 	ClusterID       string `json:"cluster_id,omitempty"`
 	MasterIP        string `json:"master_ip,omitempty"`
 	ReleaseRegistry string `json:"release_registry,omitempty"`
+	Hostname        string `json:"hostname,omitempty"`
 }
 
 type installConfigMetadata struct {
@@ -73,6 +74,11 @@ func (m *InfoClient) CreateClusterInfo(ctx context.Context) (*ClusterInfo, error
 		return nil, err
 	}
 
+	hostname, err := m.getNodeHostname(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	releaseRegistry, err := m.getReleaseRegistry(ctx)
 	if err != nil {
 		return nil, err
@@ -85,6 +91,7 @@ func (m *InfoClient) CreateClusterInfo(ctx context.Context) (*ClusterInfo, error
 		ClusterID:       string(clusterVersion.Spec.ClusterID),
 		MasterIP:        ip,
 		ReleaseRegistry: releaseRegistry,
+		Hostname:        hostname,
 	}, nil
 }
 
@@ -129,6 +136,20 @@ func (m *InfoClient) getNodeInternalIP(ctx context.Context) (string, error) {
 	}
 
 	return "", fmt.Errorf("failed to find node internal ip address")
+}
+
+func (m *InfoClient) getNodeHostname(ctx context.Context) (string, error) {
+	node, err := utils.GetSNOMasterNode(ctx, m.client)
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeHostName {
+			return addr.Address, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find node hostname")
 }
 
 func (m *InfoClient) getInstallConfig(ctx context.Context) (*basicInstallConfig, error) {

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -18,12 +18,13 @@ package clusterconfig
 
 import (
 	"context"
-	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/go-logr/logr"
 	ocpV1 "github.com/openshift/api/config/v1"
@@ -87,11 +88,12 @@ var (
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{Type: corev1.NodeInternalIP, Address: "192.168.121.10"},
+				{Type: corev1.NodeHostName, Address: "seed"},
 			},
 		},
 	}
 
-	seedManifestData = clusterinfo.ClusterInfo{Domain: "seed.com", ClusterName: "seed", MasterIP: "192.168.127.10"}
+	seedManifestData = clusterinfo.ClusterInfo{Domain: "seed.com", ClusterName: "seed", MasterIP: "192.168.127.10", Hostname: "seed"}
 
 	machineConfigs = []*mcv1.MachineConfig{
 		{

--- a/internal/recert/recert.go
+++ b/internal/recert/recert.go
@@ -44,6 +44,8 @@ func CreateRecertConfigFile(clusterInfo, seedClusterInfo *clusterinfo.ClusterInf
 	clusterFullDomain := fmt.Sprintf("%s.%s", clusterInfo.ClusterName, clusterInfo.Domain)
 	config.ExtendExpiration = true
 	config.CNSanReplaceRules = []string{
+		fmt.Sprintf("system:node:%s,system:node:%s", seedClusterInfo.Hostname, clusterInfo.Hostname),
+		fmt.Sprintf("%s,%s", seedClusterInfo.Hostname, clusterInfo.Hostname),
 		fmt.Sprintf("%s,%s", seedClusterInfo.MasterIP, clusterInfo.MasterIP),
 		fmt.Sprintf("api.%s,api.%s", seedFullDomain, clusterFullDomain),
 		fmt.Sprintf("api-int.%s,api-int.%s", seedFullDomain, clusterFullDomain),


### PR DESCRIPTION
This PR adds the following changes:

- adds `hostname` to `ClusterInfo`, in order to be able to replace the seed hostname with the target hostname in certs (in this PR) and static pod manifests (in a future PR)
- adds recert configuration params to replace the seed hostname with the target hostname in the `kubelet-client.pem` and `kubelet-server.pem`, with the goal of having those certs ready to go and skip the kubelet CSR generation (and hence the manual approval of the kubelet CSRs) during the post-pivot flow
- removes the post-pivot step of the kubelet CSR approvals 

### Skipping kubelet CSRs

According to how kubelet behaves, see [here](https://github.com/kubernetes/kubernetes/blob/930022cf267c2e0269fbd9be4be3fd83448e6419/pkg/kubelet/certificate/kubelet.go#L97-L103) and [here](https://github.com/kubernetes/client-go/blob/master/util/certificate/certificate_manager.go#L609-L652), if the respective certificates' IP addresses, DNSs and the subject orgs stay the same, then kubelet should be happy and it doesn't issue new CSRs. Thus we won't have to manually approve any kubelet CSRs during post-pivot.  