### PR TITLE
Limit scope of backup apply label to one backup

### DIFF
--- a/docs/backuprestore-with-oadp.md
+++ b/docs/backuprestore-with-oadp.md
@@ -64,12 +64,12 @@ spec:
    - deployments
 ```
 
-By adding this annotation, LCA will limit the scope exclusively to those resources. LCA will parse the annotations and apply `lca.openshift.io/backup: true` label to those resources. LCA then adds this labelSelector when creating the backup CR:
+By adding this annotation, LCA will limit the scope exclusively to those resources. LCA will parse the annotations and apply `lca.openshift.io/backup: <backup-name>` label to those resources. LCA then adds this labelSelector when creating the backup CR:
 
 ```yaml
 labelSelector:
   matchLabels:
-    lca.openshift.io/backup: true
+    lca.openshift.io/backup: <backup-name>
 ```
 
 ## Install OADP and configure OADP on target cluster via ZTP GitOps

--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -211,7 +211,7 @@ func (h *BRHandler) applyBackupLabels(ctx context.Context, backup *velerov1.Back
 	if err != nil {
 		return fmt.Errorf("failed to get objs from apply-label annotations: %w", err)
 	}
-	payload := []byte(fmt.Sprintf(`[{"op":"add","path":"/metadata/labels","value":{"%s":"true"}}]`, backupLabel))
+	payload := []byte(fmt.Sprintf(`[{"op":"add","path":"/metadata/labels","value":{"%s":"%s"}}]`, backupLabel, backup.GetName()))
 	for _, obj := range objs {
 		err := patchObj(ctx, h.DynamicClient, &obj, false, payload) //nolint:gosec
 		if err != nil {
@@ -226,7 +226,6 @@ func (h *BRHandler) applyBackupLabels(ctx context.Context, backup *velerov1.Back
 }
 
 func (h *BRHandler) cleanupBackupLabels(ctx context.Context, backup *velerov1.Backup) error {
-	h.Log.Info("start clean up backup for something")
 	objs, err := getObjsFromAnnotations(backup)
 	if err != nil {
 		return fmt.Errorf("failed to get objs from apply-label annotations: %w", err)
@@ -235,7 +234,6 @@ func (h *BRHandler) cleanupBackupLabels(ctx context.Context, backup *velerov1.Ba
 	escaped := strings.Replace(backupLabel, "/", "~1", 1)
 	payload := []byte(fmt.Sprintf(`[{"op":"remove","path":"/metadata/labels/%s"}]`, escaped))
 	for _, obj := range objs {
-		h.Log.Info("clean up back label for obj")
 		err := patchObj(ctx, h.DynamicClient, &obj, false, payload) //nolint:gosec
 		if err != nil {
 			h.Log.Error(err, "failed to remove backup label", "name", obj.Name, "namespace", obj.Namespace,

--- a/internal/backuprestore/backup_test.go
+++ b/internal/backuprestore/backup_test.go
@@ -339,7 +339,7 @@ func TestApplyBackupLabels(t *testing.T) {
 			Log:           ctrl.Log.WithName("BackupRestore"),
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			backup := fakeBackupCr("a", "1", "b")
+			backup := fakeBackupCr("backupName", "1", "b")
 			var objStrings []string
 			for _, obj := range tc.annotationObjs {
 				v := fmt.Sprintf("%s/%s/%s/", obj.Group, obj.Version, obj.Resource)
@@ -366,14 +366,14 @@ func TestApplyBackupLabels(t *testing.T) {
 					}).Namespace(meta.Namespace).Get(context.TODO(), meta.Name, metav1.GetOptions{})
 				}
 				expect := newUnstructuredWithLabel(
-					"group/version", "resource", meta.Namespace, meta.Name, backupLabel, "true")
+					"group/version", "resource", meta.Namespace, meta.Name, backupLabel, backup.GetName())
 				assert.NoError(t, err)
 				if !equality.Semantic.DeepEqual(get, expect) {
 					t.Fatal(cmp.Diff(expect, get))
 				}
 			}
 			if len(tc.annotationObjs) > 0 {
-				assert.Equal(t, backup.Spec.LabelSelector.MatchLabels[backupLabel], "true")
+				assert.Equal(t, backup.Spec.LabelSelector.MatchLabels[backupLabel], backup.GetName())
 			}
 		})
 	}

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -220,7 +220,7 @@ func setBackupLabelSelector(backup *velerov1.Backup) {
 	if backup.Spec.LabelSelector == nil {
 		backup.Spec.LabelSelector = &metav1.LabelSelector{}
 	}
-	metav1.AddLabelToSelector(backup.Spec.LabelSelector, backupLabel, "true")
+	metav1.AddLabelToSelector(backup.Spec.LabelSelector, backupLabel, backup.GetName())
 }
 
 func setBackupLabel(backup *velerov1.Backup, newLabels map[string]string) {
@@ -320,8 +320,8 @@ func (h *BRHandler) ValidateOadpConfigmap(ctx context.Context, content []lcav1al
 	}
 
 	// Check if we can apply backup label to objects included in apply-backup annotation
-	payload := []byte(fmt.Sprintf(`[{"op":"add","path":"/metadata/labels","value":{"%s":"true"}}]`, backupLabel))
 	for _, backup := range backups {
+		payload := []byte(fmt.Sprintf(`[{"op":"add","path":"/metadata/labels","value":{"%s":"%s"}}]`, backupLabel, backup.GetName()))
 		objs, err := getObjsFromAnnotations(backup)
 		if err != nil {
 			return NewBRFailedValidationError("OADP", err.Error())

--- a/internal/backuprestore/common_test.go
+++ b/internal/backuprestore/common_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestSetBackupLabelSelector(t *testing.T) {
 	t.Run("set backup label selector", func(t *testing.T) {
-		backup := fakeBackupCr("a", "1", "b")
+		backup := fakeBackupCr("backupName", "1", "b")
 		setBackupLabelSelector(backup)
-		assert.Equal(t, "true", backup.Spec.LabelSelector.MatchLabels[backupLabel])
+		assert.Equal(t, backup.GetName(), backup.Spec.LabelSelector.MatchLabels[backupLabel])
 	})
 }


### PR DESCRIPTION
Before this commit the scope of resources to be backed up using apply-backup label was cluster wide. So each individual backup resource made a backup of every resource it matched with.
Changing the value of label selector to the name of backup CR fixes this issue.

/cc @Missxiaoguo @browsell 