### PR TITLE
summarize-ibu prep failure should display `PrepInProgress`

### DIFF
--- a/hack/summarize-ibu.sh
+++ b/hack/summarize-ibu.sh
@@ -45,9 +45,9 @@ elif [ "${PREP_COMPLETE}" == "True" ]; then
     echo "  Prep completed at: $(getCondition PrepCompleted lastTransitionTime)"
 elif [ "${PREP_COMPLETE}" == "False" ] && [ "${PREP_PROG}" == "False" ]; then
     echo "  Prep failed:"
-    echo "    Time:    $(getCondition PrepCompleted lastTransitionTime)"
-    echo "    Reason:  $(getCondition PrepCompleted reason)"
-    echo "    Message: $(getCondition PrepCompleted message)"
+    echo "    Time:    $(getCondition PrepInProgress lastTransitionTime)"
+    echo "    Reason:  $(getCondition PrepInProgress reason)"
+    echo "    Message: $(getCondition PrepInProgress message)"
 elif [ "${PREP_PROG}" == "True" ]; then
     echo "  Prep in progress at: $(getCondition PrepInProgress lastTransitionTime)"
 elif [ "${IDLE}" == "True" ]; then


### PR DESCRIPTION
`PrepCompleted` is irrelevant in the case of prep failure

Before:

```
Image:   quay.io/otuchfel/ostbackup:seed
Version: 4.13.5
Stage:   Prep
Status:
  Prep failed:
    Time:    2023-12-18T14:35:26Z
    Reason:  Failed
    Message: Prep failed
```

After:

```
Image:   quay.io/otuchfel/ostbackup:seed
Version: 4.13.5
Stage:   Prep
Status:
  Prep failed:
    Time:    2023-12-18T14:35:26Z
    Reason:  Failed
    Message: Prep failed due to failed to extract ostree.tgz:
gzip: stdin: invalid compressed data--format violated
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
: exit status 2
```