### PR TITLE
Update reboot command to avoid hanging

### DIFF
--- a/controllers/rollback_handlers.go
+++ b/controllers/rollback_handlers.go
@@ -84,8 +84,8 @@ func (r *ImageBasedUpgradeReconciler) startRollback(ctx context.Context, ibu *lc
 	}
 
 	// Write an event to indicate reboot attempt
-	r.Recorder.Event(ibu, corev1.EventTypeNormal, "Reboot", "System will now reboot")
-	err = r.rebootToNewStateRoot()
+	r.Recorder.Event(ibu, corev1.EventTypeNormal, "Reboot", "System will now reboot for rollback")
+	err = r.rebootToNewStateRoot("rollback")
 	if err != nil {
 		//todo: abort handler? e.g delete desired stateroot
 		r.Log.Error(err, "")


### PR DESCRIPTION
Updated reboot command to use systemd-run to launch the reboot as a transitory service-unit job, rather than directly running the reboot command. This allows for the LCA pod to cleanly shut down on receiving the SIGTERM, rather than hanging on the running reboot command.