### PR TITLE
Add markdown linter and address existing warnings

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,13 @@
+# See https://github.com/DavidAnson/markdownlint#optionsconfig
+# and https://github.com/DavidAnson/markdownlint-cli2
+
+config:
+  line-length:
+    line_length: 300
+    code_blocks: false
+
+  ul-style: consistent
+  emphasis-style: true
+  strong-style: true
+  no-space-in-emphasis: true
+  no-blanks-blockquote: false

--- a/README.md
+++ b/README.md
@@ -10,4 +10,3 @@ Node Openshift (SNO) clusters.
 * make install run
 * make install deploy
 * make bundle-run
-

--- a/docs/precache-plugin.md
+++ b/docs/precache-plugin.md
@@ -1,32 +1,31 @@
 # Overview of the Precache Plugin
 
-The  precache plugin provides functionality for pre-caching images locally on a Single Node OpenShift (SNO) cluster as 
-part of the lifecycle-agent operator (LCA) for image-based upgrades (IBU). 
-The primary purpose is to ensure that required container images are pre-pulled and available locally to streamline the 
+The  precache plugin provides functionality for pre-caching images locally on a Single Node OpenShift (SNO) cluster as
+part of the lifecycle-agent operator (LCA) for image-based upgrades (IBU).
+The primary purpose is to ensure that required container images are pre-pulled and available locally to streamline the
 upgrade process. The plugin utilizes a Kubernetes Job and ConfigMap resource for orchestrating the pre-caching process.
 
 ## High-Level Design
 
-The schematic below illustrates the high-level design of the precache plugin, exclusively utilized by the `prep_handler` 
-controller. The primary APIs, namely `CreateJob` and `QueryJobStatus`, play pivotal roles in the creation and status 
-querying of the pre-caching Kubernetes job. Additionally, there exists a third API, `Cleanup` (not depicted in the 
+The schematic below illustrates the high-level design of the precache plugin, exclusively utilized by the `prep_handler`
+controller. The primary APIs, namely `CreateJob` and `QueryJobStatus`, play pivotal roles in the creation and status
+querying of the pre-caching Kubernetes job. Additionally, there exists a third API, `Cleanup` (not depicted in the
 schematic), responsible for resource cleanup.
 
 ![Pre-cache Plugin Design Schematic](assets/precache_design.svg)
 
-The `CreateJob` function initiates the creation of a ConfigMap (`lca-precache-cm`) and a Kubernetes Job (`lca-precache-job`). 
-The ConfigMap holds the `precache-spec` data, containing the list of images earmarked for pre-caching. This ConfigMap is 
-then consumed by the precaching job. The job, in turn, spawns a pod equipped with the `lifecycle-agent-operator:x.y.z` image. 
-Executing with the pre-compiled `precache` binary, the job incorporates both `nice` and `ionice` options. 
+The `CreateJob` function initiates the creation of a ConfigMap (`lca-precache-cm`) and a Kubernetes Job (`lca-precache-job`).
+The ConfigMap holds the `precache-spec` data, containing the list of images earmarked for pre-caching. This ConfigMap is
+then consumed by the precaching job. The job, in turn, spawns a pod equipped with the `lifecycle-agent-operator:x.y.z` image.
+Executing with the pre-compiled `precache` binary, the job incorporates both `nice` and `ionice` options.
 The main workload pulling mechanism resides in the [pullImages.go](../internal/precache/workload/pullImages.go) source file.
-Configuration of the pre-caching job is achieved through the [Config](../internal/precache/precache.go) struct, outlined 
-below. A [progress](../internal/precache/progress.go) object is used to track the precaching job's progress, capturing 
-details such as the total number of images to be precached, the number of images pulled, skipped, and failed to be pulled, 
+Configuration of the pre-caching job is achieved through the [Config](../internal/precache/precache.go) struct, outlined
+below. A [progress](../internal/precache/progress.go) object is used to track the precaching job's progress, capturing
+details such as the total number of images to be precached, the number of images pulled, skipped, and failed to be pulled,
 along with a list of failed pulls. The results are persisted to the file `precache_status.json`.
 
 The `QueryJobStatus` function is responsible for querying the status of the precaching job and attempting to load the
 precaching status file, `precache_status.json`.
-
 
 ### 1. Configuration Options
 
@@ -41,30 +40,30 @@ The `Config` struct defines the configuration options for a pre-caching job. The
 
 ### 2. ConfigMap Generation
 
-The `CreateJob` function begins by validating the precaching job configuration and proceeds to generate a ConfigMap 
+The `CreateJob` function begins by validating the precaching job configuration and proceeds to generate a ConfigMap
 containing the list of images to be pre-cached.
 
 ### 3. Kubernetes Job Creation
 
-After the ConfigMap is created, the function proceeds to generate a Kubernetes Job based on the provided configuration. 
-This Job utilizes a workload image, and its primary responsibility is to execute the pre-caching process using the `podman` 
+After the ConfigMap is created, the function proceeds to generate a Kubernetes Job based on the provided configuration.
+This Job utilizes a workload image, and its primary responsibility is to execute the pre-caching process using the `podman`
 CLI.
 
 ### 4. Job Execution and Monitoring
 
-The Job is created within the Kubernetes cluster, initiating the pre-caching process. The status of the job is monitored, 
-and relevant information is logged, including whether the job is active, succeeded, or failed. Additionally, a progress 
-summary is extracted from a specified status file (`precache_status.json`), providing details on the total, pulled, skipped, 
+The Job is created within the Kubernetes cluster, initiating the pre-caching process. The status of the job is monitored,
+and relevant information is logged, including whether the job is active, succeeded, or failed. Additionally, a progress
+summary is extracted from a specified status file (`precache_status.json`), providing details on the total, pulled, skipped,
 and failed images.
 
 ### 5. Job Cleanup
 
-The `Cleanup` function is responsible for deleting the resources created during the pre-caching process. This includes 
+The `Cleanup` function is responsible for deleting the resources created during the pre-caching process. This includes
 deleting the Kubernetes Job, ConfigMap, and the progress tracker file.
 
 ## Example Usage of Configuration
 
-To instantiate a new `Config` instance, the `NewConfig` function is provided. It allows customization of configuration 
+To instantiate a new `Config` instance, the `NewConfig` function is provided. It allows customization of configuration
 parameters by passing key-value pairs as arguments. For example:
 
 ```go

--- a/hack/Dockerfile.markdownlint
+++ b/hack/Dockerfile.markdownlint
@@ -1,0 +1,7 @@
+# Following example of: https://github.com/openshift/enhancements/blob/master/hack/Dockerfile.markdownlint
+FROM registry.access.redhat.com/ubi9/ubi:latest
+WORKDIR /workdir
+RUN dnf install -y git golang
+COPY install-markdownlint.sh /tmp
+RUN /tmp/install-markdownlint.sh
+ENTRYPOINT /workdir/hack/markdownlint.sh

--- a/hack/install-markdownlint.sh
+++ b/hack/install-markdownlint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -xe
+# Following example of: https://github.com/openshift/enhancements/blob/master/hack/install-markdownlint.sh
+
+cat /etc/redhat-release || echo "No /etc/redhat-release"
+
+if grep -q 'Red Hat Enterprise Linux' /etc/redhat-release; then
+    # install the config file for the RPM repository with node 14
+    # steps taken from https://rpm.nodesource.com/setup_14.x
+    yum module disable -y nodejs
+    curl -sL -o '/tmp/nodesource.rpm' 'https://rpm.nodesource.com/pub_14.x/el/8/x86_64/nodesource-release-el8-1.noarch.rpm'
+    rpm -i --nosignature --force /tmp/nodesource.rpm
+    yum -y install nodejs
+else
+    # Fedora has a module we can use
+    dnf -y module enable nodejs:16
+    dnf -y install nodejs
+fi
+
+npm install -g markdownlint@v0.25.1 markdownlint-cli2@v0.4.0

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+# Following example of: https://github.com/openshift/enhancements/blob/master/hack/markdownlint.sh
+
+# trap errors, including the exit code from the command failed
+trap 'handle_exit $?' EXIT
+
+function handle_exit {
+    # If the exit code we were given indicates an error, suggest that
+    # the author run the linter locally.
+    if [ "$1" != "0" ]; then
+    cat - <<EOF
+
+To run the linter on a Linux system with podman, run "make markdownlint"
+after committing your changes locally.
+
+EOF
+    fi
+}
+
+markdownlint-cli2 '**/*.md' !'vendor/**/*.md'
+

--- a/lca-cli/README.md
+++ b/lca-cli/README.md
@@ -37,7 +37,7 @@ In that direction, the tool does the following at a high level:
 Building the binary locally.
 
 ```shell
--> make cli-build 
+-> make cli-build
 go mod tidy
 Running go fmt
 go fmt ./...
@@ -57,7 +57,7 @@ To see the tool's help on your local host, run the following command:
 lca-cli assists LCA in Image Based Install (IBI) and Image Based Upgrade (IBU) workflows.
 
   Find more information at: https://github.com/openshift-kni/lifecycle-agent/blob/main/lca-cli/README.md
-        
+
 Usage:
   lca-cli [command]
 


### PR DESCRIPTION
This introduces the markdown linter. Once merged, we can add a CI job in openshift/release to create a test run on PRs that include changes to MD files.