### PR TITLE
MGMT-16652: make configuration label part of seed reconfiguration api package as consts

### DIFF
--- a/api/seedreconfig/seedreconfig.go
+++ b/api/seedreconfig/seedreconfig.go
@@ -4,6 +4,8 @@ type PEM string
 
 const (
 	SeedReconfigurationVersion = 1
+	// BlockDeviceLabel is a configuration volume label to set while providing iso with configuration files
+	BlockDeviceLabel = "cluster-config"
 )
 
 // SeedReconfiguration contains all the information that is required to

--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -71,7 +71,6 @@ const (
 	pullSecretFileName   = "pull-secret.json"
 	seedPullSecretSuffix = "_seed"
 
-	blockDeviceLabel = "cluster-config"
 	// TODO: change after all the components will move to blockDeviceLabel
 	OldblockDeviceLabel    = "relocation-config"
 	blockDeviceMountFolder = "/mnt/config"
@@ -609,7 +608,8 @@ func (p *PostPivot) createPullSecretManifest(pullSecret, pullSecretManifest stri
 // in case device was provided we are mounting it and copying files to configFolder
 func (p *PostPivot) waitForConfiguration(ctx context.Context, configFolder, blockDeviceMountFolder string) error {
 	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-		p.log.Infof("waiting for block device with label %s or for configuration folder %s", blockDeviceLabel, configFolder)
+		p.log.Infof("waiting for block device with label %s or for configuration folder %s",
+			clusterconfig_api.BlockDeviceLabel, configFolder)
 		if _, err := os.Stat(configFolder); err == nil {
 			return true, nil
 		}
@@ -619,8 +619,8 @@ func (p *PostPivot) waitForConfiguration(ctx context.Context, configFolder, bloc
 			return false, nil
 		}
 		for _, bd := range blockDevices {
-			// TODO: change after all the components will move to blockDeviceLabel
-			if lo.Contains([]string{blockDeviceLabel, OldblockDeviceLabel}, bd.Label) {
+			// TODO: change after all the components will move to clusterconfig_api.BlockDeviceLabel
+			if lo.Contains([]string{clusterconfig_api.BlockDeviceLabel, OldblockDeviceLabel}, bd.Label) {
 				// in case of error while mounting device we exit wait and return the error
 				if err := p.setupConfigurationFolder(bd.Name, blockDeviceMountFolder, filepath.Dir(configFolder)); err != nil {
 					return true, err

--- a/lca-cli/postpivot/postpivot_test.go
+++ b/lca-cli/postpivot/postpivot_test.go
@@ -388,7 +388,8 @@ func TestWaitForConfiguration(t *testing.T) {
 				}
 			}
 			if tc.listBlockDevicesSucceeds {
-				mockOps.EXPECT().ListBlockDevices().Return([]ops.BlockDevice{{Name: deviceName, Label: blockDeviceLabel}}, nil).Times(1)
+				mockOps.EXPECT().ListBlockDevices().Return([]ops.BlockDevice{{Name: deviceName,
+					Label: clusterconfig_api.BlockDeviceLabel}}, nil).Times(1)
 				if tc.mountSucceeds {
 					mockOps.EXPECT().Mount(deviceName, gomock.Any()).Return(nil).Times(1)
 					mockOps.EXPECT().Umount(deviceName).Return(nil).Times(1)


### PR DESCRIPTION
[MGMT-16652](https://issues.redhat.com//browse/MGMT-16652): make configuration label part of seed reconfiguration api package as consts
