### PR TITLE
Improve Rollback and Seedgen status reporting and error handling

### DIFF
--- a/api/seedgenerator/v1alpha1/types.go
+++ b/api/seedgenerator/v1alpha1/types.go
@@ -25,6 +25,8 @@ import (
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path=seedgenerators,scope=Cluster,shortName=seedgen
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+//+kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].type"
+//+kubebuilder:printcolumn:name="Details",type="string",JSONPath=".status.conditions[-1:].message"
 
 // SeedGenerator is the Schema for the seedgenerators API
 // +operator-sdk:csv:customresourcedefinitions:displayName="Seed Generator",resources={{Namespace, v1}}
@@ -32,6 +34,7 @@ type SeedGenerator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="cannot modify spec, cr must be deleted and recreated"
 	Spec   SeedGeneratorSpec   `json:"spec,omitempty"`
 	Status SeedGeneratorStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -25,6 +25,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=imagebasedupgrades,scope=Cluster,shortName=ibu
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Stage",type="string",JSONPath=".spec.stage"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].type"
 // +kubebuilder:printcolumn:name="Details",type="string",JSONPath=".status.conditions[-1:].message"
 // +kubebuilder:validation:XValidation:message="can not change spec.seedImageRef while ibu is in progress", rule="!has(oldSelf.status) || oldSelf.status.conditions.exists(c, c.type=='Idle' && c.status=='True') || has(oldSelf.spec.seedImageRef) && has(self.spec.seedImageRef) && oldSelf.spec.seedImageRef==self.spec.seedImageRef || !has(self.spec.seedImageRef) && !has(oldSelf.spec.seedImageRef)"

--- a/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
+++ b/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.stage
+      name: Stage
+      type: string
     - jsonPath: .status.conditions[-1:].type
       name: State
       type: string

--- a/bundle/manifests/lca.openshift.io_seedgenerators.yaml
+++ b/bundle/manifests/lca.openshift.io_seedgenerators.yaml
@@ -20,6 +20,12 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[-1:].type
+      name: State
+      type: string
+    - jsonPath: .status.conditions[-1:].message
+      name: Details
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -45,6 +51,9 @@ spec:
               seedImage:
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: cannot modify spec, cr must be deleted and recreated
+              rule: self == oldSelf
           status:
             description: SeedGeneratorStatus defines the observed state of SeedGenerator
             properties:

--- a/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
+++ b/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.stage
+      name: Stage
+      type: string
     - jsonPath: .status.conditions[-1:].type
       name: State
       type: string

--- a/config/crd/bases/lca.openshift.io_seedgenerators.yaml
+++ b/config/crd/bases/lca.openshift.io_seedgenerators.yaml
@@ -20,6 +20,12 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[-1:].type
+      name: State
+      type: string
+    - jsonPath: .status.conditions[-1:].message
+      name: Details
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -45,6 +51,9 @@ spec:
               seedImage:
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: cannot modify spec, cr must be deleted and recreated
+              rule: self == oldSelf
           status:
             description: SeedGeneratorStatus defines the observed state of SeedGenerator
             properties:

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -248,16 +248,16 @@ func GetPreviousStage(stage lcav1alpha1.ImageBasedUpgradeStage) lcav1alpha1.Imag
 // SetUpgradeStatusFailed updates the upgrade status to failed with message
 func SetUpgradeStatusFailed(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
 	SetStatusCondition(&ibu.Status.Conditions,
-		GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
-		ConditionReasons.Failed,
-		metav1.ConditionFalse,
-		msg,
-		ibu.Generation)
-	SetStatusCondition(&ibu.Status.Conditions,
 		GetCompletedConditionType(lcav1alpha1.Stages.Upgrade),
 		ConditionReasons.Failed,
 		metav1.ConditionFalse,
 		"Upgrade failed",
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Upgrade),
+		ConditionReasons.Failed,
+		metav1.ConditionFalse,
+		msg,
 		ibu.Generation)
 }
 
@@ -332,16 +332,16 @@ func SetPrepStatusCompleted(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
 // SetRollbackStatusFailed updates the Rollback status to failed with message
 func SetRollbackStatusFailed(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
 	SetStatusCondition(&ibu.Status.Conditions,
-		GetInProgressConditionType(lcav1alpha1.Stages.Rollback),
-		ConditionReasons.Failed,
-		metav1.ConditionFalse,
-		msg,
-		ibu.Generation)
-	SetStatusCondition(&ibu.Status.Conditions,
 		GetCompletedConditionType(lcav1alpha1.Stages.Rollback),
 		ConditionReasons.Failed,
 		metav1.ConditionFalse,
 		"Rollback failed",
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetInProgressConditionType(lcav1alpha1.Stages.Rollback),
+		ConditionReasons.Failed,
+		metav1.ConditionFalse,
+		msg,
 		ibu.Generation)
 }
 
@@ -358,15 +358,15 @@ func SetRollbackStatusInProgress(ibu *lcav1alpha1.ImageBasedUpgrade, msg string)
 // SetUpgradeStatusCompleted updates the Rollback status to completed
 func SetRollbackStatusCompleted(ibu *lcav1alpha1.ImageBasedUpgrade) {
 	SetStatusCondition(&ibu.Status.Conditions,
-		GetCompletedConditionType(lcav1alpha1.Stages.Rollback),
-		ConditionReasons.Completed,
-		metav1.ConditionTrue,
-		"Rollback completed",
-		ibu.Generation)
-	SetStatusCondition(&ibu.Status.Conditions,
 		GetInProgressConditionType(lcav1alpha1.Stages.Rollback),
 		ConditionReasons.Completed,
 		metav1.ConditionFalse,
+		"Rollback completed",
+		ibu.Generation)
+	SetStatusCondition(&ibu.Status.Conditions,
+		GetCompletedConditionType(lcav1alpha1.Stages.Rollback),
+		ConditionReasons.Completed,
+		metav1.ConditionTrue,
 		"Rollback completed",
 		ibu.Generation)
 }


### PR DESCRIPTION
Updates include:
- Include Stage in IBU display
- Include State and Details in SeedGen display
- Make seedgen spec immutable and only handle Create events
- Add mutex to prevent IBU and SeedGen reconcilers from running at the same time
- Delete IBU CR prior to generating seed image, so it is not included in the seed
- Update Rollback states and progress messages to provide more useful feedback for user
- Improve seedgen error handling and reporting

/cc @browsell @jc-rh 