### PR TITLE
Some changes to backup&restore plugin

### DIFF
--- a/docs/backuprestore-with-oadp.md
+++ b/docs/backuprestore-with-oadp.md
@@ -275,10 +275,13 @@ metadata:
     velero.io/storage-location: default
   namespace: openshift-adp
 spec:
+  includedNamespaces:
+  - open-cluster-management-agent
   includedClusterScopedResources:
   - klusterlets.operator.open-cluster-management.io
   - clusterclaims.cluster.open-cluster-management.io
-  ...
+  - clusterroles
+  - clusterrolebindings
 ```
 backup_localvolume.yaml
 ```yaml
@@ -427,9 +430,11 @@ spec:
 ```
 
 ### Note:
-1. The ZTP GitOps method described above can be used to install OADP on the seed cluster as well. However, please note that you should not apply the DPA (Data Protection Application) and S3 secret on the seed cluster. These will be handled by the LCA during the upgrade process.
+The ZTP GitOps method described above can be used to install OADP on the seed cluster as well. However, please note that you should not apply the DPA (Data Protection Application) and S3 secret on the seed cluster. These will be handled by the LCA during the upgrade process.
 
-2. If you prefer to install and configure OADP manually, you can copy all the neccessary CRs provided above and use them as a reference. Make sure to adjust the configuration according to your specific requirements.
+## Manually install OADP and configure OADP on target cluster
+
+If you prefer to install and configure OADP manually, you can copy all the neccessary CRs provided in the section **Install OADP and configure OADP on target cluster via ZTP GitOps**, remove the `ran.openshift.io/ztp-deploy-wave` annotation from CRs and use them as a reference. Remove Make sure to adjust the configuration according to your specific requirements.
 
 ## Update the IBU CR with OADP configmap
 To enable backup and restore during the upgrade stage, you should update the IBU CR with the generated OADP configmap specified in the `spec.oadpContent` field.

--- a/internal/backuprestore/backup_test.go
+++ b/internal/backuprestore/backup_test.go
@@ -413,6 +413,15 @@ func TestExportOadpConfigurationToDir(t *testing.T) {
 					},
 				},
 			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Reconciled",
+						"status": "True",
+						"reason": "Complete",
+					},
+				},
+			},
 		},
 	}
 	err = c.Create(context.Background(), dpa)

--- a/internal/extramanifest/extramanifest.go
+++ b/internal/extramanifest/extramanifest.go
@@ -115,12 +115,12 @@ func (h *EMHandler) ApplyExtraManifests(ctx context.Context, fromDir string) err
 	manifestYamls, err := os.ReadDir(fromDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			h.Log.Info("No extra manifests directory found, skipping", "path", fromDir)
 			return nil
 		}
 		return err
 	}
 
+	h.Log.Info("Applying extra manifests")
 	if len(manifestYamls) == 0 {
 		h.Log.Info("No extra manifests found", "path", fromDir)
 		return nil

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,11 +22,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/clientcmd"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 // MarshalToFile marshals anything and writes it to the given file path
 func MarshalToFile(data any, filePath string) error {
 	marshaled, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, marshaled, 0o644)
+}
+
+// MarshalToYamlFile marshals any object to YAML and writes it to the given file path
+func MarshalToYamlFile(data any, filePath string) error {
+	marshaled, err := k8syaml.Marshal(data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Fail the upgrade if more than one DPA found
-  Wait until DPA is reconciled before checking storage backend and do not exit the storage check immediately if no storages found
- Use utils function to read/write resource from/to file
- Use hostPath from common
- Re-organize some logs