### PR TITLE
MGMT-16227: cleanup etcd keys with seed hostname in them and small fixes for IBI process

### DIFF
--- a/ibu-imager/ops/ops.go
+++ b/ibu-imager/ops/ops.go
@@ -177,7 +177,7 @@ func (o *ops) waitForEtcd(healthzEndpoint string) error {
 }
 
 func (o *ops) RunRecert(recertContainerImage, authFile, recertConfigFile string, additionalPodmanParams ...string) error {
-
+	o.log.Info("Start running recert")
 	command := "podman"
 	args := append(podmanRecertArgs, "--name", "recert",
 		"-v", "/etc:/host-etc",


### PR DESCRIPTION
[MGMT-16227](https://issues.redhat.com//browse/MGMT-16227): cleanup etcd keys with seed hostname in them

Fixing preconfiguration script to match IBI logic

In case certs dir was not created, we should not fail recert config creation but rather not to provice key rules