### PR TITLE
MGMT-16601: allow installation without providing host ip in advance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ bashate: ## Run bashate.
 	hack/bashate.sh
 
 .PHONY: ci-job
-ci-job: common-deps-update generate fmt vet golangci-lint unittest shellcheck bashate bundle-check imager-unittest
+ci-job: common-deps-update generate fmt vet golangci-lint unittest shellcheck bashate bundle-check
 
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@v5.1.1)
@@ -262,15 +262,6 @@ imager-build: common-deps-update fmt vet ## Build the imager tool from your host
 TEST_FORMAT ?= standard-verbose
 GOTEST_FLAGS = --format=$(TEST_FORMAT)
 GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)"
-
-imager_test: $(REPORTS)
-	$(GOTESTSUM) $(GOTEST_FLAGS) $(TEST) $(GINKGO_FLAGS) -timeout $(TIMEOUT)
-
-.PHONY: imager-unittest
-imager-unittest: ## Run unittests for imager.
-	@echo "Running unittests"
-	$(call go-get-tool,$(GOTESTSUM),gotest.tools/gotestsum@latest)
-	$(MAKE) imager_test TEST_SCENARIO=unit TIMEOUT=30m TEST="$(or $(TEST),$(shell go list ./ibu-imager/...))"
 
 help:   ## Shows this message.
 	@echo "Available targets:"

--- a/ibu-imager/installation_configuration_files/scripts/prepare-installation-configuration.sh
+++ b/ibu-imager/installation_configuration_files/scripts/prepare-installation-configuration.sh
@@ -59,16 +59,6 @@ if [[ -d "${NETWORK_CONFIG_PATH}"/system-connections ]]; then
 fi
 
 CLUSTER_CONFIG_FILE="${CONFIG_PATH}"/manifest.json
-NEW_CLUSTER_NAME=$(jq -r '.cluster_name' "${CLUSTER_CONFIG_FILE}")
-NEW_BASE_DOMAIN=$(jq -r '.domain' "${CLUSTER_CONFIG_FILE}")
-NEW_HOST_IP=$(jq -r '.master_ip' "${CLUSTER_CONFIG_FILE}")
-
-cat << EOF > /etc/default/sno_dnsmasq_configuration_overrides
-SNO_CLUSTER_NAME_OVERRIDE=${NEW_CLUSTER_NAME}
-SNO_BASE_DOMAIN_OVERRIDE=${NEW_BASE_DOMAIN}
-SNO_DNSMASQ_IP_OVERRIDE=${NEW_HOST_IP}
-EOF
-
 NEW_HOSTNAME=$(jq -r '.hostname' "${CLUSTER_CONFIG_FILE}")
 echo ${NEW_HOSTNAME} > /etc/hostname
 

--- a/ibu-imager/postpivot/postpivot_test.go
+++ b/ibu-imager/postpivot/postpivot_test.go
@@ -1,0 +1,151 @@
+package postpivot
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	clusterconfig_api "github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
+	"github.com/openshift-kni/lifecycle-agent/ibu-imager/ops"
+)
+
+func TestSetNodeIPIfNotProvided(t *testing.T) {
+	createNodeIpFile := func(t *testing.T, ipFile string, ipToSet string) {
+		f, err := os.Create(ipFile)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		defer f.Close()
+		if _, err = f.WriteString(ipToSet); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	var (
+		mockController = gomock.NewController(t)
+		mockOps        = ops.NewMockOps(mockController)
+	)
+
+	defer func() {
+		mockController.Finish()
+	}()
+
+	testcases := []struct {
+		name             string
+		expectedError    bool
+		nodeipFileExists bool
+		ipProvided       bool
+		ipToSet          string
+	}{
+		{
+			name:             "Ip provided nothing to do",
+			expectedError:    false,
+			nodeipFileExists: true,
+			ipProvided:       true,
+			ipToSet:          "192.167.1.2",
+		},
+		{
+			name:             "Ip is not provided, bad ip in file",
+			expectedError:    true,
+			nodeipFileExists: true,
+			ipProvided:       false,
+			ipToSet:          "bad ip",
+		},
+		{
+			name:             "Ip is not provided, happy flow",
+			expectedError:    false,
+			nodeipFileExists: true,
+			ipProvided:       false,
+			ipToSet:          "192.167.1.2",
+		},
+	}
+
+	for _, tc := range testcases {
+		tmpDir := t.TempDir()
+		t.Run(tc.name, func(t *testing.T) {
+			log := &logrus.Logger{}
+			pp := NewPostPivot(nil, log, mockOps, "", "", "")
+			seedReconfig := &clusterconfig_api.SeedReconfiguration{}
+			if tc.ipProvided {
+				seedReconfig.NodeIP = tc.ipToSet
+			}
+			ipFile := path.Join(tmpDir, "primary")
+			if tc.nodeipFileExists {
+				createNodeIpFile(t, ipFile, tc.ipToSet)
+			} else {
+				mockOps.EXPECT().SystemctlAction("start", "nodeip-configuration").Return("", nil).Do(func(any) {
+					createNodeIpFile(t, ipFile, tc.ipToSet)
+				})
+			}
+
+			err := pp.setNodeIPIfNotProvided(context.TODO(), seedReconfig, ipFile)
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			} else {
+				assert.Equal(t, err != nil, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestSetDnsMasqConfiguration(t *testing.T) {
+	var (
+		mockController = gomock.NewController(t)
+		mockOps        = ops.NewMockOps(mockController)
+	)
+
+	defer func() {
+		mockController.Finish()
+	}()
+
+	testcases := []struct {
+		name                string
+		expectedError       bool
+		seedReconfiguration *clusterconfig_api.SeedReconfiguration
+	}{
+		{
+			name: "Happy flow",
+			seedReconfiguration: &clusterconfig_api.SeedReconfiguration{
+				BaseDomain:  "new.com",
+				ClusterName: "new_name",
+				NodeIP:      "192.167.127.10",
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tmpDir := t.TempDir()
+		t.Run(tc.name, func(t *testing.T) {
+			log := &logrus.Logger{}
+			pp := NewPostPivot(nil, log, mockOps, "", "", "")
+			mockOps.EXPECT().SystemctlAction("restart", "NetworkManager.service").Return("", nil)
+			mockOps.EXPECT().SystemctlAction("restart", "dnsmasq.service").Return("", nil)
+			confFile := path.Join(tmpDir, "override")
+			err := pp.setDnsMasqConfiguration(tc.seedReconfiguration, confFile)
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			} else {
+				assert.Equal(t, err != nil, tc.expectedError)
+			}
+			if !tc.expectedError {
+				data, errF := os.ReadFile(confFile)
+				if errF != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				lines := strings.Split(string(data), "\n")
+				assert.Equal(t, len(lines), 3)
+				assert.Equal(t, lines[0], fmt.Sprintf("SNO_CLUSTER_NAME_OVERRIDE=%s", tc.seedReconfiguration.ClusterName))
+				assert.Equal(t, lines[1], fmt.Sprintf("SNO_BASE_DOMAIN_OVERRIDE=%s", tc.seedReconfiguration.BaseDomain))
+				assert.Equal(t, lines[2], fmt.Sprintf("SNO_DNSMASQ_IP_OVERRIDE=%s", tc.seedReconfiguration.NodeIP))
+			}
+		})
+	}
+}


### PR DESCRIPTION
[MGMT-16601](https://issues.redhat.com//browse/MGMT-16601): allow installation without providing host ip in advance
In case host ip was not provided in manifest.json post-pivot configuration will start manually nodeip service, wait till it creates primary-ip file and read ip from it.
After getting ip it will create dnsmasq and dispatcher script override file and restart NM with dnsmasq