### PR TITLE
MGMT-16559: Support NMState config 

### DIFF
--- a/api/seedreconfig/seedreconfig.go
+++ b/api/seedreconfig/seedreconfig.go
@@ -61,6 +61,12 @@ type SeedReconfiguration struct {
 	// instances. Equivalent to install-config.yaml's sshKey. This will replace
 	// the SSH keys of the seed cluster.
 	SSHKey string `json:"ssh_key,omitempty"`
+
+	// RawNMStateConfig contains nmstate configuration YAML file provided as string.
+	// String will be written to file and will be applied with "nmstatectl apply" command.
+	// Example of nmstate configurations can be found in this link https://nmstate.io/examples.html
+	// This field will be used for IBI process as in IBU we will copy nmconnection files
+	RawNMStateConfig string `json:"raw_nm_state_config,omitempty"`
 }
 
 type KubeConfigCryptoRetention struct {

--- a/lca-cli/postpivot/postpivot_test.go
+++ b/lca-cli/postpivot/postpivot_test.go
@@ -1,0 +1,238 @@
+package postpivot
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift-kni/lifecycle-agent/utils"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	clusterconfig_api "github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
+)
+
+func TestSetNodeIPIfNotProvided(t *testing.T) {
+	createNodeIpFile := func(t *testing.T, ipFile string, ipToSet string) {
+		f, err := os.Create(ipFile)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		defer f.Close()
+		if _, err = f.WriteString(ipToSet); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	var (
+		mockController = gomock.NewController(t)
+		mockOps        = ops.NewMockOps(mockController)
+	)
+
+	defer func() {
+		mockController.Finish()
+	}()
+
+	testcases := []struct {
+		name             string
+		expectedError    bool
+		nodeipFileExists bool
+		ipProvided       bool
+		ipToSet          string
+	}{
+		{
+			name:             "Ip provided nothing to do",
+			expectedError:    false,
+			nodeipFileExists: true,
+			ipProvided:       true,
+			ipToSet:          "192.167.1.2",
+		},
+		{
+			name:             "Ip is not provided, bad ip in file",
+			expectedError:    true,
+			nodeipFileExists: true,
+			ipProvided:       false,
+			ipToSet:          "bad ip",
+		},
+		{
+			name:             "Ip is not provided, happy flow",
+			expectedError:    false,
+			nodeipFileExists: true,
+			ipProvided:       false,
+			ipToSet:          "192.167.1.2",
+		},
+	}
+
+	for _, tc := range testcases {
+		tmpDir := t.TempDir()
+		t.Run(tc.name, func(t *testing.T) {
+			log := &logrus.Logger{}
+			pp := NewPostPivot(nil, log, mockOps, "", "", "")
+			seedReconfig := &clusterconfig_api.SeedReconfiguration{}
+			if tc.ipProvided {
+				seedReconfig.NodeIP = tc.ipToSet
+			}
+			ipFile := path.Join(tmpDir, "primary")
+			if tc.nodeipFileExists {
+				createNodeIpFile(t, ipFile, tc.ipToSet)
+			} else {
+				mockOps.EXPECT().SystemctlAction("start", "nodeip-configuration").Return("", nil).Do(func(any) {
+					createNodeIpFile(t, ipFile, tc.ipToSet)
+				})
+			}
+
+			err := pp.setNodeIPIfNotProvided(context.TODO(), seedReconfig, ipFile)
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			} else {
+				assert.Equal(t, err != nil, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestSetDnsMasqConfiguration(t *testing.T) {
+	var (
+		mockController = gomock.NewController(t)
+		mockOps        = ops.NewMockOps(mockController)
+	)
+
+	defer func() {
+		mockController.Finish()
+	}()
+
+	testcases := []struct {
+		name                string
+		expectedError       bool
+		seedReconfiguration *clusterconfig_api.SeedReconfiguration
+	}{
+		{
+			name: "Happy flow",
+			seedReconfiguration: &clusterconfig_api.SeedReconfiguration{
+				BaseDomain:  "new.com",
+				ClusterName: "new_name",
+				NodeIP:      "192.167.127.10",
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tmpDir := t.TempDir()
+		t.Run(tc.name, func(t *testing.T) {
+			log := &logrus.Logger{}
+			pp := NewPostPivot(nil, log, mockOps, "", "", "")
+			mockOps.EXPECT().SystemctlAction("restart", "NetworkManager.service").Return("", nil)
+			mockOps.EXPECT().SystemctlAction("restart", "dnsmasq.service").Return("", nil)
+			confFile := path.Join(tmpDir, "override")
+			err := pp.setDnsMasqConfiguration(tc.seedReconfiguration, confFile)
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			} else {
+				assert.Equal(t, err != nil, tc.expectedError)
+			}
+			if !tc.expectedError {
+				data, errF := os.ReadFile(confFile)
+				if errF != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				lines := strings.Split(string(data), "\n")
+				assert.Equal(t, len(lines), 3)
+				assert.Equal(t, lines[0], fmt.Sprintf("SNO_CLUSTER_NAME_OVERRIDE=%s", tc.seedReconfiguration.ClusterName))
+				assert.Equal(t, lines[1], fmt.Sprintf("SNO_BASE_DOMAIN_OVERRIDE=%s", tc.seedReconfiguration.BaseDomain))
+				assert.Equal(t, lines[2], fmt.Sprintf("SNO_DNSMASQ_IP_OVERRIDE=%s", tc.seedReconfiguration.NodeIP))
+			}
+		})
+	}
+}
+
+func TestApplyNMStateConfiguration(t *testing.T) {
+	var (
+		mockController = gomock.NewController(t)
+		mockOps        = ops.NewMockOps(mockController)
+	)
+
+	defer func() {
+		mockController.Finish()
+	}()
+
+	testcases := []struct {
+		name                string
+		expectedError       bool
+		seedReconfiguration *clusterconfig_api.SeedReconfiguration
+	}{
+		{
+			name: "Happy flow",
+			seedReconfiguration: &clusterconfig_api.SeedReconfiguration{
+				RawNMStateConfig: `
+interfaces:
+  - name: wan0
+    type: ethernet
+    state: up
+    identifier: mac-address
+    mac-address: 1e:bd:23:e9:fb:94
+    ipv4:
+      enabled: true
+      dhcp: true
+    ipv6:
+      enabled: true
+      dhcp: true
+      autoconf: true`,
+			},
+			expectedError: false,
+		},
+		{
+			name: "Failure in nmstatectl apply",
+			seedReconfiguration: &clusterconfig_api.SeedReconfiguration{
+				RawNMStateConfig: `
+interfaces:
+  - name: wan0
+    type: ethernet
+    state: up
+    identifier: mac-address
+    mac-address: 1e:bd:23:e9:fb:94
+    ipv4:
+      enabled: true
+      dhcp: true
+    ipv6:
+      enabled: true
+      dhcp: true
+      autoconf: true`,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		tmpDir := t.TempDir()
+		t.Run(tc.name, func(t *testing.T) {
+			log := &logrus.Logger{}
+			nmstateFile := path.Join(tmpDir, "nmstate.yaml")
+			pp := NewPostPivot(nil, log, mockOps, "", tmpDir, "")
+			if tc.expectedError {
+				mockOps.EXPECT().RunInHostNamespace("nmstatectl", "apply", nmstateFile).Return("", fmt.Errorf("Dummy"))
+			} else {
+				mockOps.EXPECT().RunInHostNamespace("nmstatectl", "apply", nmstateFile).Return("", nil)
+			}
+
+			err := pp.applyNMStateConfiguration(tc.seedReconfiguration)
+			if !tc.expectedError {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				var data []interface{}
+				errF := utils.ReadYamlOrJSONFile(nmstateFile, data)
+				if errF != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else {
+				assert.Equal(t, err != nil, tc.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[MGMT-16559](https://issues.redhat.com//browse/MGMT-16559): Support NMState config
Adding new api field RawNMStateConfig that allows user to provide raw
nmstate yaml file that will be applied on the node with nmstatectl apply
command