### PR TITLE
Revert "Workaround for ci-operator git command issue in linter scripts"

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -2,9 +2,7 @@
 
 VERSION="1.55.2"
 
-# Temporary workaround until issue in ci-operator with git commands is resolved.
-#rootdir=$(git rev-parse --show-toplevel)
-rootdir=$(dirname $(dirname $(readlink -f $0)))
+rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then
     echo "Failed to determine top level directory"
     exit 1

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -2,9 +2,7 @@
 
 VERSION="0.7.2"
 
-# Temporary workaround until issue in ci-operator with git commands is resolved.
-#rootdir=$(git rev-parse --show-toplevel)
-rootdir=$(dirname $(dirname $(readlink -f $0)))
+rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then
     echo "Failed to determine top level directory"
     exit 1


### PR DESCRIPTION
Reverts openshift-kni/lifecycle-agent#251

CI fix for 4.14:
https://github.com/openshift-eng/ocp-build-data/pull/4268