### PR TITLE
CNF-11033: Delete pull secret from seed image

### DIFF
--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -21,4 +21,6 @@ const (
 var (
 	SeedGenStoredCR       = filepath.Join(SeedgenWorkspacePath, "seedgen-cr.json")
 	SeedGenStoredSecretCR = filepath.Join(SeedgenWorkspacePath, "seedgen-secret.json")
+
+	StoredPullSecret = filepath.Join(SeedgenWorkspacePath, "pull-secret.json")
 )

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -78,6 +78,7 @@ const (
 	SeedFormatOCILabel = "com.openshift.lifecycle-agent.seed_format_version"
 
 	PullSecretName           = "pull-secret"
+	PullSecretEmptyData      = "{\"auths\":{\"registry.connect.redhat.com\":{\"username\":\"empty\",\"password\":\"empty\",\"auth\":\"ZW1wdHk6ZW1wdHk=\",\"email\":\"\"}}}"
 	OpenshiftConfigNamespace = "openshift-config"
 )
 

--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -303,14 +303,15 @@ func (s *SeedCreator) backupVar() error {
 
 	// Define the 'exclude' patterns
 	excludePatterns := []string{
+		"*/.bash_history",
 		"/var/tmp/*",
-		"/var/lib/log/*",
 		"/var/log/*",
+		"/var/lib/lca",
+		"/var/lib/log/*",
+		"/var/lib/cni/bin/*",
 		"/var/lib/containers/*",
 		"/var/lib/kubelet/pods/*",
-		"/var/lib/cni/bin/*",
-		"/var/lib/ovn-ic/etc/ovnkube-node-certs/*",
-		"/var/lib/lca",
+		common.OvnNodeCerts + "/*",
 	}
 
 	// Build the tar command


### PR DESCRIPTION
We shouldn't be distributing the pull-secret of seed clusters. This cleans up the seed cluster of its pull-secret before seed creation to avoid unwanted distribution of this secret.

Also, added a commit to restore the original pull-secret in the seed cluster as soon as it gets back from seed creation for the cluster operators needing it.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>