### PR TITLE
Add recert image to containers.list only if not exists

### DIFF
--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -229,8 +229,9 @@ func (s *SeedCreator) createContainerList(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	s.log.Infof("Adding recert %s image to image list", s.recertContainerImage)
-	images = append(images, s.recertContainerImage)
+	images = utils.AppendToListIfNotExists(images, s.recertContainerImage)
 
 	s.log.Infof("Creating %s file", containersListFileName)
 	if err := os.WriteFile(containersListFileName, []byte(strings.Join(images, "\n")), 0o600); err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"text/template"
 
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -322,4 +323,11 @@ func UpdatePullSecretFromDockerConfig(ctx context.Context, c client.Client, dock
 	}
 
 	return newPullSecret, nil
+}
+
+func AppendToListIfNotExists(list []string, value string) []string {
+	if lo.Contains(list, value) {
+		return list
+	}
+	return append(list, value)
 }


### PR DESCRIPTION
Removes the duplication of the recert image from the `containers.list` in seed images. As a result, it also reduces an extra operation while pre-cachingin IBU.

The recert image was already added to the node (and hence included in the `containers.list`) before by the seedgen CR.