### PR TITLE
MGMT-16764: Add pre-caching modes to ibi command in LCA

### DIFF
--- a/lca-cli/cmd/ibi.go
+++ b/lca-cli/cmd/ibi.go
@@ -38,6 +38,8 @@ var ibi = &cobra.Command{
 var seedImage string
 var seedVersion string
 var pullSecretFile string
+var precacheBestEffort bool
+var precacheDisabled bool
 
 func init() {
 
@@ -48,7 +50,12 @@ func init() {
 	ibi.Flags().StringVarP(&seedVersion, "seed-version", "", "", "Seed version.")
 	ibi.Flags().StringVarP(&authFile, "authfile", "a", "", "The path to the authentication file of the container registry of seed image.")
 	ibi.Flags().StringVarP(&pullSecretFile, "pullSecretFile", "p", "", "The path to the pull secret file for precache process.")
-
+	ibi.Flags().BoolVarP(&precacheBestEffort, "precache-best-effort", "pb", false, "Set image precache to best effort mode")
+	ibi.Flags().BoolVarP(&precacheDisabled, "precache-disabled", "pd", false, "Disable precaching, no image precaching will run")
+	ibi.MarkFlagRequired("seed-image")
+	ibi.MarkFlagRequired("seed-version")
+	ibi.MarkFlagRequired("authfile")
+	ibi.MarkFlagRequired("pullSecretFile")
 }
 
 func runIBI() {
@@ -57,7 +64,8 @@ func runIBI() {
 	rpmOstreeClient := ostree.NewClient("lca-cli", hostCommandsExecutor)
 	ostreeClient := ostreeclient.NewClient(hostCommandsExecutor, true)
 
-	ibiRunner := ibipreparation.NewIBIPrepare(log, ops.NewOps(log, hostCommandsExecutor), rpmOstreeClient, ostreeClient, seedImage, authFile, pullSecretFile, seedVersion)
+	ibiRunner := ibipreparation.NewIBIPrepare(log, ops.NewOps(log, hostCommandsExecutor), rpmOstreeClient, ostreeClient,
+		seedImage, authFile, pullSecretFile, seedVersion, precacheBestEffort, precacheDisabled)
 	if err := ibiRunner.Run(); err != nil {
 		log.Fatal(err)
 	}

--- a/lca-cli/ibi-preparation/ibipreparation.go
+++ b/lca-cli/ibi-preparation/ibipreparation.go
@@ -78,13 +78,5 @@ func (i *IBIPrepare) Run() error {
 		return fmt.Errorf("failed to create status file dir, err %w", err)
 	}
 	i.log.Infof("chroot %s successful", common.Host)
-
-	status, err := workload.PullImages(imageList, i.pullSecretFile)
-	if err != nil {
-		return err
-	}
-	if err := workload.ValidatePrecache(status, false); err != nil {
-		return err
-	}
-	return nil
+	return workload.Precache(imageList, i.pullSecretFile, false)
 }

--- a/main/precache-workload/main.go
+++ b/main/precache-workload/main.go
@@ -106,16 +106,7 @@ func main() {
 	if err != nil {
 		terminateOnError(err)
 	}
-	// Pre-cache images
-	status, err := workload.PullImages(precacheSpec, authFile)
-	if err != nil {
-		terminateOnError(fmt.Errorf("encountered error while pre-caching images, error: %w", err))
+	if err := workload.Precache(precacheSpec, authFile, bestEffort); err != nil {
+		terminateOnError(err)
 	}
-	log.Info("Completed executing pre-caching, no errors encountered!")
-
-	if err := workload.ValidatePrecache(status, bestEffort); err != nil {
-		terminateOnError(fmt.Errorf("failed to pre-cache one or more images"))
-	}
-
-	log.Info("Pre-cached images successfully.")
 }


### PR DESCRIPTION
[MGMT-16764](https://issues.redhat.com//browse/MGMT-16764): creating one function for precache and precache validation
[MGMT-16764](https://issues.redhat.com//browse/MGMT-16764): Add pre-caching modes to ibi command in LCA
Adding disable precaching and best-effort flags