### PR TITLE
Use `condition.reason` instead of `condition.type` as state in printercolumns

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -26,7 +26,7 @@ import (
 // +kubebuilder:resource:path=imagebasedupgrades,scope=Cluster,shortName=ibu
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Stage",type="string",JSONPath=".spec.stage"
-// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].type"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].reason"
 // +kubebuilder:printcolumn:name="Details",type="string",JSONPath=".status.conditions[-1:].message"
 // +kubebuilder:validation:XValidation:message="can not change spec.seedImageRef while ibu is in progress", rule="!has(oldSelf.status) || oldSelf.status.conditions.exists(c, c.type=='Idle' && c.status=='True') || has(oldSelf.spec.seedImageRef) && has(self.spec.seedImageRef) && oldSelf.spec.seedImageRef==self.spec.seedImageRef || !has(self.spec.seedImageRef) && !has(oldSelf.spec.seedImageRef)"
 // +kubebuilder:validation:XValidation:message="can not change spec.oadpContent while ibu is in progress", rule="!has(oldSelf.status) || oldSelf.status.conditions.exists(c, c.type=='Idle' && c.status=='True') || has(oldSelf.spec.oadpContent) && has(self.spec.oadpContent) && oldSelf.spec.oadpContent==self.spec.oadpContent || !has(self.spec.oadpContent) && !has(oldSelf.spec.oadpContent)"

--- a/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
+++ b/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
@@ -23,7 +23,7 @@ spec:
     - jsonPath: .spec.stage
       name: Stage
       type: string
-    - jsonPath: .status.conditions[-1:].type
+    - jsonPath: .status.conditions[-1:].reason
       name: State
       type: string
     - jsonPath: .status.conditions[-1:].message

--- a/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
+++ b/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
@@ -23,7 +23,7 @@ spec:
     - jsonPath: .spec.stage
       name: Stage
       type: string
-    - jsonPath: .status.conditions[-1:].type
+    - jsonPath: .status.conditions[-1:].reason
       name: State
       type: string
     - jsonPath: .status.conditions[-1:].message

--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -344,7 +344,7 @@ func (r *ImageBasedUpgradeReconciler) prepStageWorker(ctx context.Context, ibu *
 		msg := "Prep completed successfully"
 		status, err := r.Precache.QueryJobStatus(ctx)
 		if err == nil && status != nil && status.Message != "" {
-			msg += fmt.Sprintf(": %s", status.Message)
+			r.Log.Info(msg, "summary", status.Message)
 		}
 		r.PrepTask.Progress = msg
 

--- a/main/main.go
+++ b/main/main.go
@@ -158,7 +158,7 @@ func main() {
 
 	var config *rest.Config
 	if _, err := os.Stat(common.PathOutsideChroot(common.KubeconfigFile)); err != nil {
-		setupLog.Error(err, "could not fine KubeconfigFile. Using empty config only for test environment")
+		setupLog.Error(err, "could not find KubeconfigFile. Using empty config only for test environment")
 		config = &rest.Config{}
 	} else {
 		config, err = clientcmd.BuildConfigFromFlags("", common.PathOutsideChroot(common.KubeconfigFile))


### PR DESCRIPTION
Condition.reason represent the state better than condition.type

Also:
- Remove precache summary from status messages
- Fix typo in main