### PR TITLE
Mirror registry : Adding verification if we should override mirror registry or not

### DIFF
--- a/ibu-imager/clusterinfo/clusterinfo.go
+++ b/ibu-imager/clusterinfo/clusterinfo.go
@@ -13,6 +13,7 @@ type ClusterInfo struct {
 	MasterIP        string `json:"master_ip,omitempty"`
 	ReleaseRegistry string `json:"release_registry,omitempty"`
 	Hostname        string `json:"hostname,omitempty"`
+	MirrorRegistry  bool   `json:"mirror_registry,omitempty"`
 }
 
 type installConfigMetadata struct {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -195,12 +195,10 @@ func CopyFileIfExists(source, dest string) error {
 }
 
 func ReplaceImageRegistry(image, targetRegistry, sourceRegistry string) (string, error) {
-	if sourceRegistry == "" || targetRegistry == "" {
+	if sourceRegistry == "" || targetRegistry == "" || targetRegistry == sourceRegistry {
 		return image, nil
 	}
-	if targetRegistry == sourceRegistry {
-		return image, nil
-	}
+
 	re, err := regexp.Compile(fmt.Sprintf("^%s", sourceRegistry))
 	if err != nil {
 		return "", fmt.Errorf("failed to create regex for registry replacement, err: %w", err)


### PR DESCRIPTION

1. If seed has mirror registry and cluster not, try to override
2. If cluster has mirror registry and seed not verify if seeds registry is part of sources in icsps and idms and if it is don't override
3. If cluster has mirror registry and seed regsitry is not part of sources try to override seeds registry