### PR TITLE
Remove unused field MirrorRegistryConfigured from SeedReconfiguration

### DIFF
--- a/api/seedreconfig/seedreconfig.go
+++ b/api/seedreconfig/seedreconfig.go
@@ -48,9 +48,6 @@ type SeedReconfiguration struct {
 	// The desired hostname of the SNO node.
 	Hostname string `json:"hostname,omitempty"`
 
-	// Whether or not the cluster is using a mirror registry.
-	MirrorRegistryConfigured bool `json:"mirror_registry_configured,omitempty"`
-
 	// KubeconfigCryptoRetention contains all the crypto material that is
 	// required for recert to ensure existing kubeconfigs can be used to access
 	// the cluster after recert.

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -209,7 +209,6 @@ func SeedReconfigurationFromClusterInfo(clusterInfo *utils.ClusterInfo,
 		NodeIP:                    clusterInfo.NodeIP,
 		ReleaseRegistry:           clusterInfo.ReleaseRegistry,
 		Hostname:                  clusterInfo.Hostname,
-		MirrorRegistryConfigured:  clusterInfo.MirrorRegistryConfigured,
 		KubeconfigCryptoRetention: *kubeconfigCryptoRetention,
 	}
 }


### PR DESCRIPTION
This field is not used on reconfiguration process and currently useful only for seed info