### PR TITLE
Copy the kubeadmin password from original SNO

### DIFF
--- a/api/seedreconfig/seedreconfig.go
+++ b/api/seedreconfig/seedreconfig.go
@@ -69,6 +69,19 @@ type SeedReconfiguration struct {
 	// the SSH keys of the seed cluster.
 	SSHKey string `json:"ssh_key,omitempty"`
 
+	// KubeadminPasswordHash is the hash of the password for the kubeadmin
+	// user, as can be found in the kubeadmin key of the kube-system/kubeadmin
+	// secret. This will replace the kubeadmin password of the seed cluster.
+	// The seed image must have an existing kubeadmin password secret, this is
+	// because the secret is rejected by OCP if its creation timestamp differs
+	// from the kube-system namespace creation timestamp by more than 1 hour.
+	// During IBU, this is taken from the cluster that is being upgraded.
+	// During IBI, this is generated in advance so it can be displayed to the
+	// user. If empty, the kubeadmin password secret of the seed cluster will
+	// be deleted (thus disabling kubeadmin password login), to ensure we're
+	// not accepting a possibly compromised seed password.
+	KubeadminPasswordHash string `json:"kubeadmin_password_hash,omitempty"`
+
 	// RawNMStateConfig contains nmstate configuration YAML file provided as string.
 	// String will be written to file and will be applied with "nmstatectl apply" command.
 	// Example of nmstate configurations can be found in this link https://nmstate.io/examples.html

--- a/internal/recert/recert.go
+++ b/internal/recert/recert.go
@@ -20,48 +20,54 @@ const (
 var staticDirs = []string{"/kubelet", "/kubernetes", "/machine-config-daemon"}
 
 type RecertConfig struct {
-	DryRun            bool     `json:"dry_run,omitempty"`
-	ExtendExpiration  bool     `json:"extend_expiration,omitempty"`
-	ForceExpire       bool     `json:"force_expire,omitempty"`
-	EtcdEndpoint      string   `json:"etcd_endpoint,omitempty"`
-	ClusterRename     string   `json:"cluster_rename,omitempty"`
-	Hostname          string   `json:"hostname,omitempty"`
-	SummaryFile       string   `json:"summary_file,omitempty"`
-	SummaryFileClean  string   `json:"summary_file_clean,omitempty"`
-	StaticDirs        []string `json:"static_dirs,omitempty"`
-	StaticFiles       []string `json:"static_files,omitempty"`
-	CNSanReplaceRules []string `json:"cn_san_replace_rules,omitempty"`
-	UseKeyRules       []string `json:"use_key_rules,omitempty"`
-	UseCertRules      []string `json:"use_cert_rules,omitempty"`
+	DryRun           bool   `json:"dry_run,omitempty"`
+	ExtendExpiration bool   `json:"extend_expiration,omitempty"`
+	ForceExpire      bool   `json:"force_expire,omitempty"`
+	EtcdEndpoint     string `json:"etcd_endpoint,omitempty"`
+	ClusterRename    string `json:"cluster_rename,omitempty"`
+	Hostname         string `json:"hostname,omitempty"`
+	// We intentionally don't omitEmpty this field because an empty string here
+	// means "delete the kubeadmin password secret" while a complete omission
+	// of the field means "don't touch the secret". We never want the latter,
+	// we either want to delete the secret or update it, never leave it as is.
+	KubeadminPasswordHash string   `json:"kubeadmin_password_hash"`
+	SummaryFile           string   `json:"summary_file,omitempty"`
+	SummaryFileClean      string   `json:"summary_file_clean,omitempty"`
+	StaticDirs            []string `json:"static_dirs,omitempty"`
+	StaticFiles           []string `json:"static_files,omitempty"`
+	CNSanReplaceRules     []string `json:"cn_san_replace_rules,omitempty"`
+	UseKeyRules           []string `json:"use_key_rules,omitempty"`
+	UseCertRules          []string `json:"use_cert_rules,omitempty"`
 }
 
 // CreateRecertConfigFile function to create recert config file
 // those params will be provided to an installation script after reboot
 // that will run recert command with them
-func CreateRecertConfigFile(clusterInfo *seedreconfig.SeedReconfiguration, seedClusterInfo *seedclusterinfo.SeedClusterInfo, cryptoDir, recertConfigFolder string) error {
+func CreateRecertConfigFile(seedReconfig *seedreconfig.SeedReconfiguration, seedClusterInfo *seedclusterinfo.SeedClusterInfo, cryptoDir, recertConfigFolder string) error {
 	config := createBasicEmptyRecertConfig()
 
-	config.ClusterRename = fmt.Sprintf("%s:%s", clusterInfo.ClusterName, clusterInfo.BaseDomain)
-	if clusterInfo.InfraID != "" {
-		config.ClusterRename = fmt.Sprintf("%s:%s", config.ClusterRename, clusterInfo.InfraID)
+	config.ClusterRename = fmt.Sprintf("%s:%s", seedReconfig.ClusterName, seedReconfig.BaseDomain)
+	if seedReconfig.InfraID != "" {
+		config.ClusterRename = fmt.Sprintf("%s:%s", config.ClusterRename, seedReconfig.InfraID)
 	}
 
-	if clusterInfo.Hostname != seedClusterInfo.SNOHostname {
-		config.Hostname = clusterInfo.Hostname
+	if seedReconfig.Hostname != seedClusterInfo.SNOHostname {
+		config.Hostname = seedReconfig.Hostname
 	}
 
 	config.SummaryFile = SummaryFile
 	seedFullDomain := fmt.Sprintf("%s.%s", seedClusterInfo.ClusterName, seedClusterInfo.BaseDomain)
-	clusterFullDomain := fmt.Sprintf("%s.%s", clusterInfo.ClusterName, clusterInfo.BaseDomain)
+	clusterFullDomain := fmt.Sprintf("%s.%s", seedReconfig.ClusterName, seedReconfig.BaseDomain)
 	config.ExtendExpiration = true
 	config.CNSanReplaceRules = []string{
-		fmt.Sprintf("system:node:%s,system:node:%s", seedClusterInfo.SNOHostname, clusterInfo.Hostname),
-		fmt.Sprintf("%s,%s", seedClusterInfo.SNOHostname, clusterInfo.Hostname),
-		fmt.Sprintf("%s,%s", seedClusterInfo.NodeIP, clusterInfo.NodeIP),
+		fmt.Sprintf("system:node:%s,system:node:%s", seedClusterInfo.SNOHostname, seedReconfig.Hostname),
+		fmt.Sprintf("%s,%s", seedClusterInfo.SNOHostname, seedReconfig.Hostname),
+		fmt.Sprintf("%s,%s", seedClusterInfo.NodeIP, seedReconfig.NodeIP),
 		fmt.Sprintf("api.%s,api.%s", seedFullDomain, clusterFullDomain),
 		fmt.Sprintf("api-int.%s,api-int.%s", seedFullDomain, clusterFullDomain),
 		fmt.Sprintf("*.apps.%s,*.apps.%s", seedFullDomain, clusterFullDomain),
 	}
+	config.KubeadminPasswordHash = seedReconfig.KubeadminPasswordHash
 
 	if _, err := os.Stat(cryptoDir); err == nil {
 		ingressFile, ingressCN, err := getIngressCNAndFile(cryptoDir)

--- a/utils/client_helper.go
+++ b/utils/client_helper.go
@@ -22,6 +22,8 @@ import (
 func GetSecretData(ctx context.Context, name, namespace, key string, client runtimeclient.Client) (string, error) {
 	secret := &corev1.Secret{}
 	if err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, secret); err != nil {
+		// NOTE: The error is intentionally left unwrapped here, so the caller
+		// can check client.IgnoreNotFound on it
 		return "", err
 	}
 


### PR DESCRIPTION
Solves [MGMT-15731](https://issues.redhat.com//browse/MGMT-15731)

Users of OCP expect the default kubeadmin password generated during
installation time to keep working even after an IBU.

To achieve that, LCA will have to copy the password hash from the
kube-system/kubeadmin secret in the original SNO into the
`SeedReconfiguration` struct so it can be set in the equivalent secret
in the new SNO.

Note that not all clusters that we will be upgrading will have such
password, as OCP encourages people, for security reasons, to disable
this password by deleting the secret as outlined here:
https://docs.openshift.com/container-platform/4.14/authentication/remove-kubeadmin.html

In case no such secret exists, LCA will ensure that the secret will
simply be deleted in the new SNO.

The secret hash replacement will be actually done using a new recert
feature (which is activated by simply setting the hash in the recert
config, or setting it to an empty string to signal to recert to delete
the secret). The reason for doing it using recert is that recert is
already modifying etcd secrets while the cluster is offline, and we
don't want to launch a cluster that might still have some old
compromised seed password, even for just a little while.

An alternative solution to doing it in recert would be to have the seed
generator set a dummy password hash that no one in the world knows the
true password of. We arbitrarily chose the recert solution instead.

Note that if the seed cluster for some reason doesn't have the secret,
and the original SNO does have the secret, then it will cause an error,
as recert only supports modifying an existing secret, not creating one
from scratch. We could modify recert to theoretically create the secret,
but there's not much point to do it - we expect all seed clusters to
still have the secret. Another thing worth noting that we can't simply
in this case create the secret after the cluster has already started,
because the password gets rejected by OCP if the creation timestamp of
the secret differs from the kube-system namespace's creation timestamp
by more than 1 hour.