### PR TITLE
CNF-11136: Add handleFinalizeFailure and handleAbortFailure

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -237,20 +237,18 @@ func (r *ImageBasedUpgradeReconciler) handleStage(ctx context.Context, ibu *lcav
 
 func (r *ImageBasedUpgradeReconciler) handleAbortOrFinalize(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade) (nextReconcile ctrl.Result, err error) {
 	idleCondition := meta.FindStatusCondition(ibu.Status.Conditions, string(utils.ConditionTypes.Idle))
-	if idleCondition != nil && idleCondition.Status == metav1.ConditionFalse {
-		switch idleCondition.Reason {
-		case string(utils.ConditionReasons.Aborting):
-			nextReconcile, err = r.handleAbort(ctx, ibu)
-		case string(utils.ConditionReasons.AbortFailed):
-			nextReconcile, err = r.handleAbortFailure(ctx, ibu)
-		case string(utils.ConditionReasons.Finalizing):
-			nextReconcile, err = r.handleFinalize(ctx, ibu)
-		case string(utils.ConditionReasons.FinalizeFailed):
-			nextReconcile, err = r.handleFinalizeFailure(ctx, ibu)
-		}
-		if nextReconcile.Requeue == false {
-			utils.ResetStatusConditions(&ibu.Status.Conditions, ibu.Generation)
-		}
+	if idleCondition == nil || idleCondition.Status == metav1.ConditionTrue {
+		return
+	}
+	switch idleCondition.Reason {
+	case string(utils.ConditionReasons.Aborting):
+		nextReconcile, err = r.handleAbort(ctx, ibu)
+	case string(utils.ConditionReasons.AbortFailed):
+		nextReconcile, err = r.handleAbortFailure(ctx, ibu)
+	case string(utils.ConditionReasons.Finalizing):
+		nextReconcile, err = r.handleFinalize(ctx, ibu)
+	case string(utils.ConditionReasons.FinalizeFailed):
+		nextReconcile, err = r.handleFinalizeFailure(ctx, ibu)
 	}
 	return
 }
@@ -427,8 +425,18 @@ func (r *ImageBasedUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				// not metadata or status
 				oldGeneration := e.ObjectOld.GetGeneration()
 				newGeneration := e.ObjectNew.GetGeneration()
-				// spec update only for IBU
-				return oldGeneration != newGeneration
+				if oldGeneration != newGeneration {
+					return true
+				}
+
+				// trigger reconcile upon adding or removing ManualCleanupAnnotation
+				_, oldExist := e.ObjectOld.GetAnnotations()[utils.ManualCleanupAnnotation]
+				_, newExist := e.ObjectNew.GetAnnotations()[utils.ManualCleanupAnnotation]
+				if oldExist != newExist {
+					return true
+				}
+
+				return false
 			},
 			CreateFunc:  func(ce event.CreateEvent) bool { return true },
 			GenericFunc: func(ge event.GenericEvent) bool { return false },

--- a/controllers/idle_handlers_test.go
+++ b/controllers/idle_handlers_test.go
@@ -17,16 +17,27 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
+	lcav1alpha1 "github.com/openshift-kni/lifecycle-agent/api/v1alpha1"
+	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
 	"github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
 	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
 	rpmostreeclient "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func init() {
+	testscheme.AddKnownTypes(lcav1alpha1.GroupVersion, &lcav1alpha1.ImageBasedUpgrade{})
+}
 
 func TestImageBasedUpgradeReconciler_cleanupUnbootedStateroot(t *testing.T) {
 	tests := []struct {
@@ -128,6 +139,59 @@ func TestImageBasedUpgradeReconciler_cleanupUnbootedStateroot(t *testing.T) {
 			if err := r.cleanupUnbootedStateroot(tt.input); (err != nil) != tt.wantErr {
 				t.Errorf("ImageBasedUpgradeReconciler.cleanupUnbootedStateroot() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func TestCheckManualCleanup(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expect      bool
+	}{
+		{
+			name:        "annotation is set",
+			annotations: map[string]string{utils.ManualCleanupAnnotation: ""},
+			expect:      true,
+		},
+		{
+			name:        "annotation is not set",
+			annotations: map[string]string{},
+			expect:      false,
+		},
+	}
+
+	ibu := &lcav1alpha1.ImageBasedUpgrade{
+		ObjectMeta: corev1.ObjectMeta{
+			Name: utils.IBUName,
+		},
+		Spec: lcav1alpha1.ImageBasedUpgradeSpec{
+			Stage: lcav1alpha1.Stages.Idle,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ibu.SetAnnotations(tt.annotations)
+			objs := []client.Object{ibu}
+			client, err := getFakeClientFromObjects(objs...)
+			if err != nil {
+				t.Errorf("error in creating fake client")
+			}
+			r := &ImageBasedUpgradeReconciler{
+				Client: client,
+				Log:    logr.Discard(),
+			}
+
+			got, err := r.checkManualCleanup(context.TODO(), ibu)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expect, got)
+			gotIbu := &lcav1alpha1.ImageBasedUpgrade{}
+			if err := client.Get(context.TODO(), types.NamespacedName{Name: utils.IBUName}, gotIbu); err != nil {
+				t.Errorf("unexcepted error: %v", err.Error())
+			}
+			_, annotationPresent := gotIbu.Annotations[utils.ManualCleanupAnnotation]
+			assert.Equal(t, false, annotationPresent)
 		})
 	}
 }

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -10,6 +10,8 @@ const (
 	IBUName     string = "upgrade"
 	IBUFilePath string = "/opt/ibu.json"
 
+	ManualCleanupAnnotation string = "lca.openshift.io/manualCleanupDone"
+
 	// SeedGenName defines the valid name of the CR for the controller to reconcile
 	SeedGenName          string = "seedimage"
 	SeedGenSecretName    string = "seedgen"


### PR DESCRIPTION
If finalize or abort fails, ibu trasitions into finalizeFailed and
abortFailed states respectively.
```
  status:
    conditions:
    - message: failed to cleanup backups. Perform cleanup manually then
add lca.openshift.io/manualCleanupDone
        annotation to ibu CR to transition back to Idle
      observedGeneration: 5
      reason: AbortFailed
      status: "False"
      type: Idle
```

User should perform cleanup manually in these states. After manual
cleanup user should add 'lca.openshift.io/manualCleanupDone' annotation
to IBU CR.

```
  kind: ImageBasedUpgrade
  metadata:
    annotations:
      lca.openshit.io/manualCleanupDone: ""

```
Upon observing this annotation IBU will remove the annotations and runs
abort/finalize. If successful ibu transitions back to idle state.