### PR TITLE
Update health checks

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -207,6 +207,14 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - infrastructures
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
           - proxies
           verbs:
           - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -122,6 +122,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - proxies
   verbs:
   - get

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -4,33 +4,46 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 
 	"github.com/go-logr/logr"
-	v12 "github.com/openshift/api/config/v1"
-	v1 "github.com/openshift/api/machineconfiguration/v1"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mcv1 "github.com/openshift/api/machineconfiguration/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // +kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigpools,verbs=list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=list;watch
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch
 
 var (
-	pollInterval = 3 * time.Second
+	pollInterval = 30 * time.Second
 	pollTimeout  = 15 * time.Minute
 )
 
-func HealthChecks(c client.Client, l logr.Logger) error {
+const (
+	NodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
+	NodeRoleMaster       = "node-role.kubernetes.io/master"
+	NodeRoleWorker       = "node-role.kubernetes.io/worker"
+)
+
+func HealthChecks(c client.Reader, l logr.Logger) error {
 	defer common.FuncTimer(time.Now(), "healthCheck", l)
 
 	// using channel store go routine return val and WaitGroup to sync.
-	chanBufferSize := 3
+	chanBufferSize := 5
 	errChn := make(chan error, chanBufferSize)
 	var wg sync.WaitGroup
 
@@ -56,6 +69,20 @@ func HealthChecks(c client.Client, l logr.Logger) error {
 		errChn <- clusterServiceVersionReady(c, l)
 	}()
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer common.FuncTimer(time.Now(), "clusterVersionReady", l)
+		errChn <- clusterVersionReady(c, l)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer common.FuncTimer(time.Now(), "nodesReady", l)
+		errChn <- nodesReady(c, l)
+	}()
+
 	// wait
 	go func() {
 		l.Info("Wait until WaitGroup is done")
@@ -74,7 +101,7 @@ func HealthChecks(c client.Client, l logr.Logger) error {
 	return finalErrs
 }
 
-func clusterServiceVersionReady(c client.Client, l logr.Logger) error {
+func clusterServiceVersionReady(c client.Reader, l logr.Logger) error {
 	l.Info("Waiting for all ClusterServiceVersion (csv) to be ready")
 	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, isClusterServiceVersionReady(c, l))
 	if err != nil {
@@ -84,16 +111,21 @@ func clusterServiceVersionReady(c client.Client, l logr.Logger) error {
 	return nil
 }
 
-func isClusterServiceVersionReady(c client.Client, l logr.Logger) wait.ConditionWithContextFunc {
+func isClusterServiceVersionReady(c client.Reader, l logr.Logger) wait.ConditionWithContextFunc {
 	return func(ctx context.Context) (bool, error) {
-		clusterServiceVersionList := v1alpha1.ClusterServiceVersionList{}
+		clusterServiceVersionList := operatorsv1alpha1.ClusterServiceVersionList{}
 		err := c.List(context.Background(), &clusterServiceVersionList)
 		if err != nil {
-			return false, err
+			l.Error(err, "failed to get csv list")
+			return false, nil
 		}
 
 		for _, csv := range clusterServiceVersionList.Items {
-			if !(csv.Status.Phase == v1alpha1.CSVPhaseSucceeded && csv.Status.Reason == v1alpha1.CSVReasonInstallSuccessful) {
+			if strings.Contains(csv.Name, "lifecycle-agent") {
+				l.Info(fmt.Sprintf("Skipping check of %s/%s", csv.Kind, csv.Name))
+				continue
+			}
+			if !(csv.Status.Phase == operatorsv1alpha1.CSVPhaseSucceeded && csv.Status.Reason == operatorsv1alpha1.CSVReasonInstallSuccessful) {
 				l.Info(fmt.Sprintf("%s not ready yet", csv.Name), "kind", csv.Kind)
 				return false, nil
 			}
@@ -104,7 +136,39 @@ func isClusterServiceVersionReady(c client.Client, l logr.Logger) wait.Condition
 	}
 }
 
-func machineConfigPoolReady(c client.Client, l logr.Logger) error {
+func clusterVersionReady(c client.Reader, l logr.Logger) error {
+	l.Info("Waiting for ClusterVersion to be ready")
+	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, isClusterVersionReady(c, l))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isClusterVersionReady(c client.Reader, l logr.Logger) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		clusterVersionList := configv1.ClusterVersionList{}
+		err := c.List(context.Background(), &clusterVersionList)
+		if err != nil {
+			l.Error(err, "failed to get cv list")
+			return false, nil
+		}
+
+		for _, co := range clusterVersionList.Items {
+			if !getClusterOperatorStatusCondition(co.Status.Conditions, configv1.OperatorAvailable) {
+				l.Info(fmt.Sprintf("%s not ready yet", co.Name), "kind", co.Kind)
+				return false, nil
+			}
+		}
+
+		l.Info("Cluster version is ready")
+		return true, nil
+	}
+
+}
+
+func machineConfigPoolReady(c client.Reader, l logr.Logger) error {
 	l.Info("Waiting for MachineConfigPool (mcp) to be ready")
 	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, isMachineConfigPoolReady(c, l))
 	if err != nil {
@@ -114,12 +178,13 @@ func machineConfigPoolReady(c client.Client, l logr.Logger) error {
 	return nil
 }
 
-func isMachineConfigPoolReady(c client.Client, l logr.Logger) wait.ConditionWithContextFunc {
+func isMachineConfigPoolReady(c client.Reader, l logr.Logger) wait.ConditionWithContextFunc {
 	return func(ctx context.Context) (bool, error) {
-		machineConfigPoolList := v1.MachineConfigPoolList{}
+		machineConfigPoolList := mcv1.MachineConfigPoolList{}
 		err := c.List(context.Background(), &machineConfigPoolList)
 		if err != nil {
-			return false, err
+			l.Error(err, "failed to get mcp list")
+			return false, nil
 		}
 
 		for _, mcp := range machineConfigPoolList.Items {
@@ -134,7 +199,7 @@ func isMachineConfigPoolReady(c client.Client, l logr.Logger) wait.ConditionWith
 	}
 }
 
-func clusterOperatorsReady(c client.Client, l logr.Logger) error {
+func clusterOperatorsReady(c client.Reader, l logr.Logger) error {
 	l.Info("Waiting for all ClusterOperator (co) to be ready")
 	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, areClusterOperatorsReady(c, l))
 	if err != nil {
@@ -144,17 +209,28 @@ func clusterOperatorsReady(c client.Client, l logr.Logger) error {
 	return nil
 }
 
-func areClusterOperatorsReady(c client.Client, l logr.Logger) wait.ConditionWithContextFunc {
+func areClusterOperatorsReady(c client.Reader, l logr.Logger) wait.ConditionWithContextFunc {
 	return func(ctx context.Context) (bool, error) {
-		clusterOperatorList := v12.ClusterOperatorList{}
+		clusterOperatorList := configv1.ClusterOperatorList{}
 		err := c.List(context.Background(), &clusterOperatorList)
 		if err != nil {
-			return false, err
+			l.Error(err, "failed to get co list")
+			return false, nil
 		}
 
 		for _, co := range clusterOperatorList.Items {
-			if !findCOStatusCondition(co.Status.Conditions, v12.OperatorAvailable) {
+			if !getClusterOperatorStatusCondition(co.Status.Conditions, configv1.OperatorAvailable) {
 				l.Info(fmt.Sprintf("%s not ready yet", co.Name), "kind", co.Kind)
+				return false, nil
+			}
+
+			if getClusterOperatorStatusCondition(co.Status.Conditions, configv1.OperatorProgressing) {
+				l.Info(fmt.Sprintf("%s is in progressing state", co.Name), "kind", co.Kind)
+				return false, nil
+			}
+
+			if getClusterOperatorStatusCondition(co.Status.Conditions, configv1.OperatorDegraded) {
+				l.Info(fmt.Sprintf("%s is in degraded state", co.Name), "kind", co.Kind)
 				return false, nil
 			}
 		}
@@ -164,10 +240,78 @@ func areClusterOperatorsReady(c client.Client, l logr.Logger) wait.ConditionWith
 	}
 }
 
-func findCOStatusCondition(conditions []v12.ClusterOperatorStatusCondition, conditionType v12.ClusterStatusConditionType) bool {
+func getClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) bool {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {
-			return true
+			return condition.Status == configv1.ConditionTrue
+		}
+	}
+
+	return false
+}
+
+func nodesReady(c client.Reader, l logr.Logger) error {
+	l.Info("Waiting for Node to be ready")
+	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, isNodeReady(c, l))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isNodeReady(c client.Reader, l logr.Logger) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		infra := &configv1.Infrastructure{}
+		if err := c.Get(ctx, types.NamespacedName{Name: "cluster"}, infra); err != nil {
+			l.Error(err, "failed to get infrastucture CR")
+			return false, nil
+		}
+
+		if infra.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+			// This is likely a test environment, so skip the health check.
+			l.Info(fmt.Sprintf("Skipping Node check. InfrastructureTopology is %s. Expected %s", infra.Status.InfrastructureTopology, configv1.SingleReplicaTopologyMode))
+			return true, nil
+		}
+
+		nodeList := corev1.NodeList{}
+		err := c.List(context.Background(), &nodeList)
+		if err != nil {
+			l.Error(err, "failed to get node list")
+			return false, nil
+		}
+
+		for _, node := range nodeList.Items {
+			if !getNodeStatusCondition(node.Status.Conditions, corev1.NodeReady) {
+				l.Info(fmt.Sprintf("%s not ready yet", node.Name), "kind", node.Kind)
+				return false, nil
+			}
+
+			if getNodeStatusCondition(node.Status.Conditions, corev1.NodeNetworkUnavailable) {
+				l.Info(fmt.Sprintf("%s NodeNetworkUnavailable", node.Name), "kind", node.Kind)
+				return false, nil
+			}
+
+			// Verify the node has the expected node-role labels for SNO
+			labels := node.ObjectMeta.GetLabels()
+			requiredLabels := []string{NodeRoleControlPlane, NodeRoleMaster, NodeRoleWorker}
+			for _, label := range requiredLabels {
+				if _, found := labels[label]; !found {
+					l.Info(fmt.Sprintf("%s does not have %s label", node.Name, label), "kind", node.Kind)
+					return false, nil
+				}
+			}
+		}
+
+		l.Info("Node is ready")
+		return true, nil
+	}
+}
+
+func getNodeStatusCondition(conditions []corev1.NodeCondition, conditionType corev1.NodeConditionType) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == corev1.ConditionTrue
 		}
 	}
 


### PR DESCRIPTION
This update includes the following:
- change client.Client parameter to client.Reader, to support non-cached client in early init function
- bug fix for ClusterOperator condition check
- add checks for ClusterOperator Progressing=false and Degraded=false
- add Node "Ready" check, as well as node-role labels
- add ClusterVersion Available=true check
- update health check polling interval to 30 seconds