### PR TITLE
Also update conditions' `ObservedGeneration`

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -374,6 +374,13 @@ func validateStageTransition(ibu *lcav1alpha1.ImageBasedUpgrade, isAfterPivot bo
 
 func (r *ImageBasedUpgradeReconciler) updateStatus(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) error {
 	ibu.Status.ObservedGeneration = ibu.ObjectMeta.Generation
+
+	// TODO: Does a blanket update of all conditions even make sense, or should
+	// we be more selective?
+	for i := range ibu.Status.Conditions {
+		ibu.Status.Conditions[i].ObservedGeneration = ibu.ObjectMeta.Generation
+	}
+
 	err := common.RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
 		return r.Status().Update(ctx, ibu)
 	})


### PR DESCRIPTION
~There's an `ObservedGeneration` field on every condition within the
status, not just on the status itself.~

~LCA should make sure this field is kept up to date on its conditions.~

~If we don't do that, commands like `oc wait --for=condition=somecondition=somevalue`
will wait forever, as [apparently](https://github.com/kubernetes/kubernetes/pull/122319) they ignore conditions which have a generation
older than the resource's own `.metadata.generation`~

~Also added TODO to reconsider this change, I'm not sure how much such
blanket update of all conditions actually makes sense.~

EDIT: Reviews are understandably against this patch, please consider this PR to be more of an issue/suggestion and feel free to come up with better solutions to this problem