### PR TITLE
Add recert hostname arg to skip control-plane revision triggers

### DIFF
--- a/internal/recert/recert.go
+++ b/internal/recert/recert.go
@@ -25,6 +25,7 @@ type RecertConfig struct {
 	ForceExpire       bool     `json:"force_expire,omitempty"`
 	EtcdEndpoint      string   `json:"etcd_endpoint,omitempty"`
 	ClusterRename     string   `json:"cluster_rename,omitempty"`
+	Hostname          string   `json:"hostname,omitempty"`
 	SummaryFile       string   `json:"summary_file,omitempty"`
 	SummaryFileClean  string   `json:"summary_file_clean,omitempty"`
 	StaticDirs        []string `json:"static_dirs,omitempty"`
@@ -43,6 +44,10 @@ func CreateRecertConfigFile(clusterInfo *seedreconfig.SeedReconfiguration, seedC
 	config.ClusterRename = fmt.Sprintf("%s:%s", clusterInfo.ClusterName, clusterInfo.BaseDomain)
 	if clusterInfo.InfraID != "" {
 		config.ClusterRename = fmt.Sprintf("%s:%s", config.ClusterRename, clusterInfo.InfraID)
+	}
+
+	if clusterInfo.Hostname != seedClusterInfo.SNOHostname {
+		config.Hostname = clusterInfo.Hostname
 	}
 
 	config.SummaryFile = SummaryFile


### PR DESCRIPTION
This change leverages recert's latest OCP post-process [hostname](https://github.com/rh-ecosystem-edge/recert/pull/82) feature, which makes OCP's control-plane cluster operators (i.e. etcd, kube-apiserver, kube-controller-manager, kube-scheduler) happy, so that the latter won't trigger additional revisions. Thus reducing the time OCP needs to stabilize after recert.