### PR TITLE
Seed image format version OCI image label

### DIFF
--- a/ibu-imager/seedcreator/seedcreator.go
+++ b/ibu-imager/seedcreator/seedcreator.go
@@ -414,8 +414,15 @@ func (s *SeedCreator) createAndPushSeedImage() error {
 	_ = tmpfile.Close() // Close the temporary file
 
 	// Build the single OCI image (note: We could include --squash-all option, as well)
+	podmanBuildArgs := []string{
+		"build",
+		"--file", tmpfile.Name(),
+		"--tag", s.containerRegistry,
+		"--label", fmt.Sprintf("%s=%d", common.SeedFormatOCILabel, common.SeedFormatVersion),
+		s.backupDir,
+	}
 	_, err = s.ops.RunInHostNamespace(
-		"podman", []string{"build", "-f", tmpfile.Name(), "-t", s.containerRegistry, s.backupDir}...)
+		"podman", podmanBuildArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to build seed image: %w", err)
 	}

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -57,6 +57,10 @@ const (
 	InstallConfigCM = "cluster-config-v1"
 	// InstallConfigCMNamespace cm namespace
 	InstallConfigCMNamespace = "kube-system"
+
+	// Bump this every time the seed format changes in a backwards incompatible way
+	SeedFormatVersion  = 1
+	SeedFormatOCILabel = "com.openshift.lifecycle-agent.seed_format_version"
 )
 
 // CertPrefixes is the list of certificate prefixes to be backed up


### PR DESCRIPTION
IBU reconciler now has a `checkSeedImageCompatibility` method that
checks if the seed image is compatible with the current version of the
lifecycle-agent. It does so by inspecting the OCI image's labels and
checking if the specified format version equals the hard-coded one that
this version of the lifecycle agent expects. That format version is set
by the imager during the image build process, and is only manually
bumped by developers when the image format changes in a way that is
incompatible with previous versions of the lifecycle-agent.