### PR TITLE
Handle IBU with no rhcos delta

### DIFF
--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -250,6 +250,10 @@ func (r *ImageBasedUpgradeReconciler) SetupStateroot(ctx context.Context, ibu *l
 		return fmt.Errorf("failed ostree admin deploy: %w", err)
 	}
 
+	if err = r.RPMOstreeClient.RpmOstreeCleanup(); err != nil {
+		return fmt.Errorf("failed rpm-ostree cleanup -b: %w", err)
+	}
+
 	deploymentID, err := r.RPMOstreeClient.GetDeploymentID(osname)
 	if err != nil {
 		return fmt.Errorf("failed to get deploymentID: %w", err)

--- a/ibu-imager/ostreeclient/mock_rpmostreeclient.go
+++ b/ibu-imager/ostreeclient/mock_rpmostreeclient.go
@@ -142,6 +142,20 @@ func (mr *MockIClientMockRecorder) QueryStatus() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryStatus", reflect.TypeOf((*MockIClient)(nil).QueryStatus))
 }
 
+// RpmOstreeCleanup mocks base method.
+func (m *MockIClient) RpmOstreeCleanup() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RpmOstreeCleanup")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RpmOstreeCleanup indicates an expected call of RpmOstreeCleanup.
+func (mr *MockIClientMockRecorder) RpmOstreeCleanup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RpmOstreeCleanup", reflect.TypeOf((*MockIClient)(nil).RpmOstreeCleanup))
+}
+
 // RpmOstreeVersion mocks base method.
 func (m *MockIClient) RpmOstreeVersion() (*VersionData, error) {
 	m.ctrl.T.Helper()
@@ -158,7 +172,7 @@ func (mr *MockIClientMockRecorder) RpmOstreeVersion() *gomock.Call {
 }
 
 // newCmd mocks base method.
-func (m *MockIClient) newCmd(args ...string) []byte {
+func (m *MockIClient) newCmd(args ...string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{}
 	for _, a := range args {
@@ -166,7 +180,8 @@ func (m *MockIClient) newCmd(args ...string) []byte {
 	}
 	ret := m.ctrl.Call(m, "newCmd", varargs...)
 	ret0, _ := ret[0].([]byte)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // newCmd indicates an expected call of newCmd.

--- a/internal/ostreeclient/ostreeclient.go
+++ b/internal/ostreeclient/ostreeclient.go
@@ -38,7 +38,7 @@ func (c *Client) OSInit(osname string) error {
 }
 
 func (c *Client) Deploy(osname, refsepc string, kargs []string) error {
-	args := []string{"admin", "deploy", "--os", osname}
+	args := []string{"admin", "deploy", "--os", osname, "--no-prune"}
 	args = append(args, kargs...)
 	args = append(args, refsepc)
 	if c.IsOstreeAdminSetDefaultFeatureEnabled() {


### PR DESCRIPTION
In an IBU where both releases have the same underlying rhcos image, the parent commit of the deployment has unique commit IDs (due to import from seed), but the same checksum. When the new deployment is created, the original parent commit is getting pruned as a result.

In order to avoid this pruning, this update includes the following changes:
- Add the "--no-prune" option to the "ostree admin deploy" command
- Add a call to "rpm-ostree cleanup -b" to update the base refs