### PR TITLE
MGMT-15783: moving pull secret to seed reconfiguration struct.

### DIFF
--- a/api/seedreconfig/seedreconfig.go
+++ b/api/seedreconfig/seedreconfig.go
@@ -74,6 +74,9 @@ type SeedReconfiguration struct {
 	// Example of nmstate configurations can be found in this link https://nmstate.io/examples.html
 	// This field will be used for IBI process as in IBU we will copy nmconnection files
 	RawNMStateConfig string `json:"raw_nm_state_config,omitempty"`
+
+	// PullSecret is the secret to use when pulling images. Equivalent to install-config.yaml's pullSecret.
+	PullSecret string `json:"pull_secret,omitempty"`
 }
 
 type KubeConfigCryptoRetention struct {

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -194,9 +194,9 @@ func TestClusterConfig(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pullSecretName,
-					Namespace: configNamespace,
+					Namespace: common.OpenshiftConfigNamespace,
 				},
-				Data: map[string][]byte{"aaa": []byte("bbb")},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte("pull-secret")},
 			},
 			clusterVersion: &ocpV1.ClusterVersion{
 				ObjectMeta: metav1.ObjectMeta{
@@ -239,17 +239,6 @@ func TestClusterConfig(t *testing.T) {
 				assert.Equal(t, proxyName, proxy.Name)
 				assert.Equal(t, "some-http-proxy", proxy.Spec.HTTPProxy)
 
-				// validate pull secret
-				secret := &corev1.Secret{}
-				if err := utils.ReadYamlOrJSONFile(filepath.Join(manifestsDir, pullSecretFileName), secret); err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-
-				testData := map[string][]byte{"aaa": []byte("bbb")}
-				assert.Equal(t, testData, secret.Data)
-				assert.Equal(t, pullSecretName, secret.Name)
-				assert.Equal(t, configNamespace, secret.Namespace)
-
 				// validate pull idms
 				idms := &ocpV1.ImageDigestMirrorSetList{}
 				if err := utils.ReadYamlOrJSONFile(filepath.Join(manifestsDir, idmsFileName), idms); err != nil {
@@ -267,6 +256,7 @@ func TestClusterConfig(t *testing.T) {
 					t.Errorf("unexpected error: %v", err)
 				}
 				assert.Equal(t, "mysno-xsb4m", seedReconfig.InfraID)
+				assert.Equal(t, "pull-secret", seedReconfig.PullSecret)
 				assert.Equal(t, "ssh-key", seedReconfig.SSHKey)
 				assert.Equal(t, "test-infra-cluster", seedReconfig.ClusterName)
 				assert.Equal(t, "redhat.com", seedReconfig.BaseDomain)
@@ -305,8 +295,9 @@ func TestClusterConfig(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pullSecretName,
-					Namespace: configNamespace,
+					Namespace: common.OpenshiftConfigNamespace,
 				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte("pull-secret")},
 			},
 			idms:       nil,
 			icsps:      nil,
@@ -328,8 +319,9 @@ func TestClusterConfig(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pullSecretName,
-					Namespace: configNamespace,
+					Namespace: common.OpenshiftConfigNamespace,
 				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte("pull-secret")},
 			},
 			clusterVersion: &ocpV1.ClusterVersion{
 				ObjectMeta: metav1.ObjectMeta{
@@ -358,7 +350,7 @@ func TestClusterConfig(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				assert.Equal(t, 2, len(dir))
+				assert.Equal(t, 1, len(dir))
 			},
 		},
 		{
@@ -366,8 +358,9 @@ func TestClusterConfig(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pullSecretName,
-					Namespace: configNamespace,
+					Namespace: common.OpenshiftConfigNamespace,
 				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte("pull-secret")},
 			},
 			clusterVersion: &ocpV1.ClusterVersion{
 				ObjectMeta: metav1.ObjectMeta{
@@ -398,9 +391,9 @@ func TestClusterConfig(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pullSecretName,
-					Namespace: configNamespace,
+					Namespace: common.OpenshiftConfigNamespace,
 				},
-				Data: map[string][]byte{"aaa": []byte("bbb")},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte("pull-secret")},
 			},
 			clusterVersion: &ocpV1.ClusterVersion{
 				ObjectMeta: metav1.ObjectMeta{
@@ -432,7 +425,7 @@ func TestClusterConfig(t *testing.T) {
 				}, Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{{Source: "icspData2"}}}}},
 			caBundleCM: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: caBundleCMName,
-				Namespace: configNamespace}, Data: map[string]string{"test": "data"}},
+				Namespace: common.OpenshiftConfigNamespace}, Data: map[string]string{"test": "data"}},
 			expectedErr: false,
 			validateFunc: func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather) {
 				clusterConfigPath, err := ucc.configDir(tempDir)

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -76,6 +76,9 @@ const (
 	// Bump this every time the seed format changes in a backwards incompatible way
 	SeedFormatVersion  = 3
 	SeedFormatOCILabel = "com.openshift.lifecycle-agent.seed_format_version"
+
+	PullSecretName           = "pull-secret"
+	OpenshiftConfigNamespace = "openshift-config"
 )
 
 // CertPrefixes is the list of certificate prefixes to be backed up

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -292,3 +292,12 @@ func ConvertToRawExtension(config any) (runtime.RawExtension, error) {
 		Raw: rawIgnConfig,
 	}, nil
 }
+
+func MoveFileIfExists(source, dest string) error {
+	if _, err := os.Stat(source); err == nil {
+		if err := os.Rename(source, dest); err != nil {
+			return fmt.Errorf("failed to move %s to %s, err :%w", source, dest, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
IBU/I will set pull secret in struct and post pivot will create pull-secret secret that will be applied with all the manifests whenever
cluster will be up
Flow:
1. We will move seed pull secret aside, write new pull secret to
/var/lib/kubelet/config.json.
2. After api is up and images were pulled, we will write back seed pull
   secret in order for MCO to be happy
3. After it we will apply new pull secret to cluster
