### PR TITLE
precaching: Always pull tagged images

### DIFF
--- a/internal/precache/workload/pullImages.go
+++ b/internal/precache/workload/pullImages.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/openshift-kni/lifecycle-agent/internal/precache"
@@ -149,7 +150,9 @@ func PullImages(precacheSpec []string) (progress *precache.Progress, err error) 
 	log.Infof("Checking the pre-cache spec file images to determine if they need to be pulled...")
 	var skip bool
 	for _, image := range precacheSpec {
-		skip = podmanImgExists(image)
+		// Never skip tagged images, as the tagged image may have been updated
+		isUntagged := strings.Contains(image, "@sha")
+		skip = isUntagged && podmanImgExists(image)
 		if !skip {
 			pullSpec = append(pullSpec, image)
 		} else {


### PR DESCRIPTION
The precache handler checks images to see whether they already exist in container-storage prior to pulling. In the case of tagged images, however, this means the image could be stale, as the tag may have been updated in the registry.

This update modifies the precache handler to never skip pulling tagged images. If the tag has not been updated, the layers should not get downloaded, only the manifest, so the pull should be quick.