### PR TITLE
Cosmetic: Change prep failure message

### DIFF
--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -406,7 +406,7 @@ func (r *ImageBasedUpgradeReconciler) prepStageWorker(ctx context.Context, ibu *
 
 	if err := errGroup.Wait(); err != nil {
 		r.Log.Info("Encountered error while running prep-stage worker goroutine", "error", err)
-		r.PrepTask.Progress = fmt.Sprintf("Prep failed due to %v", err)
+		r.PrepTask.Progress = fmt.Sprintf("Prep failed with error: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
Flowing directly into the error string without a colon is confusing,
especially if the error message itself starts with something like
"failed to..." then it reads "Prep failed due to failed to..."