### PR TITLE
Temporary workaround for password bug

### DIFF
--- a/internal/recert/recert.go
+++ b/internal/recert/recert.go
@@ -95,6 +95,7 @@ func CreateRecertConfigFileForSeedCreation(path string) error {
 	config := createBasicEmptyRecertConfig()
 	config.SummaryFileClean = "/kubernetes/recert-seed-summary.yaml"
 	config.ForceExpire = true
+	config.KubeadminPasswordHash = "$2a$10$seed-placeholder-password-hash"
 	return utils.MarshalToFile(config, path)
 }
 


### PR DESCRIPTION
Right now post-pivot recert fails because this lack of hash causes the
pre-pivot expiration recert to delete the secret, which must not be
deleted.

See [MGMT-16801](https://issues.redhat.com//browse/MGMT-16801) for full future solution, but for now to unblock IBU
upgrades let's just place a placeholder hash in there.

Until the full solution is implemented, seeds will still have their
kubeadmin broken following an image generation.