### PR TITLE
Add support for rollback and ostree admin set-default

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
@@ -417,5 +418,5 @@ func (r *ImageBasedUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func getDesiredStaterootName(ibu *lcav1alpha1.ImageBasedUpgrade) string {
-	return fmt.Sprintf("rhcos_%s", ibu.Spec.SeedImageRef.Version)
+	return fmt.Sprintf("rhcos_%s", strings.ReplaceAll(ibu.Spec.SeedImageRef.Version, "-", "_"))
 }

--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -241,6 +241,10 @@ func (r *ImageBasedUpgradeReconciler) handleAbortOrFinalize(ctx context.Context,
 
 func isRollbackAllowed(ibu *lcav1alpha1.ImageBasedUpgrade, isAfterPivot bool) bool {
 	if !isAfterPivot {
+		rollbackInProgressCondition := meta.FindStatusCondition(ibu.Status.Conditions, string(utils.ConditionTypes.RollbackInProgress))
+		if rollbackInProgressCondition != nil && rollbackInProgressCondition.Status == metav1.ConditionTrue {
+			return true
+		}
 		return false
 	}
 	upgradeInProgressCondition := meta.FindStatusCondition(ibu.Status.Conditions, string(utils.ConditionTypes.UpgradeInProgress))

--- a/controllers/rollback_handlers.go
+++ b/controllers/rollback_handlers.go
@@ -18,18 +18,90 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	"github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
+	lcautils "github.com/openshift-kni/lifecycle-agent/utils"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	lcav1alpha1 "github.com/openshift-kni/lifecycle-agent/api/v1alpha1"
-	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 //nolint:unparam
-func (r *ImageBasedUpgradeReconciler) handleRollback(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
+func (r *ImageBasedUpgradeReconciler) startRollback(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
+	utils.SetRollbackStatusInProgress(ibu, "Initiating rollback")
 
-	// TODO actual steps
-	// If completed, update conditions and return doNotRequeue
+	stateroot, err := r.RPMOstreeClient.GetUnbootedStaterootName()
+	if err != nil {
+		utils.SetRollbackStatusFailed(ibu, err.Error())
+		return requeueWithError(err)
+	}
+
+	if _, err := r.Executor.Execute("mount", "/sysroot", "-o", "remount,rw"); err != nil {
+		return requeueWithError(err)
+	}
+
+	stateRootRepo := common.PathOutsideChroot(ostreeclient.StaterootPath(stateroot))
+
+	// Save the CR for post-reboot restore, stripping Upgrade conditions and ResourceVersion from IBU CR before saving
+	r.Log.Info("Save the IBU CR to the old state root before pivot")
+	filePath := filepath.Join(stateRootRepo, utils.IBUFilePath)
+	// Temporarily empty resource version so the file can be used to restore status
+	rv := ibu.ResourceVersion
+	ibu.ResourceVersion = ""
+	if err := lcautils.MarshalToFile(ibu, filePath); err != nil {
+		return requeueWithError(err)
+	}
+	ibu.ResourceVersion = rv
+
+	r.Log.Info("Finding unbooted deployment")
+	deploymentIndex, err := r.RPMOstreeClient.GetUnbootedDeploymentIndex()
+	if err != nil {
+		utils.SetRollbackStatusFailed(ibu, err.Error())
+		return requeueWithError(fmt.Errorf("failed to get unbooted deployment index: %w", err))
+	}
+
+	// Set the new default deployment
+	r.Log.Info("Checking for set-default feature")
+
+	if r.OstreeClient.IsOstreeAdminSetDefaultFeatureEnabled() {
+		r.Log.Info("set-default feature available")
+
+		if err = r.OstreeClient.SetDefaultDeployment(deploymentIndex); err != nil {
+			utils.SetRollbackStatusFailed(ibu, err.Error())
+			return requeueWithError(fmt.Errorf("failed to set default deployment for pivot: %w", err))
+		}
+	} else {
+		r.Log.Info("set-default feature not available")
+
+		// Check to make sure the default deployment is set
+		if deploymentIndex != 0 {
+			msg := "default deployment must be manually set for next boot"
+			utils.SetRollbackStatusFailed(ibu, msg)
+			return requeueWithError(fmt.Errorf(msg))
+		}
+	}
+
+	// Write an event to indicate reboot attempt
+	r.Recorder.Event(ibu, corev1.EventTypeNormal, "Reboot", "System will now reboot")
+	err = r.rebootToNewStateRoot()
+	if err != nil {
+		//todo: abort handler? e.g delete desired stateroot
+		r.Log.Error(err, "")
+		utils.SetUpgradeStatusFailed(ibu, err.Error())
+		return doNotRequeue(), nil
+	}
+
+	return doNotRequeue(), nil
+}
+
+//nolint:unparam
+func (r *ImageBasedUpgradeReconciler) finishRollback(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
 	utils.SetStatusCondition(&ibu.Status.Conditions,
 		utils.GetCompletedConditionType(lcav1alpha1.Stages.Rollback),
 		utils.ConditionReasons.Completed,
@@ -42,5 +114,24 @@ func (r *ImageBasedUpgradeReconciler) handleRollback(ctx context.Context, ibu *l
 		metav1.ConditionFalse,
 		"Rollback completed",
 		ibu.Generation)
+
 	return doNotRequeue(), nil
+}
+
+//nolint:unparam
+func (r *ImageBasedUpgradeReconciler) handleRollback(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (ctrl.Result, error) {
+	origStaterootBooted, err := isOrigStaterootBooted(r, ibu)
+	if err != nil {
+		//todo: abort handler? e.g delete desired stateroot
+		utils.SetRollbackStatusFailed(ibu, err.Error())
+		return doNotRequeue(), nil
+	}
+
+	if origStaterootBooted {
+		r.Log.Info("Pivot for rollback successful, starting post pivot steps")
+		return r.finishRollback(ctx, ibu)
+	} else {
+		r.Log.Info("Starting pre pivot for rollback steps and will pivot to previous stateroot with a reboot")
+		return r.startRollback(ctx, ibu)
+	}
 }

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -106,6 +106,10 @@ func SetStatusCondition(existingConditions *[]metav1.Condition, conditionType Co
 	)
 }
 
+func ClearStatusCondition(existingConditions *[]metav1.Condition, conditionType ConditionType) {
+	meta.RemoveStatusCondition(existingConditions, string(conditionType))
+}
+
 // ResetStatusConditions remove all other conditions and sets idle to true
 func ResetStatusConditions(existingConditions *[]metav1.Condition, generation int64) {
 	for _, condition := range *existingConditions {
@@ -322,5 +326,47 @@ func SetPrepStatusCompleted(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
 		ConditionReasons.Completed,
 		metav1.ConditionFalse,
 		"Prep completed",
+		ibu.Generation)
+}
+
+// SetRollbackStatusFailed updates the Rollback status to failed with message
+func SetRollbackStatusFailed(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Rollback),
+		ConditionReasons.Failed,
+		metav1.ConditionFalse,
+		msg,
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetCompletedConditionType(lcav1alpha1.Stages.Rollback),
+		ConditionReasons.Failed,
+		metav1.ConditionFalse,
+		"Rollback failed",
+		ibu.Generation)
+}
+
+// SetRollbackStatusInProgress updates the Rollback status to in progress with message
+func SetRollbackStatusInProgress(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Rollback),
+		ConditionReasons.InProgress,
+		metav1.ConditionTrue,
+		msg,
+		ibu.Generation)
+}
+
+// SetUpgradeStatusCompleted updates the Rollback status to completed
+func SetRollbackStatusCompleted(ibu *lcav1alpha1.ImageBasedUpgrade) {
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetCompletedConditionType(lcav1alpha1.Stages.Rollback),
+		ConditionReasons.Completed,
+		metav1.ConditionTrue,
+		"Rollback completed",
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Rollback),
+		ConditionReasons.Completed,
+		metav1.ConditionFalse,
+		"Rollback completed",
 		ibu.Generation)
 }

--- a/hack/summarize-ibu.sh
+++ b/hack/summarize-ibu.sh
@@ -26,19 +26,30 @@ PREP_PROG=$(getCondition PrepInProgress status)
 PREP_COMPLETE=$(getCondition PrepCompleted status)
 UPG_PROG=$(getCondition UpgradeInProgress status)
 UPG_COMPLETE=$(getCondition UpgradeCompleted status)
+ROLLBACK_PROG=$(getCondition RollbackInProgress status)
+ROLLBACK_COMPLETE=$(getCondition RollbackCompleted status)
 
 echo "Image:   ${SEED}"
 echo "Version: ${VER}"
 echo "Stage:   ${STAGE}"
 echo "Status:"
 
-if [ "${UPG_COMPLETE}" == "True" ]; then
+if [ "${ROLLBACK_COMPLETE}" == "True" ]; then
+    echo "  Rollback completed at: $(getCondition RollbackCompleted lastTransitionTime)"
+elif [ "${ROLLBACK_COMPLETE}" == "False" ] && [ "${ROLLBACK_PROG}" == "False" ]; then
+    echo "  Rollback failed:"
+    echo "    Time:    $(getCondition RollbackInProgress lastTransitionTime)"
+    echo "    Reason:  $(getCondition RollbackInProgress reason)"
+    echo "    Message: $(getCondition RollbackInProgress message)"
+elif [ "${ROLLBACK_PROG}" == "True" ]; then
+    echo "  Rollback in progress at: $(getCondition RollbackInProgress lastTransitionTime)"
+elif [ "${UPG_COMPLETE}" == "True" ]; then
     echo "  Upgrade completed at: $(getCondition UpgradeCompleted lastTransitionTime)"
 elif [ "${UPG_COMPLETE}" == "False" ] && [ "${UPG_PROG}" == "False" ]; then
     echo "  Upgrade failed:"
-    echo "    Time:    $(getCondition UpgradeCompleted lastTransitionTime)"
-    echo "    Reason:  $(getCondition UpgradeCompleted reason)"
-    echo "    Message: $(getCondition UpgradeCompleted message)"
+    echo "    Time:    $(getCondition UpgradeInProgress lastTransitionTime)"
+    echo "    Reason:  $(getCondition UpgradeInProgress reason)"
+    echo "    Message: $(getCondition UpgradeInProgress message)"
 elif [ "${UPG_PROG}" == "True" ]; then
     echo "  Upgrade in progress at: $(getCondition UpgradeInProgress lastTransitionTime)"
 elif [ "${PREP_COMPLETE}" == "True" ]; then

--- a/ibu-imager/ostreeclient/mock_rpmostreeclient.go
+++ b/ibu-imager/ostreeclient/mock_rpmostreeclient.go
@@ -67,6 +67,51 @@ func (mr *MockIClientMockRecorder) GetDeploymentID(osname any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentID", reflect.TypeOf((*MockIClient)(nil).GetDeploymentID), osname)
 }
 
+// GetDeploymentIndex mocks base method.
+func (m *MockIClient) GetDeploymentIndex(osname string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeploymentIndex", osname)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeploymentIndex indicates an expected call of GetDeploymentIndex.
+func (mr *MockIClientMockRecorder) GetDeploymentIndex(osname any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentIndex", reflect.TypeOf((*MockIClient)(nil).GetDeploymentIndex), osname)
+}
+
+// GetUnbootedDeploymentIndex mocks base method.
+func (m *MockIClient) GetUnbootedDeploymentIndex() (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnbootedDeploymentIndex")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnbootedDeploymentIndex indicates an expected call of GetUnbootedDeploymentIndex.
+func (mr *MockIClientMockRecorder) GetUnbootedDeploymentIndex() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnbootedDeploymentIndex", reflect.TypeOf((*MockIClient)(nil).GetUnbootedDeploymentIndex))
+}
+
+// GetUnbootedStaterootName mocks base method.
+func (m *MockIClient) GetUnbootedStaterootName() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnbootedStaterootName")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnbootedStaterootName indicates an expected call of GetUnbootedStaterootName.
+func (mr *MockIClientMockRecorder) GetUnbootedStaterootName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnbootedStaterootName", reflect.TypeOf((*MockIClient)(nil).GetUnbootedStaterootName))
+}
+
 // IsStaterootBooted mocks base method.
 func (m *MockIClient) IsStaterootBooted(stateroot string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/ostreeclient/mock_ostreeclient.go
+++ b/internal/ostreeclient/mock_ostreeclient.go
@@ -51,6 +51,20 @@ func (mr *MockIClientMockRecorder) Deploy(osname, refsepc, kargs any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockIClient)(nil).Deploy), osname, refsepc, kargs)
 }
 
+// IsOstreeAdminSetDefaultFeatureEnabled mocks base method.
+func (m *MockIClient) IsOstreeAdminSetDefaultFeatureEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOstreeAdminSetDefaultFeatureEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOstreeAdminSetDefaultFeatureEnabled indicates an expected call of IsOstreeAdminSetDefaultFeatureEnabled.
+func (mr *MockIClientMockRecorder) IsOstreeAdminSetDefaultFeatureEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOstreeAdminSetDefaultFeatureEnabled", reflect.TypeOf((*MockIClient)(nil).IsOstreeAdminSetDefaultFeatureEnabled))
+}
+
 // OSInit mocks base method.
 func (m *MockIClient) OSInit(osname string) error {
 	m.ctrl.T.Helper()
@@ -77,6 +91,20 @@ func (m *MockIClient) PullLocal(repoPath string) error {
 func (mr *MockIClientMockRecorder) PullLocal(repoPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullLocal", reflect.TypeOf((*MockIClient)(nil).PullLocal), repoPath)
+}
+
+// SetDefaultDeployment mocks base method.
+func (m *MockIClient) SetDefaultDeployment(index int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDefaultDeployment", index)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetDefaultDeployment indicates an expected call of SetDefaultDeployment.
+func (mr *MockIClientMockRecorder) SetDefaultDeployment(index any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultDeployment", reflect.TypeOf((*MockIClient)(nil).SetDefaultDeployment), index)
 }
 
 // Undeploy mocks base method.

--- a/internal/ostreeclient/ostreeclient.go
+++ b/internal/ostreeclient/ostreeclient.go
@@ -2,6 +2,7 @@ package ostreeclient
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
 )
@@ -12,6 +13,8 @@ type IClient interface {
 	OSInit(osname string) error
 	Deploy(osname, refsepc string, kargs []string) error
 	Undeploy(ostreeIndex int) error
+	SetDefaultDeployment(index int) error
+	IsOstreeAdminSetDefaultFeatureEnabled() bool
 }
 
 type Client struct {
@@ -38,6 +41,9 @@ func (c *Client) Deploy(osname, refsepc string, kargs []string) error {
 	args := []string{"admin", "deploy", "--os", osname}
 	args = append(args, kargs...)
 	args = append(args, refsepc)
+	if c.IsOstreeAdminSetDefaultFeatureEnabled() {
+		args = append(args, "--not-as-default")
+	}
 	_, err := c.executor.Execute("ostree", args...)
 	return err
 }
@@ -45,4 +51,26 @@ func (c *Client) Deploy(osname, refsepc string, kargs []string) error {
 func (c *Client) Undeploy(ostreeIndex int) error {
 	_, err := c.executor.Execute("ostree", "admin", "undeploy", fmt.Sprint(ostreeIndex))
 	return err
+}
+
+func (c *Client) IsOstreeAdminSetDefaultFeatureEnabled() bool {
+	// Quick check to see if the "ostree admin set-default" feature is available
+	args := []string{"admin --help | grep -q set-default"}
+	_, err := c.executor.Execute("ostree", args...)
+	return err == nil
+}
+
+func (c *Client) SetDefaultDeployment(index int) error {
+	if index == 0 {
+		// Already set as default deployment
+		return nil
+	}
+
+	args := []string{"admin", "set-default", strconv.Itoa(index)}
+	_, err := c.executor.Execute("ostree", args...)
+	return err
+}
+
+func StaterootPath(stateroot string) string {
+	return fmt.Sprintf("/ostree/deploy/%s/var", stateroot)
 }

--- a/internal/ostreeclient/ostreeclient.go
+++ b/internal/ostreeclient/ostreeclient.go
@@ -70,7 +70,3 @@ func (c *Client) SetDefaultDeployment(index int) error {
 	_, err := c.executor.Execute("ostree", args...)
 	return err
 }
-
-func StaterootPath(stateroot string) string {
-	return fmt.Sprintf("/ostree/deploy/%s/var", stateroot)
-}

--- a/main/main.go
+++ b/main/main.go
@@ -223,6 +223,9 @@ func initIBU(ctx context.Context, c client.Client, log *logr.Logger) error {
 		return err
 	}
 
+	// Strip the ResourceVersion, otherwise the restore fails
+	ibu.SetResourceVersion("")
+
 	log.Info("Saved IBU CR found, restoring ...")
 	if err := common.RetryOnConflictOrRetriable(retry.DefaultBackoff, func() error {
 		return client.IgnoreNotFound(c.Delete(ctx, ibu))
@@ -305,6 +308,9 @@ func initSeedGen(ctx context.Context, c client.Client, log *logr.Logger) error {
 		return err
 	}
 
+	// Strip the ResourceVersion, otherwise the restore fails
+	secret.SetResourceVersion("")
+
 	seedgen := &seedgenv1alpha1.SeedGenerator{}
 	if err := lcautils.ReadYamlOrJSONFile(seedgenFilePath, seedgen); err != nil {
 		if os.IsNotExist(err) {
@@ -312,6 +318,9 @@ func initSeedGen(ctx context.Context, c client.Client, log *logr.Logger) error {
 		}
 		return err
 	}
+
+	// Strip the ResourceVersion, otherwise the restore fails
+	seedgen.SetResourceVersion("")
 
 	// Restore Secret CR
 	log.Info("Saved SeedGenerator Secret CR found, restoring ...")


### PR DESCRIPTION
Added use of "ostree admin set-default" feature, if enabled, to manage setting the desired next-boot deployment.

This feature also allows for the introduction of rollback support.