### PR TITLE
CNF-10412: Remove progress file from the prep-handler

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -69,10 +69,11 @@ type ImageBasedUpgradeReconciler struct {
 
 // Task contains objects for executing a group of serial tasks asynchronously
 type Task struct {
-	Active  bool
-	Success bool
-	Cancel  context.CancelFunc
-	done    chan struct{}
+	Active   bool
+	Success  bool
+	Cancel   context.CancelFunc
+	Progress string
+	done     chan struct{}
 }
 
 // Reset Re-initialize the Task variables to initial values
@@ -80,6 +81,7 @@ func (c *Task) Reset() {
 	c.Active = false
 	c.Success = false
 	c.Cancel = nil
+	c.Progress = ""
 	select {
 	case _, open := <-c.done:
 		if open {

--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -64,6 +64,28 @@ type ImageBasedUpgradeReconciler struct {
 	ManifestClient  *clusterinfo.InfoClient
 	OstreeClient    ostreeclient.IClient
 	Ops             ops.Ops
+	PrepTask        *Task
+}
+
+// Task contains objects for executing a group of serial tasks asynchronously
+type Task struct {
+	Active  bool
+	Success bool
+	Cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// Reset Re-initialize the Task variables to initial values
+func (c *Task) Reset() {
+	c.Active = false
+	c.Success = false
+	c.Cancel = nil
+	select {
+	case _, open := <-c.done:
+		if open {
+			close(c.done)
+		}
+	}
 }
 
 func doNotRequeue() ctrl.Result {

--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -98,7 +98,11 @@ func (r *ImageBasedUpgradeReconciler) cleanup(
 		r.Log.Error(err, msg)
 		errorMessage += msg + " "
 	}
-
+	// Terminate precaching worker thread
+	if r.PrepTask.Active && r.PrepTask.Cancel != nil {
+		r.PrepTask.Cancel()
+		r.PrepTask.Reset()
+	}
 	if err := r.cleanupStateroots(allUnbootedStateroots, ibu); err != nil {
 		handleError(err, "failed to cleanup stateroots.")
 	}

--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -18,10 +18,16 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	"github.com/openshift-kni/lifecycle-agent/internal/prep"
@@ -33,32 +39,8 @@ import (
 
 	"github.com/openshift-kni/lifecycle-agent/internal/precache"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
-
-func (r *ImageBasedUpgradeReconciler) launchGetSeedImage(
-	ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade, imageListFile, progressfile string,
-) (ctrl.Result, error) {
-	result := requeueImmediately()
-	if err := updateProgressFile(progressfile, "started-seed-image-pull"); err != nil {
-		r.Log.Error(err, "failed to update progress file")
-		return result, err
-	}
-	if err := r.getSeedImage(ctx, ibu, imageListFile); err != nil {
-		r.Log.Error(err, "failed to get seed image")
-		if err := updateProgressFile(progressfile, "Failed"); err != nil {
-			r.Log.Error(err, "failed to update progress file")
-			return result, err
-		}
-		return result, err
-	}
-	if err := updateProgressFile(progressfile, "completed-seed-image-pull"); err != nil {
-		r.Log.Error(err, "failed to update progress file")
-		return result, err
-	}
-	return result, nil
-}
 
 func (r *ImageBasedUpgradeReconciler) getSeedImage(
 	ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade, imageListFile string,
@@ -125,28 +107,24 @@ func readPrecachingList(imageListFile, clusterRegistry, seedRegistry string) (im
 	return imageList, nil
 }
 
-func updateProgressFile(path, progress string) error {
-	return os.WriteFile(common.PathOutsideChroot(path), []byte(progress), 0o700)
-}
-
-func (r *ImageBasedUpgradeReconciler) launchPrecaching(ctx context.Context, imageListFile, progressfile string, ibu *lcav1alpha1.ImageBasedUpgrade) (result ctrl.Result, err error) {
+func (r *ImageBasedUpgradeReconciler) launchPrecaching(ctx context.Context, imageListFile string, ibu *lcav1alpha1.ImageBasedUpgrade) (bool, error) {
 	clusterRegistry, err := clusterinfo.NewClusterInfoClient(r.Client).GetReleaseRegistry(ctx)
 	if err != nil {
 		r.Log.Error(err, "Failed to get cluster registry")
-		return
+		return false, err
 	}
 
 	seedInfo, err := clusterinfo.ReadClusterInfoFromFile(
 		common.PathOutsideChroot(getSeedManifestPath(getDesiredStaterootName(ibu))))
 	if err != nil {
 		r.Log.Error(err, "Failed to read seed info")
-		return
+		return false, err
 	}
 
 	imageList, err := readPrecachingList(imageListFile, clusterRegistry, seedInfo.ReleaseRegistry)
 	if err != nil {
 		err = fmt.Errorf("failed to read pre-caching image file: %s, %w", common.PathOutsideChroot(imageListFile), err)
-		return
+		return false, err
 	}
 
 	// Create pre-cache config using default values
@@ -154,59 +132,41 @@ func (r *ImageBasedUpgradeReconciler) launchPrecaching(ctx context.Context, imag
 	err = r.Precache.CreateJob(ctx, config)
 	if err != nil {
 		r.Log.Error(err, "Failed to create precaching job")
-		if err = updateProgressFile(progressfile, "Failed"); err != nil {
-			r.Log.Error(err, "Failed to update progress file for precaching")
-			return
-		}
-		return
+		return false, err
 	}
-	if err = updateProgressFile(progressfile, "precaching-in-progress"); err != nil {
-		r.Log.Error(err, "Failed to update progress file for precaching")
-		return
-	}
-	r.Log.Info("Precaching progress status updated to in-progress")
 
-	result = requeueWithShortInterval()
-	return
+	return true, nil
 }
 
-func (r *ImageBasedUpgradeReconciler) queryPrecachingStatus(ctx context.Context, progressfile string) (result ctrl.Result, err error) {
-	// fetch precaching status
-	status, err := r.Precache.QueryJobStatus(ctx)
+func (r *ImageBasedUpgradeReconciler) queryPrecachingStatus(ctx context.Context) (status *precache.Status, err error) {
+	status, err = r.Precache.QueryJobStatus(ctx)
 	if err != nil {
-		r.Log.Error(err, "Failed to get precaching job status")
+		r.Log.Info("Failed to get precaching job status")
 		return
 	}
 
-	result = requeueImmediately()
-
-	var progressContent []byte
-	var logMsg string
-	switch {
-	case status.Status == "Active":
-		logMsg = "Precaching in-progress"
-		result = requeueWithMediumInterval()
-	case status.Status == "Succeeded":
-		progressContent = []byte("completed-precache")
-		logMsg = "Precaching completed"
-	case status.Status == "Failed":
-		progressContent = []byte("Failed")
-		logMsg = "Precaching failed"
+	if status == nil {
+		r.Log.Info("Precaching job status is nil")
+		return
 	}
 
-	// Augment precaching summary data if available
+	if status.Status == precache.Failed {
+		return status, precache.ErrFailed
+	}
+
+	var logMsg string
+	switch {
+	case status.Status == precache.Active:
+		logMsg = "Precaching in-progress"
+	case status.Status == precache.Succeeded:
+		logMsg = "Precaching completed"
+	}
+
+	// Augment precaching log message data with precache summary report (if available)
 	if status.Message != "" {
 		logMsg = fmt.Sprintf("%s: %s", logMsg, status.Message)
 	}
 	r.Log.Info(logMsg)
-
-	// update progress-file
-	if len(progressContent) > 0 {
-		if err = os.WriteFile(common.PathOutsideChroot(progressfile), progressContent, 0o700); err != nil {
-			r.Log.Error(err, "Failed to update progress file for precaching")
-			return
-		}
-	}
 
 	return
 }
@@ -342,29 +302,110 @@ func (r *ImageBasedUpgradeReconciler) SetupStateroot(ctx context.Context, ibu *l
 	return nil
 }
 
-func (r *ImageBasedUpgradeReconciler) launchSetupStateroot(ctx context.Context,
-	ibu *lcav1alpha1.ImageBasedUpgrade, progressfile string) (ctrl.Result, error) {
-	result := requeueImmediately()
-	if err := updateProgressFile(progressfile, "started-stateroot"); err != nil {
-		r.Log.Error(err, "failed to update progress file")
-		return result, err
-	}
-	if err := r.SetupStateroot(ctx, ibu); err != nil {
-		r.Log.Error(err, "failed to setup stateroot")
-		if err := updateProgressFile(progressfile, "Failed"); err != nil {
-			r.Log.Error(err, "failed to update progress file")
-			return result, err
+func (r *ImageBasedUpgradeReconciler) verifyPrecachingCompleteFunc(retries int, interval time.Duration) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		r.Log.Info("Querying pre-caching job for completion...")
+		for retry := 0; retry < retries; retry++ {
+			status, err := r.queryPrecachingStatus(ctx)
+			if err != nil && errors.Is(err, precache.ErrFailed) {
+				// precaching job failed - exit immediately
+				return false, err
+			} else if status != nil {
+				if status.Status == precache.Succeeded {
+					// precaching job succeeded
+					return true, nil
+				} else if status.Status == precache.Active {
+					// precaching job still in-progress
+					return false, nil
+				}
+			}
+			// retry after interval
+			time.Sleep(interval)
 		}
-		return result, err
+		// failed more than retries times to retrieve precaching status - exit with error
+		return false, fmt.Errorf("failed more than %d times to fetch precaching job status", retries)
 	}
-	if err := updateProgressFile(progressfile, "completed-stateroot"); err != nil {
-		r.Log.Error(err, "failed to update progress file")
-		return result, err
-	}
-	return result, nil
 }
 
+func (r *ImageBasedUpgradeReconciler) prepStageWorker(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (err error) {
+	var (
+		derivedCtx context.Context
+		errGroup   errgroup.Group
+	)
+
+	// Create a new context for the worker, derived from the original context
+	derivedCtx, r.PrepTask.Cancel = context.WithCancel(ctx)
+	defer r.PrepTask.Cancel() // Ensure that the cancel function is called when the prepStageWorker function exits
+
+	errGroup.Go(func() error {
+		var ok bool
+		imageListFile := filepath.Join(utils.IBUWorkspacePath, "image-list-file")
+
+		// Pull seed image
+		select {
+		case <-derivedCtx.Done():
+			r.Log.Info("Context canceled before pulling seed image")
+			return derivedCtx.Err()
+		default:
+			if err = r.getSeedImage(derivedCtx, ibu, imageListFile); err != nil {
+				r.Log.Error(err, "failed to pull seed image")
+				return err
+			}
+			r.Log.Info("Successfully pulled seed image")
+		}
+
+		// Setup state-root
+		select {
+		case <-derivedCtx.Done():
+			r.Log.Info("Context canceled before setting up stateroot")
+			return derivedCtx.Err()
+		default:
+			if err = r.SetupStateroot(derivedCtx, ibu); err != nil {
+				r.Log.Error(err, "failed to setup stateroot")
+				return err
+			}
+			r.Log.Info("Successfully setup stateroot")
+		}
+
+		// Launch precaching job
+		select {
+		case <-derivedCtx.Done():
+			r.Log.Info("Context canceled before creating precaching job")
+			return derivedCtx.Err()
+		default:
+			ok, err = r.launchPrecaching(derivedCtx, imageListFile, ibu)
+			if err != nil {
+				r.Log.Info("Failed to launch pre-caching phase")
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("failed to create precaching job")
+			}
+			r.Log.Info("Successfully created precaching job")
+		}
+
+		// Wait for precaching job to complete
+		interval := 30 * time.Second
+		if err = wait.PollUntilContextCancel(derivedCtx, interval, false, r.verifyPrecachingCompleteFunc(5, interval)); err != nil {
+			r.Log.Info("Failed to precache images")
+			return err
+		}
+
+		// Prep-stage completed successfully
+		return nil
+	})
+
+	if err := errGroup.Wait(); err != nil {
+		r.Log.Info("Encountered error while running prep-stage worker goroutine", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+//nolint:unparam
 func (r *ImageBasedUpgradeReconciler) handlePrep(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (result ctrl.Result, err error) {
+
 	result = doNotRequeue()
 
 	_, err = os.Stat(common.Host)
@@ -381,82 +422,42 @@ func (r *ImageBasedUpgradeReconciler) handlePrep(ctx context.Context, ibu *lcav1
 		return
 	}
 
-	progressfile := filepath.Join(utils.IBUWorkspacePath, "prep-progress")
-	imageListFile := filepath.Join(utils.IBUWorkspacePath, "image-list-file")
-
-	_, err = os.Stat(common.PathOutsideChroot(progressfile))
-
-	if err == nil {
-		// in progress
-		var content []byte
-		content, err = os.ReadFile(common.PathOutsideChroot(progressfile))
-		if err != nil {
-			return
-		}
-
-		progress := strings.TrimSpace(string(content))
-		r.Log.Info("Prep progress: " + progress)
-
-		if progress == "Failed" {
-			utils.SetStatusCondition(&ibu.Status.Conditions,
-				utils.GetCompletedConditionType(lcav1alpha1.Stages.Prep),
-				utils.ConditionReasons.Completed,
-				metav1.ConditionFalse,
-				"Prep failed",
-				ibu.Generation)
-			utils.SetStatusCondition(&ibu.Status.Conditions,
-				utils.GetInProgressConditionType(lcav1alpha1.Stages.Prep),
-				utils.ConditionReasons.Completed,
-				metav1.ConditionFalse,
-				"Prep failed",
-				ibu.Generation)
-		} else if progress == "completed-seed-image-pull" {
-			result, err = r.launchSetupStateroot(ctx, ibu, progressfile)
+	switch {
+	case !r.PrepTask.Active:
+		r.PrepTask.done = make(chan struct{})
+		r.PrepTask.Active = true
+		r.PrepTask.Success = false
+		go func() {
+			err = r.prepStageWorker(ctx, ibu)
+			close(r.PrepTask.done)
 			if err != nil {
-				r.Log.Error(err, "Failed to setupStateroot")
-				return
+				r.Log.Error(err, "Prep stage failed with error")
+				r.PrepTask.Success = false
+			} else {
+				r.Log.Info("Prep stage completed successfully!")
+				r.PrepTask.Success = true
 			}
-		} else if progress == "completed-stateroot" {
-			result, err = r.launchPrecaching(ctx, imageListFile, progressfile, ibu)
-			if err != nil {
-				r.Log.Error(err, "Failed to launch get-seed-image phase")
-				return
+		}()
+		result = requeueWithShortInterval()
+	case r.PrepTask.Active:
+		select {
+		case <-r.PrepTask.done:
+			if r.PrepTask.Success {
+				// Fetch final precaching job report summary
+				conditionMessage := "Prep completed"
+				status, err := r.Precache.QueryJobStatus(ctx)
+				if err == nil && status != nil && status.Message != "" {
+					conditionMessage += fmt.Sprintf(": %s", status.Message)
+				}
+				utils.SetPrepSucceededStatus(ibu, conditionMessage)
+			} else {
+				utils.SetPrepFailedStatus(ibu)
 			}
-		} else if progress == "precaching-in-progress" {
-			result, err = r.queryPrecachingStatus(ctx, progressfile)
-			if err != nil {
-				r.Log.Error(err, "Failed to query get-seed-image phase")
-				return
-			}
-		} else if progress == "completed-precache" {
-			// Fetch final precaching job report summary
-			conditionMessage := "Prep completed"
-			status, err := r.Precache.QueryJobStatus(ctx)
-			if err == nil && status != nil && status.Message != "" {
-				conditionMessage += fmt.Sprintf(": %s", status.Message)
-			}
-
-			// If completed, update conditions and return doNotRequeue
-			utils.SetStatusCondition(&ibu.Status.Conditions,
-				utils.GetCompletedConditionType(lcav1alpha1.Stages.Prep),
-				utils.ConditionReasons.Completed,
-				metav1.ConditionTrue,
-				conditionMessage,
-				ibu.Generation)
-			utils.SetStatusCondition(&ibu.Status.Conditions,
-				utils.GetInProgressConditionType(lcav1alpha1.Stages.Prep),
-				utils.ConditionReasons.Completed,
-				metav1.ConditionFalse,
-				"Prep completed",
-				ibu.Generation)
-		} else {
+			// Reset Task values
+			r.PrepTask.Reset()
+			result = doNotRequeue()
+		default:
 			result = requeueWithShortInterval()
-		}
-	} else if os.IsNotExist(err) {
-		result, err = r.launchGetSeedImage(ctx, ibu, imageListFile, progressfile)
-		if err != nil {
-			r.Log.Error(err, "Failed to launch get-seed-image phase")
-			return
 		}
 	}
 

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -283,29 +283,39 @@ func SetUpgradeStatusCompleted(ibu *lcav1alpha1.ImageBasedUpgrade) {
 		ibu.Generation)
 }
 
-// SetPrepFailedStatus updates the IBU CR status for a failure to complete the Prep stage
-func SetPrepFailedStatus(ibu *lcav1alpha1.ImageBasedUpgrade) {
-	SetStatusCondition(&ibu.Status.Conditions,
-		GetCompletedConditionType(lcav1alpha1.Stages.Prep),
-		ConditionReasons.Completed,
-		metav1.ConditionFalse,
-		"Prep failed",
-		ibu.Generation)
+// SetPrepStatusInProgress updates the prep status to in progress with message
+func SetPrepStatusInProgress(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
 	SetStatusCondition(&ibu.Status.Conditions,
 		GetInProgressConditionType(lcav1alpha1.Stages.Prep),
-		ConditionReasons.Completed,
+		ConditionReasons.InProgress,
+		metav1.ConditionTrue,
+		msg,
+		ibu.Generation)
+}
+
+// SetPrepStatusFailed updates the prep status to failed with message
+func SetPrepStatusFailed(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Prep),
+		ConditionReasons.Failed,
+		metav1.ConditionFalse,
+		msg,
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetCompletedConditionType(lcav1alpha1.Stages.Prep),
+		ConditionReasons.Failed,
 		metav1.ConditionFalse,
 		"Prep failed",
 		ibu.Generation)
 }
 
-// SetPrepSucceededStatus updates the IBU CR status for a successful execution of the Prep stage
-func SetPrepSucceededStatus(ibu *lcav1alpha1.ImageBasedUpgrade, conditionMessage string) {
+// SetPrepStatusCompleted updates the prep status to completed
+func SetPrepStatusCompleted(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
 	SetStatusCondition(&ibu.Status.Conditions,
 		GetCompletedConditionType(lcav1alpha1.Stages.Prep),
 		ConditionReasons.Completed,
 		metav1.ConditionTrue,
-		conditionMessage,
+		msg,
 		ibu.Generation)
 	SetStatusCondition(&ibu.Status.Conditions,
 		GetInProgressConditionType(lcav1alpha1.Stages.Prep),

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -282,3 +282,35 @@ func SetUpgradeStatusCompleted(ibu *lcav1alpha1.ImageBasedUpgrade) {
 		"Upgrade completed",
 		ibu.Generation)
 }
+
+// SetPrepFailedStatus updates the IBU CR status for a failure to complete the Prep stage
+func SetPrepFailedStatus(ibu *lcav1alpha1.ImageBasedUpgrade) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetCompletedConditionType(lcav1alpha1.Stages.Prep),
+		ConditionReasons.Completed,
+		metav1.ConditionFalse,
+		"Prep failed",
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Prep),
+		ConditionReasons.Completed,
+		metav1.ConditionFalse,
+		"Prep failed",
+		ibu.Generation)
+}
+
+// SetPrepSucceededStatus updates the IBU CR status for a successful execution of the Prep stage
+func SetPrepSucceededStatus(ibu *lcav1alpha1.ImageBasedUpgrade, conditionMessage string) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetCompletedConditionType(lcav1alpha1.Stages.Prep),
+		ConditionReasons.Completed,
+		metav1.ConditionTrue,
+		conditionMessage,
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Prep),
+		ConditionReasons.Completed,
+		metav1.ConditionFalse,
+		"Prep completed",
+		ibu.Generation)
+}

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -5,11 +5,7 @@ import (
 )
 
 const (
-	IBUWorkspacePath   string = "/var/ibu"
-	PrepGetSeedImage   string = "prepGetSeedImage.sh"
-	PrepSetupStateroot string = "prepSetupStateroot.sh"
-	PrepCleanup        string = "prepCleanup.sh"
-
+	IBUWorkspacePath string = "/var/ibu"
 	// IBUName defines the valid name of the CR for the controller to reconcile
 	IBUName     string = "upgrade"
 	IBUFilePath string = "/opt/ibu.json"

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/vmware-tanzu/velero v1.12.0
 	go.etcd.io/etcd/client/v3 v3.5.10
 	go.uber.org/mock v0.3.0
+	golang.org/x/sync v0.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.2
 	k8s.io/apiextensions-apiserver v0.28.2
@@ -76,7 +77,6 @@ require (
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
-	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/internal/precache/constants.go
+++ b/internal/precache/constants.go
@@ -17,6 +17,8 @@
 package precache
 
 import (
+	"fmt"
+
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -87,3 +89,12 @@ const (
 	DefaultIoNiceClass            = IoNiceClassBestEffort
 	DefaultIoNicePriority     int = 4
 )
+
+// Precache status
+const (
+	Active    string = "Active"
+	Failed    string = "Failed"
+	Succeeded string = "Succeeded"
+)
+
+var ErrFailed = fmt.Errorf("precaching failed")

--- a/internal/precache/precache.go
+++ b/internal/precache/precache.go
@@ -153,13 +153,13 @@ func (h *PHandler) QueryJobStatus(ctx context.Context) (*Status, error) {
 	status := &Status{Message: ""}
 	// Extract job status: active, successful, failed
 	if job.Status.Active > 0 {
-		status.Status = "Active"
+		status.Status = Active
 		h.Log.Info("Precaching job in-progress", "name:", LcaPrecacheJobName)
 	} else if job.Status.Succeeded > 0 {
-		status.Status = "Succeeded"
+		status.Status = Succeeded
 		h.Log.Info("Precaching job succeeded", "name:", LcaPrecacheJobName)
 	} else if job.Status.Failed > 0 {
-		status.Status = "Failed"
+		status.Status = Failed
 		h.Log.Info("Precaching job failed", "name:", LcaPrecacheJobName)
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -164,6 +164,7 @@ func main() {
 		ManifestClient:  clusterinfo.NewClusterInfoClient(mgr.GetClient()),
 		OstreeClient:    ostreeClient,
 		Ops:             op,
+		PrepTask:        &controllers.Task{Active: false, Success: false, Cancel: nil},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageBasedUpgrade")
 		os.Exit(1)

--- a/main/main.go
+++ b/main/main.go
@@ -164,7 +164,7 @@ func main() {
 		ManifestClient:  clusterinfo.NewClusterInfoClient(mgr.GetClient()),
 		OstreeClient:    ostreeClient,
 		Ops:             op,
-		PrepTask:        &controllers.Task{Active: false, Success: false, Cancel: nil},
+		PrepTask:        &controllers.Task{Active: false, Success: false, Cancel: nil, Progress: ""},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageBasedUpgrade")
 		os.Exit(1)


### PR DESCRIPTION
The progress file used to track and facilitate the various sub-stages of the prep-stage is removed. A new prep-stage worker goroutine is used instead.

Support is added to abort the prep-stage during any of the intermediate sub-steps (i.e. pulling the seed image, setting up the stateroot, precaching images).

/cc @jc-rh @browsell @sudomakeinstall2 