### PR TITLE
Upgrade post pivot with extra manifest apply and OADP restore

### DIFF
--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -18,23 +18,20 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/openshift-kni/lifecycle-agent/internal/healthcheck"
-
-	"path/filepath"
-
-	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lcav1alpha1 "github.com/openshift-kni/lifecycle-agent/api/v1alpha1"
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
 	"github.com/openshift-kni/lifecycle-agent/internal/backuprestore"
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	"github.com/openshift-kni/lifecycle-agent/internal/extramanifest"
+	"github.com/openshift-kni/lifecycle-agent/internal/healthcheck"
+	v1 "k8s.io/api/core/v1"
+
 	lcautils "github.com/openshift-kni/lifecycle-agent/utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -43,20 +40,6 @@ var (
 	// todo: this value might need adjusting later
 	defaultRebootTimeout = 60 * time.Minute
 )
-
-// simple custom error types to handle backup cases
-type (
-	BackupFailedError     string
-	BackupValidationError string
-)
-
-func (b BackupFailedError) Error() string {
-	return string(b)
-}
-
-func (b BackupValidationError) Error() string {
-	return string(b)
-}
 
 var isPrePivot = func(r *ImageBasedUpgradeReconciler, ibu *lcav1alpha1.ImageBasedUpgrade) (bool, error) {
 	currentStaterootName, err := r.RPMOstreeClient.GetCurrentStaterootName()
@@ -74,7 +57,7 @@ func (r *ImageBasedUpgradeReconciler) handleUpgrade(ctx context.Context, ibu *lc
 	prePivot, err := isPrePivot(r, ibu)
 	if err != nil {
 		//todo: abort handler? e.g delete desired stateroot
-		upgradeFailedStatus(ibu, err.Error())
+		utils.SetUpgradeStatusFailed(ibu, err.Error())
 		return doNotRequeue(), nil
 	}
 
@@ -84,7 +67,7 @@ func (r *ImageBasedUpgradeReconciler) handleUpgrade(ctx context.Context, ibu *lc
 		ctrlResult, err := r.prePivot(ctx, ibu)
 		if err != nil {
 			//todo: abort handler? e.g delete desired stateroot
-			upgradeFailedStatus(ibu, err.Error())
+			utils.SetUpgradeStatusFailed(ibu, err.Error())
 			return doNotRequeue(), nil
 		}
 
@@ -99,16 +82,14 @@ func (r *ImageBasedUpgradeReconciler) handleUpgrade(ctx context.Context, ibu *lc
 		if err != nil {
 			//todo: abort handler? e.g delete desired stateroot
 			r.Log.Error(err, "")
-			upgradeFailedStatus(ibu, err.Error())
+			utils.SetUpgradeStatusFailed(ibu, err.Error())
 			return doNotRequeue(), nil
 		}
 	} else {
 		r.Log.Info("Pivot successful, starting post pivot steps")
 		ctrlResult, err := r.postPivot(ctx, ibu)
 		if err != nil {
-			//todo: abort handler? e.g delete desired stateroot
-			upgradeFailedStatus(ibu, err.Error())
-			return doNotRequeue(), nil
+			return requeueWithError(err)
 		}
 
 		// postPivot requested a requeue
@@ -117,19 +98,7 @@ func (r *ImageBasedUpgradeReconciler) handleUpgrade(ctx context.Context, ibu *lc
 		}
 
 		r.Log.Info("Done handleUpgrade")
-
-		utils.SetStatusCondition(&ibu.Status.Conditions,
-			utils.GetCompletedConditionType(lcav1alpha1.Stages.Upgrade),
-			utils.ConditionReasons.Completed,
-			metav1.ConditionTrue,
-			"Upgrade completed",
-			ibu.Generation)
-		utils.SetStatusCondition(&ibu.Status.Conditions,
-			utils.GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
-			utils.ConditionReasons.Completed,
-			metav1.ConditionFalse,
-			"Upgrade completed",
-			ibu.Generation)
+		utils.SetUpgradeStatusCompleted(ibu)
 		return doNotRequeue(), nil
 	}
 
@@ -153,47 +122,21 @@ func (r *ImageBasedUpgradeReconciler) rebootToNewStateRoot() error {
 // prePivot all the funcs needed to be called before a pivot
 func (r *ImageBasedUpgradeReconciler) prePivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
 	// backup with OADP
-	r.Log.Info("Backup with Oadp operator")
-	reqBackup, backupCRs, err := r.BackupRestore.CheckIfBackupRequested(ctx, ibu.Spec.OADPContent)
+	r.Log.Info("Handling backups with OADP operator")
+	ctrlResult, err := r.handleBackup(ctx, ibu)
 	if err != nil {
-		if k8serrors.IsInvalid(err) {
-			utils.SetStatusCondition(&ibu.Status.Conditions,
-				utils.GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
-				utils.ConditionReasons.InProgress,
-				metav1.ConditionTrue,
-				fmt.Sprintf("Invalid backup resource detected in configMap, please update"),
-				ibu.Generation)
-			return requeueWithShortInterval(), nil
+		if backuprestore.IsBRFailedError(err) {
+			utils.SetUpgradeStatusFailed(ibu, err.Error())
+			return doNotRequeue(), nil
+		}
+		if backuprestore.IsBRFailedValidationError(err) || backuprestore.IsBRNotFoundError(err) {
+			utils.SetUpgradeStatusInProgress(ibu, err.Error())
+			return requeueWithMediumInterval(), nil
 		}
 		return requeueWithError(err)
 	}
-	if reqBackup {
-		r.Log.Info("Backup requested")
-		ctrlResult, err := r.startBackup(ctx, backupCRs)
-		if err != nil {
-			var (
-				backupFailedError     *BackupFailedError
-				backupValidationError *BackupValidationError
-			)
-			switch {
-			case errors.As(err, &backupFailedError):
-				upgradeFailedStatus(ibu, backupFailedError.Error())
-				return ctrlResult, nil
-			case errors.As(err, &backupValidationError):
-				utils.SetStatusCondition(&ibu.Status.Conditions,
-					utils.GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
-					utils.ConditionReasons.InProgress,
-					metav1.ConditionTrue,
-					backupValidationError.Error(),
-					ibu.Generation)
-				return ctrlResult, nil
-			default:
-				return requeueWithError(err)
-			}
-		}
-		if !ctrlResult.IsZero() {
-			return ctrlResult, nil
-		}
+	if !ctrlResult.IsZero() {
+		return ctrlResult, nil
 	}
 
 	if _, err := r.Executor.Execute("mount", "/sysroot", "-o", "remount,rw"); err != nil {
@@ -208,14 +151,9 @@ func (r *ImageBasedUpgradeReconciler) prePivot(ctx context.Context, ibu *lcav1al
 
 	r.Log.Info("Writing Restore CRs into new stateroot")
 	if err := r.BackupRestore.ExportRestoresToDir(ctx, ibu.Spec.OADPContent, stateRootRepo); err != nil {
-		if k8serrors.IsInvalid(err) {
-			utils.SetStatusCondition(&ibu.Status.Conditions,
-				utils.GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
-				utils.ConditionReasons.InProgress,
-				metav1.ConditionTrue,
-				fmt.Sprintf("Invalid restore resource detected in configMap, please update"),
-				ibu.Generation)
-			return requeueWithShortInterval(), nil
+		if backuprestore.IsBRFailedValidationError(err) {
+			utils.SetUpgradeStatusInProgress(ibu, err.Error())
+			return requeueWithMediumInterval(), nil
 		}
 		return requeueWithError(err)
 	}
@@ -254,72 +192,135 @@ func (r *ImageBasedUpgradeReconciler) prePivot(ctx context.Context, ibu *lcav1al
 	return ctrl.Result{}, nil
 }
 
-// startBackup manages backup flow and returns with possible requeue
-func (r *ImageBasedUpgradeReconciler) startBackup(ctx context.Context, backupCRs []*velerov1.Backup) (ctrl.Result, error) {
-	// sort backupCRs by wave-apply
-	sortedBackupGroups, err := backuprestore.SortByApplyWaveBackupCrs(backupCRs)
-	if err != nil {
-		return requeueWithError(err)
-	}
-
-	// trigger and track each group
-	for _, backups := range sortedBackupGroups {
-		backupTracker, err := r.BackupRestore.TriggerBackup(ctx, backups)
-		if err != nil {
-			return requeueWithError(err)
-		}
-		if len(backupTracker.SucceededBackups) == len(backups) {
-			// The current backup group has done, work on the next group
-			continue
-		} else if len(backupTracker.FailedBackups) != 0 {
-			// not recoverable
-			msg := fmt.Sprintf("Failed backups: %s", strings.Join(backupTracker.FailedBackups, ","))
-			err := BackupFailedError(msg)
-			return doNotRequeue(), &err
-		} else if len(backupTracker.FailedValidationBackups) != 0 {
-			msg := fmt.Sprintf("Failed validation backups reported by Oadp: %s. %s", strings.Join(backupTracker.FailedValidationBackups, ","), "Please update the invalid backups.")
-			err := BackupValidationError(msg)
-			return requeueWithShortInterval(), &err
-		} else if len(backupTracker.ProgressingBackups) != 0 {
-			r.Log.Info(fmt.Sprintf("Inprogress backups: %s", strings.Join(backupTracker.ProgressingBackups, ",")))
-			return requeueWithCustomInterval(2 * time.Second), nil
-		} else {
-			// Backup doesn't have any status, it's likely
-			// that the object storage backend is not available.
-			// Requeue to wait for the object storage backend
-			// to be ready.
-			r.Log.Info(fmt.Sprintf("Pending backups: %s. %s", strings.Join(backupTracker.PendingBackups, ","), "Wait for object storage backend to be available."))
-			return requeueWithMediumInterval(), nil
-		}
-	}
-
-	return doNotRequeue(), nil
-}
-
-// nolint:unparam
 func (r *ImageBasedUpgradeReconciler) postPivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
 	r.Log.Info("Starting health check for different components")
 	err := healthcheck.HealthChecks(r.Client, r.Log)
 	if err != nil {
-		upgradeFailedStatus(ibu, err.Error())
+		utils.SetUpgradeStatusFailed(ibu, err.Error())
 		return doNotRequeue(), nil
 	}
 
+	r.Log.Info("Applying extra manifests")
+	err = r.ExtraManifest.ApplyExtraManifests(ctx, common.PathOutsideChroot(extramanifest.ExtraManifestPath))
+	if err != nil {
+		if extramanifest.IsEMFailedError(err) {
+			utils.SetUpgradeStatusFailed(ibu, err.Error())
+			return doNotRequeue(), nil
+		}
+		return requeueWithError(err)
+	}
+
+	r.Log.Info("Recovering OADP configuration")
+	err = r.BackupRestore.RestoreOadpConfigurations(ctx)
+	if err != nil {
+		if backuprestore.IsBRStorageBackendUnavailableError(err) {
+			utils.SetUpgradeStatusFailed(ibu, err.Error())
+			return doNotRequeue(), nil
+		}
+		return requeueWithError(err)
+	}
+
+	r.Log.Info("Handling restores with OADP operator")
+	result, err := r.handleRestore(ctx)
+	if err != nil {
+		// Restore failed
+		if backuprestore.IsBRFailedError(err) {
+			utils.SetUpgradeStatusFailed(ibu, err.Error())
+			return doNotRequeue(), nil
+		}
+		return requeueWithError(err)
+	}
+
+	return result, nil
+}
+
+// handleBackup manages backup flow and returns with possible requeue
+func (r *ImageBasedUpgradeReconciler) handleBackup(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
+	sortedBackupGroups, err := r.BackupRestore.GetSortedBackupsFromConfigmap(ctx, ibu.Spec.OADPContent)
+	if err != nil {
+		return requeueWithError(err)
+	}
+
+	if len(sortedBackupGroups) == 0 {
+		r.Log.Info("No backup requests, skipping")
+		return doNotRequeue(), nil
+	}
+
+	// trigger and track each group
+	for index, backups := range sortedBackupGroups {
+		r.Log.Info("Processing backup", "groupIndex", index+1, "totalGroups", len(sortedBackupGroups))
+		backupTracker, err := r.BackupRestore.StartOrTrackBackup(ctx, backups)
+		if err != nil {
+			return requeueWithError(err)
+		}
+
+		// The current backup group has done, work on the next group
+		if len(backupTracker.SucceededBackups) == len(backups) {
+			continue
+		}
+
+		// Backup CRs failed
+		if len(backupTracker.FailedBackups) > 0 {
+			errMsg := fmt.Sprintf("Failed backup CRs: %s", strings.Join(backupTracker.FailedBackups, ","))
+			return requeueWithError(backuprestore.NewBRFailedError("Backup", errMsg))
+		}
+
+		// Backups are in progress
+		if len(backupTracker.ProgressingBackups) > 0 {
+			return requeueWithCustomInterval(5 * time.Second), nil
+		}
+
+		// Backups are waiting for condition
+		return requeueWithMediumInterval(), nil
+	}
+
+	r.Log.Info("All backups succeeded")
 	return doNotRequeue(), nil
 }
 
-// upgradeFailedStatus call this when upgrade fails
-func upgradeFailedStatus(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
-	utils.SetStatusCondition(&ibu.Status.Conditions,
-		utils.GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
-		utils.ConditionReasons.Failed,
-		metav1.ConditionFalse,
-		msg,
-		ibu.Generation)
-	utils.SetStatusCondition(&ibu.Status.Conditions,
-		utils.GetCompletedConditionType(lcav1alpha1.Stages.Upgrade),
-		utils.ConditionReasons.Failed,
-		metav1.ConditionFalse,
-		"Upgrade failed",
-		ibu.Generation)
+func (r *ImageBasedUpgradeReconciler) handleRestore(ctx context.Context) (ctrl.Result, error) {
+	// Load restore CRs from files
+	sortedRestoreGroups, err := r.BackupRestore.LoadRestoresFromOadpRestorePath()
+	if err != nil {
+		return requeueWithError(err)
+	}
+
+	if len(sortedRestoreGroups) == 0 {
+		r.Log.Info("No restore requests, skipping")
+		return doNotRequeue(), nil
+	}
+
+	for index, restores := range sortedRestoreGroups {
+		r.Log.Info("Processing restore", "groupIndex", index+1, "totalGroups", len(sortedRestoreGroups))
+		restoreTracker, err := r.BackupRestore.StartOrTrackRestore(ctx, restores)
+		if err != nil {
+			return requeueWithError(err)
+		}
+
+		// The current restore group has done, work on the next group
+		if len(restoreTracker.SucceededRestores) == len(restores) {
+			continue
+		}
+
+		// Restore CRs failed
+		if len(restoreTracker.FailedRestores) > 0 {
+			errMsg := fmt.Sprintf("Failed restore CRs: %s", strings.Join(restoreTracker.FailedRestores, ","))
+			return requeueWithError(backuprestore.NewBRFailedError("Restore", errMsg))
+		}
+
+		// Restores CRs are in progress
+		if len(restoreTracker.ProgressingRestores) > 0 {
+			return requeueWithShortInterval(), nil
+		}
+
+		// Restores are waiting for condition
+		return requeueWithMediumInterval(), nil
+	}
+
+	r.Log.Info("All restores succeeded")
+	if err := os.RemoveAll(common.PathOutsideChroot(backuprestore.OadpRestorePath)); err != nil {
+		return requeueWithError(err)
+	}
+	r.Log.Info("OADP restore path removed", "path", backuprestore.OadpRestorePath)
+	return doNotRequeue(), nil
 }

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -240,3 +240,45 @@ func GetPreviousStage(stage lcav1alpha1.ImageBasedUpgradeStage) lcav1alpha1.Imag
 	}
 	return ""
 }
+
+// SetUpgradeStatusFailed updates the upgrade status to failed with message
+func SetUpgradeStatusFailed(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
+		ConditionReasons.Failed,
+		metav1.ConditionFalse,
+		msg,
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetCompletedConditionType(lcav1alpha1.Stages.Upgrade),
+		ConditionReasons.Failed,
+		metav1.ConditionFalse,
+		"Upgrade failed",
+		ibu.Generation)
+}
+
+// SetUpgradeStatusInProgress updates the upgrade status to in progress with message
+func SetUpgradeStatusInProgress(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
+		ConditionReasons.InProgress,
+		metav1.ConditionTrue,
+		msg,
+		ibu.Generation)
+}
+
+// SetUpgradeStatusCompleted updates the upgrade status to completed
+func SetUpgradeStatusCompleted(ibu *lcav1alpha1.ImageBasedUpgrade) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetCompletedConditionType(lcav1alpha1.Stages.Upgrade),
+		ConditionReasons.Completed,
+		metav1.ConditionTrue,
+		"Upgrade completed",
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
+		ConditionReasons.Completed,
+		metav1.ConditionFalse,
+		"Upgrade completed",
+		ibu.Generation)
+}

--- a/internal/backuprestore/restore_test.go
+++ b/internal/backuprestore/restore_test.go
@@ -146,7 +146,7 @@ func TestSortRestoreCrs(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, _ := sortRestoreCrs(tc.resources)
+			result, _ := sortByApplyWaveRestoreCrs(tc.resources)
 			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
@@ -154,119 +154,80 @@ func TestSortRestoreCrs(t *testing.T) {
 
 func TestTriggerRestore(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		existingBackups         []client.Object
-		existingRestores        []client.Object
-		expectedReconcileResult ctrl.Result
-		expectedStatus          RestorePhase
-		expectedRestoresCount   int
+		name                   string
+		existingBackups        []client.Object
+		existingRestores       []client.Object
+		expectedRestoreTracker RestoreTracker
 	}{
 		{
-			name:                    "No restores applied and required backups not found",
-			existingBackups:         []client.Object{},
-			existingRestores:        []client.Object{},
-			expectedReconcileResult: ctrl.Result{RequeueAfter: 10 * time.Second},
-			expectedStatus:          RestorePending,
-			expectedRestoresCount:   0,
+			name:             "No restores applied and required backups not found",
+			existingBackups:  []client.Object{},
+			existingRestores: []client.Object{},
+			expectedRestoreTracker: RestoreTracker{
+				MissingBackups: []string{"restore1", "restore2", "restore3"},
+			},
 		},
 		{
 			name: "No restores applied and required backups found",
 			existingBackups: []client.Object{
 				fakeBackupCr("backup1", "1", "fakeResource1"),
 				fakeBackupCr("backup2", "1", "fakeResource2"),
-				fakeBackupCr("backup3", "2", "fakeResource3"),
-				fakeBackupCr("backup4", "2", "fakeResource4"),
+				fakeBackupCr("backup3", "1", "fakeResource3"),
 			},
-			existingRestores:        []client.Object{},
-			expectedReconcileResult: ctrl.Result{RequeueAfter: 30 * time.Second},
-			expectedStatus:          RestoreInProgress,
-			expectedRestoresCount:   2,
+			existingRestores: []client.Object{},
+			expectedRestoreTracker: RestoreTracker{
+				ProgressingRestores: []string{"restore1", "restore2", "restore3"},
+			},
 		},
 		{
-			name: "Restores applied in the first group but have no status",
+			name: "Restores applied but have no status",
 			existingBackups: []client.Object{
 				fakeBackupCr("backup1", "1", "fakeResource1"),
 				fakeBackupCr("backup2", "1", "fakeResource2"),
-				fakeBackupCr("backup3", "2", "fakeResource3"),
-				fakeBackupCr("backup4", "2", "fakeResource4"),
+				fakeBackupCr("backup3", "1", "fakeResource3"),
 			},
 			existingRestores: []client.Object{
 				fakeRestoreCrWithStatus("restore1", "1", "backup1", ""),
 				fakeRestoreCrWithStatus("restore2", "1", "backup2", ""),
+				fakeRestoreCrWithStatus("restore3", "1", "backup3", ""),
 			},
-			expectedReconcileResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-			expectedStatus:          RestorePending,
-			expectedRestoresCount:   2,
+			expectedRestoreTracker: RestoreTracker{
+				PendingRestores: []string{"restore1", "restore2", "restore3"},
+			},
 		},
 		{
-			name: "Restores applied in the first group but have failed status",
+			name: "Restores applied but have failed status",
 			existingBackups: []client.Object{
 				fakeBackupCr("backup1", "1", "fakeResource1"),
 				fakeBackupCr("backup2", "1", "fakeResource2"),
-				fakeBackupCr("backup3", "2", "fakeResource3"),
-				fakeBackupCr("backup4", "2", "fakeResource4"),
+				fakeBackupCr("backup3", "1", "fakeResource3"),
 			},
 			existingRestores: []client.Object{
 				fakeRestoreCrWithStatus("restore1", "1", "backup1", velerov1.RestorePhaseFailed),
 				fakeRestoreCrWithStatus("restore2", "1", "backup2", velerov1.RestorePhaseInProgress),
+				fakeRestoreCrWithStatus("restore3", "1", "backup3", velerov1.RestorePhaseCompleted),
 			},
-			expectedReconcileResult: ctrl.Result{Requeue: false},
-			expectedStatus:          RestoreFailed,
-			expectedRestoresCount:   2,
-		},
-		{
-			name: "Restores completed in the first group and in progress in the second group",
-			existingBackups: []client.Object{
-				fakeBackupCr("backup1", "1", "fakeResource1"),
-				fakeBackupCr("backup2", "1", "fakeResource2"),
-				fakeBackupCr("backup3", "2", "fakeResource3"),
-				fakeBackupCr("backup4", "2", "fakeResource4"),
+			expectedRestoreTracker: RestoreTracker{
+				FailedRestores:      []string{"restore1"},
+				ProgressingRestores: []string{"restore2"},
+				SucceededRestores:   []string{"restore3"},
 			},
-			existingRestores: []client.Object{
-				fakeRestoreCrWithStatus("restore1", "1", "backup1", velerov1.RestorePhaseCompleted),
-				fakeRestoreCrWithStatus("restore2", "1", "backup2", velerov1.RestorePhaseCompleted),
-				fakeRestoreCrWithStatus("restore3", "2", "backup3", velerov1.RestorePhaseInProgress),
-				fakeRestoreCrWithStatus("restore4", "2", "backup4", velerov1.RestorePhaseInProgress),
-			},
-			expectedReconcileResult: ctrl.Result{RequeueAfter: 30 * time.Second},
-			expectedStatus:          RestoreInProgress,
-			expectedRestoresCount:   4,
-		},
-		{
-			name: "Restores completed in the first group and failed in the second group",
-			existingBackups: []client.Object{
-				fakeBackupCr("backup1", "1", "fakeResource1"),
-				fakeBackupCr("backup2", "1", "fakeResource2"),
-				fakeBackupCr("backup3", "2", "fakeResource3"),
-				fakeBackupCr("backup4", "2", "fakeResource4"),
-			},
-			existingRestores: []client.Object{
-				fakeRestoreCrWithStatus("restore1", "1", "backup1", velerov1.RestorePhaseCompleted),
-				fakeRestoreCrWithStatus("restore2", "1", "backup2", velerov1.RestorePhaseCompleted),
-				fakeRestoreCrWithStatus("restore3", "2", "backup3", velerov1.RestorePhaseFailed),
-				fakeRestoreCrWithStatus("restore4", "2", "backup4", velerov1.RestorePhaseInProgress),
-			},
-			expectedReconcileResult: ctrl.Result{Requeue: false},
-			expectedStatus:          RestoreFailed,
-			expectedRestoresCount:   4,
 		},
 		{
 			name: "All restores completed",
 			existingBackups: []client.Object{
 				fakeBackupCr("backup1", "1", "fakeResource1"),
 				fakeBackupCr("backup2", "1", "fakeResource2"),
-				fakeBackupCr("backup3", "2", "fakeResource3"),
-				fakeBackupCr("backup4", "2", "fakeResource4"),
+				fakeBackupCr("backup3", "1", "fakeResource3"),
 			},
 			existingRestores: []client.Object{
 				fakeRestoreCrWithStatus("restore1", "1", "backup1", velerov1.RestorePhaseCompleted),
 				fakeRestoreCrWithStatus("restore2", "1", "backup2", velerov1.RestorePhaseCompleted),
-				fakeRestoreCrWithStatus("restore3", "2", "backup3", velerov1.RestorePhaseCompleted),
-				fakeRestoreCrWithStatus("restore4", "2", "backup4", velerov1.RestorePhaseCompleted),
+				fakeRestoreCrWithStatus("restore3", "1", "backup3", velerov1.RestorePhaseCompleted),
 			},
-			expectedReconcileResult: ctrl.Result{Requeue: false},
-			expectedStatus:          RestoreCompleted,
-			expectedRestoresCount:   4,
+			expectedRestoreTracker: RestoreTracker{
+				SucceededRestores: []string{"restore1", "restore2", "restore3"},
+			},
 		},
 	}
 
@@ -287,36 +248,32 @@ func TestTriggerRestore(t *testing.T) {
 			}
 
 			// restore CRs to apply
-			restores := [][]*velerov1.Restore{
-				{
-					fakeRestoreCr("restore1", "1", "backup1"),
-					fakeRestoreCr("restore2", "1", "backup2"),
-				}, {
-					fakeRestoreCr("restore3", "2", "backup3"),
-					fakeRestoreCr("restore4", "2", "backup4"),
-				},
+			restores := []*velerov1.Restore{
+				fakeRestoreCr("restore1", "1", "backup1"),
+				fakeRestoreCr("restore2", "1", "backup2"),
+				fakeRestoreCr("restore3", "1", "backup3"),
 			}
 
 			handler := &BRHandler{
 				Client: fakeClient,
 				Log:    ctrl.Log.WithName("BackupRestore"),
 			}
-			result, restoreStatus, err := handler.triggerRestore(context.Background(), restores)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err.Error())
-			}
-			assert.Equal(t, tc.expectedReconcileResult, result)
-			assert.Equal(t, tc.expectedStatus, restoreStatus.Status)
 
-			restoreList := &velerov1.RestoreList{}
-			err = fakeClient.List(context.Background(), restoreList, client.InNamespace(OadpNs))
+			restoreTracker, err := handler.StartOrTrackRestore(context.Background(), restores)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err.Error())
 			}
-			assert.Equal(t, tc.expectedRestoresCount, len(restoreList.Items))
+
+			// Verify the result
+			assert.Equal(t, len(tc.expectedRestoreTracker.SucceededRestores), len(restoreTracker.SucceededRestores))
+			assert.Equal(t, len(tc.expectedRestoreTracker.FailedRestores), len(restoreTracker.FailedRestores))
+			assert.Equal(t, len(tc.expectedRestoreTracker.MissingBackups), len(restoreTracker.MissingBackups))
+			assert.Equal(t, len(tc.expectedRestoreTracker.PendingRestores), len(restoreTracker.PendingRestores))
+			assert.Equal(t, len(tc.expectedRestoreTracker.ProgressingRestores), len(restoreTracker.ProgressingRestores))
 		})
 	}
 }
+
 func TestLoadRestoresFromDir(t *testing.T) {
 	// Create temporary directory
 	tmpDir, err := os.MkdirTemp("", "staterootB")
@@ -326,7 +283,7 @@ func TestLoadRestoresFromDir(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create restores directory
-	restoreDir := filepath.Join(tmpDir, oadpRestorePath)
+	restoreDir := filepath.Join(tmpDir, OadpRestorePath)
 	if err := os.MkdirAll(restoreDir, 0755); err != nil {
 		t.Fatalf("Failed to create restore directory: %v", err)
 	}
@@ -341,7 +298,7 @@ func TestLoadRestoresFromDir(t *testing.T) {
 		t.Fatalf("Failed to create restore subdirectory: %v", err)
 	}
 
-	restore1File := filepath.Join(restoreSubDir1, "restore1.yaml")
+	restore1File := filepath.Join(restoreSubDir1, "1_default-restore1.yaml")
 	if err := os.WriteFile(restore1File, []byte("apiVersion: velero.io/v1\n"+
 		"kind: Restore\n"+
 		"metadata:\n"+
@@ -350,7 +307,7 @@ func TestLoadRestoresFromDir(t *testing.T) {
 		"  backupName: backup1\n"), 0644); err != nil {
 		t.Fatalf("Failed to create restore file: %v", err)
 	}
-	restore2File := filepath.Join(restoreSubDir1, "restore2.yaml")
+	restore2File := filepath.Join(restoreSubDir1, "2_default-restore2.yaml")
 	if err := os.WriteFile(restore2File, []byte("apiVersion: velero.io/v1\n"+
 		"kind: Restore\n"+
 		"metadata:\n"+
@@ -359,7 +316,7 @@ func TestLoadRestoresFromDir(t *testing.T) {
 		"  backupName: backup2\n"), 0644); err != nil {
 		t.Fatalf("Failed to create restore file: %v", err)
 	}
-	restore3File := filepath.Join(restoreSubDir2, "restore3.yaml")
+	restore3File := filepath.Join(restoreSubDir2, "1_default-restore3.yaml")
 	if err := os.WriteFile(restore3File, []byte("apiVersion: velero.io/v1\n"+
 		"kind: Restore\n"+
 		"metadata:\n"+
@@ -373,8 +330,11 @@ func TestLoadRestoresFromDir(t *testing.T) {
 		Client: nil,
 		Log:    ctrl.Log.WithName("BackupRestore"),
 	}
+
+	// Override the default host path
+	hostDir = tmpDir
 	// Load restores from the temporary directory
-	restores, err := handler.loadRestoresFromDir(tmpDir)
+	restores, err := handler.LoadRestoresFromOadpRestorePath()
 	if err != nil {
 		t.Fatalf("Failed to load restores: %v", err)
 	}
@@ -435,7 +395,7 @@ func TestRestoreDataProtectionApplications(t *testing.T) {
 	}
 	defer os.RemoveAll(fromDir)
 
-	// Create oadp DPA directory
+	// Create oadp directory
 	dpaDir := filepath.Join(fromDir, oadpDpaPath)
 	if err := os.MkdirAll(dpaDir, 0755); err != nil {
 		t.Fatalf("Failed to create oadp directory: %v", err)
@@ -467,13 +427,13 @@ func TestRestoreDataProtectionApplications(t *testing.T) {
 		Log:    ctrl.Log.WithName("BackupRestore"),
 	}
 
-	resultChan := make(chan bool)
 	errorChan := make(chan error)
 
 	// Test restore of DataProtectionApplication
 	go func() {
-		result, err := handler.restoreDataProtectionApplications(context.Background(), fromDir)
-		resultChan <- result
+		// Override the default host path
+		hostDir = fromDir
+		err := handler.restoreDataProtectionApplications(context.Background())
 		errorChan <- err
 	}()
 
@@ -508,14 +468,14 @@ func fakeBackupStorageBackendWithStatus(name string, phase velerov1.BackupStorag
 
 func TestEnsureStorageBackendAvailable(t *testing.T) {
 	testcases := []struct {
-		name     string
-		bsl      []client.Object
-		expected bool
+		name        string
+		bsl         []client.Object
+		expectedErr error
 	}{
 		{
-			name:     "No backup storage locations",
-			bsl:      []client.Object{},
-			expected: false,
+			name:        "No backup storage locations",
+			bsl:         []client.Object{},
+			expectedErr: NewBRStorageBackendUnavailableError("No backup storage location found"),
 		},
 		{
 			name: "Backup storage location is unavailable",
@@ -523,7 +483,7 @@ func TestEnsureStorageBackendAvailable(t *testing.T) {
 				fakeBackupStorageBackendWithStatus("oadp1", velerov1.BackupStorageLocationPhaseUnavailable),
 				fakeBackupStorageBackendWithStatus("oadp2", velerov1.BackupStorageLocationPhaseAvailable),
 			},
-			expected: false,
+			expectedErr: NewBRStorageBackendUnavailableError("BackupStorageLocation is unavailable. Name: oadp1, Error: "),
 		},
 		{
 			name: "Backup storage locations are available",
@@ -531,7 +491,7 @@ func TestEnsureStorageBackendAvailable(t *testing.T) {
 				fakeBackupStorageBackendWithStatus("oadp1", velerov1.BackupStorageLocationPhaseAvailable),
 				fakeBackupStorageBackendWithStatus("oadp2", velerov1.BackupStorageLocationPhaseAvailable),
 			},
-			expected: true,
+			expectedErr: nil,
 		},
 	}
 	ns := &corev1.Namespace{
@@ -554,11 +514,8 @@ func TestEnsureStorageBackendAvailable(t *testing.T) {
 				Log:    ctrl.Log.WithName("BackupRestore"),
 			}
 
-			ok, err := handler.ensureStorageBackendAvailable(context.Background(), OadpNs)
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			assert.Equal(t, tc.expected, ok)
+			err = handler.ensureStorageBackendAvailable(context.Background(), OadpNs)
+			assert.Equal(t, err, tc.expectedErr)
 		})
 	}
 }


### PR DESCRIPTION
The directories that store the manifests will be cleaned up once each recovery has completed.
i.e., /opt/du-extra-manifests
       /opt/OADP/secret
       /opt/OADP/dpa
       /opt/OADP/veleroRestore

Upgrade will fail when there's issue with creation of extramanifest, recovery of OADP configuration and failed restore CRs. 