### PR TITLE
Workaround for ci-operator git command issue in linter scripts

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -2,7 +2,9 @@
 
 VERSION="1.51.1"
 
-rootdir=$(git rev-parse --show-toplevel)
+# Temporary workaround until issue in ci-operator with git commands is resolved.
+#rootdir=$(git rev-parse --show-toplevel)
+rootdir=$(dirname $(dirname $(readlink -f $0)))
 if [ -z "${rootdir}" ]; then
     echo "Failed to determine top level directory"
     exit 1

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -2,7 +2,9 @@
 
 VERSION="0.7.2"
 
-rootdir=$(git rev-parse --show-toplevel)
+# Temporary workaround until issue in ci-operator with git commands is resolved.
+#rootdir=$(git rev-parse --show-toplevel)
+rootdir=$(dirname $(dirname $(readlink -f $0)))
 if [ -z "${rootdir}" ]; then
     echo "Failed to determine top level directory"
     exit 1


### PR DESCRIPTION
The ci-operator image appears to be ignoring its git config for safe.directory, causing git commands run during the ci-job to fail with 'dubious ownership' error. Until this issue is resolved, avoid git commands in the linter scripts.

Unfortunately, this means that the check-git-tree.sh script isn't able to check the git status. As a result, it's possible for commits with stale generated code files to be missed, where normally this check would catch such issues. Developers will need to manually run 'make ci-job' prior to posting PRs as a safety check.