### PR TITLE
Add recert IP arg to skip control-plane revision triggers

### DIFF
--- a/internal/recert/recert.go
+++ b/internal/recert/recert.go
@@ -26,6 +26,7 @@ type RecertConfig struct {
 	EtcdEndpoint     string `json:"etcd_endpoint,omitempty"`
 	ClusterRename    string `json:"cluster_rename,omitempty"`
 	Hostname         string `json:"hostname,omitempty"`
+	IP               string `json:"ip,omitempty"`
 	// We intentionally don't omitEmpty this field because an empty string here
 	// means "delete the kubeadmin password secret" while a complete omission
 	// of the field means "don't touch the secret". We never want the latter,
@@ -53,6 +54,10 @@ func CreateRecertConfigFile(seedReconfig *seedreconfig.SeedReconfiguration, seed
 
 	if seedReconfig.Hostname != seedClusterInfo.SNOHostname {
 		config.Hostname = seedReconfig.Hostname
+	}
+
+	if seedReconfig.NodeIP != seedClusterInfo.NodeIP {
+		config.IP = seedReconfig.NodeIP
 	}
 
 	config.SummaryFile = SummaryFile

--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -194,17 +194,6 @@ func (p *PostPivot) etcdPostPivotOperations(ctx context.Context, reconfiguration
 	}
 	defer cli.Close()
 
-	// cleanup etcd keys
-	p.log.Info("Cleaning up etcd keys from seed data")
-	keysToDelete := []string{"/kubernetes.io/configmaps/openshift-etcd/etcd-endpoints"}
-
-	for _, key := range keysToDelete {
-		_, err = cli.Delete(ctx, key)
-		if err != nil {
-			return err
-		}
-	}
-
 	newEtcdIp := reconfigurationInfo.NodeIP
 	if utils.IsIpv6(newEtcdIp) {
 		newEtcdIp = fmt.Sprintf("[%s]", newEtcdIp)


### PR DESCRIPTION
Similar to b6c5db194b205dd86e2227b630907b92f597b724 but for IP instead of hostname

This change leverages recert's latest OCP post-process IP feature, which makes OCP's control-plane cluster operators (i.e. etcd, kube-apiserver, authentication, etc) happy, so that they won't trigger additional revisions. Thus reducing the time OCP needs to stabilize after recert.

For more details please check here:
- https://github.com/rh-ecosystem-edge/recert/pull/89