### PR TITLE
Cluster config API diff to trigger label

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -28,3 +28,6 @@ filters:
     - oourfali
     - romfreiman
     - tsorya
+  ^ibu-imager/clusterinfo/clusterinfo.go:
+    labels:
+      - cluster-config-api-changed


### PR DESCRIPTION
Any PR changing any cluster-configuration API related files will
automatically get a `cluster-config-api-changed` label.

The cluster configuration API is consumed by external projects (e.g. the
project currently named
[cluster-relocation-service](https://github.com/openshift/cluster-relocation-service))
so changes to this API should not be done casually, they have to be
explicitly thought out and ideally non-breaking.

This change along with a [corresponding PR in openshift/release](https://github.com/openshift/release/pull/47213) to gate
PRs that have this label (until removed as an act of acknowledgment)
using tide config will ensure that people developing, testing and
reviewing for the IBU use case also take the IBI use case (which
consumes the same API) into account

An alternative suggestion to this mechanism was to create a separate
repo just for this API, but the overhead of doing that was decided
against.