### PR TITLE
Use recert stable tag

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -130,7 +130,7 @@ AUTHFILE=/tmp/backup-secret.json
 podman login --authfile ${AUTHFILE} -u ${MY_ID} quay.io/${MY_REPO_ID}
 
 export IMG_REFSPEC=quay.io/${MY_REPO_ID}/${MY_REPO}:${MY_TAG}
-export IMG_RECERT_TOOL=quay.io/edge-infrastructure/recert:latest
+export IMG_RECERT_TOOL=quay.io/edge-infrastructure/recert:v0
 
 podman run --privileged --pid=host --rm --net=host \
     -v /etc:/etc \
@@ -369,7 +369,7 @@ metadata:
   name: seedimage
 spec:
   seedImage: quay.io/dpenney/upgbackup:orchestrated-seed-image
-  recertImage: quay.io/edge-infrastructure/recert:latest
+  recertImage: quay.io/edge-infrastructure/recert:v0
 ```
 
 ## Rollbacks

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -31,7 +31,7 @@ const (
 	ImageRegistryAuthFile = "/var/lib/kubelet/config.json"
 	KubeconfigFile        = "/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/lb-ext.kubeconfig"
 
-	DefaultRecertImage     = "quay.io/edge-infrastructure/recert:latest"
+	DefaultRecertImage     = "quay.io/edge-infrastructure/recert:v0"
 	EtcdStaticPodFile      = "/etc/kubernetes/manifests/etcd-pod.yaml"
 	EtcdStaticPodContainer = "etcd"
 	EtcdDefaultEndpoint    = "localhost:2379"

--- a/lca-cli/README.md
+++ b/lca-cli/README.md
@@ -86,7 +86,7 @@ To create an IBU seed image out of your Single Node OpenShift (SNO), run the fol
 
 -> export AUTHFILE=/path/to/pull-secret.json
 -> export SEED_IMG_REFSPEC=quay.io/${MY_REPO_ID}/${MY_REPO}:${MY_TAG}
--> export IMG_RECERT_TOOL=quay.io/edge-infrastructure/recert:latest
+-> export IMG_RECERT_TOOL=quay.io/edge-infrastructure/recert:v0
 
 -> podman run --privileged --pid=host --rm --net=host \
     -v /etc:/etc \
@@ -116,7 +116,7 @@ time="2023-11-28 11:56:37" level=info msg="Seed cluster restored successfully!"
 ```
 
 Notice that the `--recert-image` flag is optional (mainly used in disconnected environments), if not provided the
-tool will use `quay.io/edge-infrastructure/recert:latest` as the default recert image.
+tool will use `quay.io/edge-infrastructure/recert:v0` as the default recert image.
 
 > **Note:** For a disconnected environment, first mirror the `lca-cli` and `recert` container images to your local
 > registry using [skopeo](https://github.com/containers/skopeo) or a similar tool.


### PR DESCRIPTION
The `:latest` tag of the recert image is not stable, it contains changes
from the `main` branch. We should default to the `:v0` tag instead which
we merge into less often.