### PR TITLE
Fix post-pivot for disconn envs

### DIFF
--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -191,7 +191,7 @@ func (p *PostPivot) recert(ctx context.Context, seedReconfiguration *clusterconf
 	defer cancel()
 	_ = wait.PollUntilContextCancel(ctxWithTimeout, time.Second, true, func(ctx context.Context) (bool, error) {
 		p.log.Info("pulling recert image")
-		if _, err := p.ops.RunInHostNamespace("podman", "pull", seedClusterInfo.RecertImagePullSpec); err != nil {
+		if _, err := p.ops.RunInHostNamespace("podman", "pull", "--authfile", common.ImageRegistryAuthFile, seedClusterInfo.RecertImagePullSpec); err != nil {
 			p.log.Warnf("failed to pull recert image, will retry, err: %s", err.Error())
 			return false, nil
 		}


### PR DESCRIPTION
In disconnected environments, post-pivot fails pulling the recert image with below error.

```
Feb 08 11:41:17 zt-sno2.inbound.vz.bos2.lab lca-cli[2609]: time="2024-02-08 11:41:17" level=info msg="pulling recert image"
Feb 08 11:41:17 zt-sno2.inbound.vz.bos2.lab lca-cli[2609]: time="2024-02-08 11:41:17" level=info msg="Executing podman with args [pull jumphost.inbound.vz.bos2.lab:8443/edge-infrastructure/recert:v0]"
Feb 08 11:45:20 zt-sno2.inbound.vz.bos2.lab podman[6040]: 2024-02-08 11:41:17.963436474 +0000 UTC m=+0.078100691 image pull  jumphost.inbound.vz.bos2.lab:8443/edge-infrastructure/recert:v0
Feb 08 11:45:20 zt-sno2.inbound.vz.bos2.lab lca-cli[2609]: time="2024-02-08 11:45:20" level=warning msg="failed to pull recert image, will retry, err: Trying to pull jumphost.inbound.vz.bos2.lab:8443/edge-infrastructure/recert:v0...\ntime=\"2024-02-08T11:42:17Z\" level=warning msg=\"Failed, retrying in 1s ... (1/3). Error: initializing source docker://jumphost.inbound.vz.bos2.lab:8443/edge-infrastructure/recert:v0: pinging container registry jumphost.inbound.vz.bos2.lab:8443: Get \\\"https://jumphost.inbound.vz.bos2.lab:8443/v2/\\\": dial tcp: lookup jumphost.inbound.vz.bos2.lab: i/o timeout\"\ntime=\"2024-02-08T11:43:18Z\" level=warning msg=\"Failed, retrying in 1s ... (2/3). Error: initializing source docker://jumphost.inbound.vz.bos2.lab:8443/edge-infrastructure/recert:v0: pinging container registry jumphost.inbound.vz.bos2.lab:8443: Get \\\"https://jumphost.inbound.vz.bos2.lab:8443/v2/\\\": dial tcp: lookup jumphost.inbound.vz.bos2.lab: i/o timeout\"\ntime=\"2024-02-08T11:44:19Z\" level=warning msg=\"Failed, retrying in 1s ... (3/3). Error: initializing source docker://jumphost.inbound.vz.bos2.lab:8443/edge-infrastructure/recert:v0: pinging container registry jumphost.inbound.vz.bos2.lab:8443: Get \\\"https://jumphost.inbound.vz.bos2.lab:8443/v2/\\\": dial tcp: lookup jumphost.inbound.vz.bos2.lab: i/o timeout\"\nError: initializing source docker://jumphost.inbound.vz.bos2.lab:8443/edge-infrastructure/recert:v0: pinging container registry jumphost.inbound.vz.bos2.lab:8443: Get \"https://jumphost.inbound.vz.bos2.lab:8443/v2/\": dial tcp: lookup jumphost.inbound.vz.bos2.lab: i/o timeout\n: exit status 125"
Feb 08 11:45:20 zt-sno2.inbound.vz.bos2.lab lca-cli[2609]: time="2024-02-08 11:45:20" level=info msg="pulling recert image"
Feb 08 11:45:20 zt-sno2.inbound.vz.bos2.lab lca-cli[2609]: time="2024-02-08 11:45:20" level=info msg="Executing podman with args [pull jumphost.inbound.vz.bos2.lab:8443/edge-infrastructure/recert:v0]"
Feb 08 11:48:58 zt-sno2.inbound.vz.bos2.lab systemd[1]: installation-configuration.service: Main process exited, code=killed, status=15/TERM
Feb 08 11:48:58 zt-sno2.inbound.vz.bos2.lab systemd[1]: installation-configuration.service: Failed with result 'signal'.
Feb 08 11:48:58 zt-sno2.inbound.vz.bos2.lab systemd[1]: Stopped Image base SNO configuration script.

```