### PR TITLE
Fix condition for mounting config ISO

### DIFF
--- a/ibu-imager/installation_configuration_files/scripts/prepare-installation-configuration.sh
+++ b/ibu-imager/installation_configuration_files/scripts/prepare-installation-configuration.sh
@@ -37,7 +37,7 @@ while [[ ! $(lsblk -f --json | jq -r '.blockdevices[] | select(.label == "reloca
 done
 
 DEVICE=$(lsblk -f --json | jq -r '.blockdevices[] | select(.label == "relocation-config") | .name')
-if [[ -n "${DEVICE}" && ! -d "${OPT_OPENSHIFT}" ]]; then
+if [[ -n "${DEVICE}" && ! -d "${CONFIG_PATH}" ]]; then
     mount_config "${DEVICE}"
     cp -r /mnt/config/* ${OPT_OPENSHIFT}
 fi


### PR DESCRIPTION
Previously this was checking for the existence of /opt/openshift which would always be present at this point as it was created earlier in the script. Instead this should check for the presence of the configuration directory which will only be present if we don't need to copy data from the ISO.

Relates to https://issues.redhat.com/browse/MGMT-16394

cc @tsorya 