### PR TITLE
Fail upgrade if any OADP configmap issues detected at upgrade stage

### DIFF
--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -369,7 +369,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 			},
 		},
 		{
-			name: "backup failed validation request medium requeue",
+			name: "backup failed validation request no requeue",
 			args: args{
 				ibu: lcav1alpha1.ImageBasedUpgrade{},
 			},
@@ -377,19 +377,25 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 				return [][]*velerov1.Backup{},
 					backuprestore.NewBRFailedValidationError("Backup", "this is a test - FailedValidation")
 			},
-			want:    requeueWithMediumInterval(),
+			want:    doNotRequeue(),
 			wantErr: assert.NoError,
 			wantConditions: []metav1.Condition{
 				{
+					Type:    string(utils.ConditionTypes.UpgradeCompleted),
+					Reason:  string(utils.ConditionReasons.Failed),
+					Status:  metav1.ConditionFalse,
+					Message: "Upgrade failed",
+				},
+				{
 					Type:    string(utils.ConditionTypes.UpgradeInProgress),
-					Reason:  string(utils.ConditionReasons.InProgress),
-					Status:  metav1.ConditionTrue,
+					Reason:  string(utils.ConditionReasons.Failed),
+					Status:  metav1.ConditionFalse,
 					Message: "error while getting sorted backups from configmap: this is a test - FailedValidation",
 				},
 			},
 		},
 		{
-			name: "backup not found in configmap request medium requeue",
+			name: "backup not found in configmap request no requeue",
 			args: args{
 				ibu: lcav1alpha1.ImageBasedUpgrade{},
 			},
@@ -397,13 +403,19 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 				return nil,
 					backuprestore.NewBRNotFoundError("this is a test - NotFound")
 			},
-			want:    requeueWithMediumInterval(),
+			want:    doNotRequeue(),
 			wantErr: assert.NoError,
 			wantConditions: []metav1.Condition{
 				{
+					Type:    string(utils.ConditionTypes.UpgradeCompleted),
+					Reason:  string(utils.ConditionReasons.Failed),
+					Status:  metav1.ConditionFalse,
+					Message: "Upgrade failed",
+				},
+				{
 					Type:    string(utils.ConditionTypes.UpgradeInProgress),
-					Reason:  string(utils.ConditionReasons.InProgress),
-					Status:  metav1.ConditionTrue,
+					Reason:  string(utils.ConditionReasons.Failed),
+					Status:  metav1.ConditionFalse,
 					Message: "error while getting sorted backups from configmap: this is a test - NotFound",
 				},
 			},
@@ -506,13 +518,19 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 				return backuprestore.NewBRFailedValidationError("Restore", "ExportRestoresToDir validation failed")
 			},
 
-			want:    requeueWithMediumInterval(),
+			want:    doNotRequeue(),
 			wantErr: assert.NoError,
 			wantConditions: []metav1.Condition{
 				{
+					Type:    string(utils.ConditionTypes.UpgradeCompleted),
+					Reason:  string(utils.ConditionReasons.Failed),
+					Status:  metav1.ConditionFalse,
+					Message: "Upgrade failed",
+				},
+				{
 					Type:    string(utils.ConditionTypes.UpgradeInProgress),
-					Reason:  string(utils.ConditionReasons.InProgress),
-					Status:  metav1.ConditionTrue,
+					Reason:  string(utils.ConditionReasons.Failed),
+					Status:  metav1.ConditionFalse,
 					Message: "ExportRestoresToDir validation failed",
 				},
 			},

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -62,8 +62,18 @@ func GetConfigMap(ctx context.Context, c client.Client, configMap v1alpha1.Confi
 // GetConfigMaps retrieves a collection of configmaps from cluster
 func GetConfigMaps(ctx context.Context, c client.Client, configMaps []v1alpha1.ConfigMapRef) ([]corev1.ConfigMap, error) {
 	var cms []corev1.ConfigMap
+	var cmSet = map[v1alpha1.ConfigMapRef]bool{}
+	var uniqueCms []v1alpha1.ConfigMapRef
 
+	// Remove duplicate configmaps
 	for _, cm := range configMaps {
+		if _, found := cmSet[cm]; !found {
+			cmSet[cm] = true
+			uniqueCms = append(uniqueCms, cm)
+		}
+	}
+
+	for _, cm := range uniqueCms {
 		existingCm, err := GetConfigMap(ctx, c, cm)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
[OCPBUGS-29120](https://issues.redhat.com/browse/OCPBUGS-29120)

The oadp configmap should have been validated at prep stage but it may be a rare case where the configmap is deleted/changed after prep, so for any configmap issues that appear in the upgrade stage, we fail the upgrade. Also, for identical configmaps defined in spec, we only process them once. 




/cc @browsell @donpenney @jc-rh 