### PR TITLE
CNF-11236: Apply extra manifests in the order specified by the `apply-wave` annotation

### DIFF
--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package common
 
+import (
+	"math"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
 // Common constants mainly used by packages in lca-cli
 const (
 	VarFolder       = "/var"
@@ -84,6 +90,13 @@ const (
 
 	NMConnectionFolder = "/etc/NetworkManager/system-connections"
 	NetworkDir         = "network-configuration"
+	ApplyWaveAnn       = "lca.openshift.io/apply-wave"
+	defaultApplyWave   = math.MaxInt32 // 2147483647, an enough large number
+)
+
+var (
+	BackupGvk  = schema.GroupVersionKind{Group: "velero.io", Kind: "Backup", Version: "v1"}
+	RestoreGvk = schema.GroupVersionKind{Group: "velero.io", Kind: "Restore", Version: "v1"}
 )
 
 // CertPrefixes is the list of certificate prefixes to be backed up

--- a/internal/common/manifest_helpers.go
+++ b/internal/common/manifest_helpers.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func SortAndGroupByApplyWave[T metav1.Object](objs []T) ([][]T, error) {
+	groups := [][]T{}
+	if len(objs) == 0 {
+		return groups, nil
+	}
+	sort.SliceStable(objs, func(i, j int) bool {
+		iStr, iExist := objs[i].GetAnnotations()[ApplyWaveAnn]
+		jStr, jExist := objs[j].GetAnnotations()[ApplyWaveAnn]
+		// ignoring errors here since they will be handled when the slice is traversed
+		iVal, _ := strconv.Atoi(iStr)
+		jVal, _ := strconv.Atoi(jStr)
+		if !jExist || jStr == "" {
+			jVal = defaultApplyWave
+		}
+		if !iExist || iStr == "" {
+			iVal = defaultApplyWave
+		}
+		if iVal != jVal {
+			return iVal < jVal
+		}
+		return objs[i].GetName() < objs[j].GetName()
+	})
+	previousGroupValue := 0
+	var groupValue int
+	var err error
+	for i, obj := range objs {
+		groupStr, ok := objs[i].GetAnnotations()[ApplyWaveAnn]
+		if !ok || groupStr == "" {
+			groupValue = defaultApplyWave
+		} else {
+			groupValue, err = strconv.Atoi(groupStr)
+			if err != nil {
+				return groups, fmt.Errorf("error convert: %w", err)
+			}
+		}
+		if i == 0 || groupValue != previousGroupValue {
+			previousGroupValue = groupValue
+			groups = append(groups, []T{})
+		}
+		index := len(groups) - 1
+		groups[index] = append(groups[index], obj)
+	}
+	return groups, nil
+}
+
+func ExtractResourcesFromConfigmaps[T metav1.Object](
+	ctx context.Context, configmaps []corev1.ConfigMap, gvk schema.GroupVersionKind,
+) ([]T, error) {
+	var objs []T
+
+	for _, cm := range configmaps {
+		for _, value := range cm.Data {
+			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewBufferString(value), 4096)
+			for {
+				resource := unstructured.Unstructured{}
+				err := decoder.Decode(&resource)
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						// Reach the end of the data, exit the loop
+						break
+					}
+					return nil, fmt.Errorf("failed to decode file: %w", err)
+				}
+
+				if resource.GroupVersionKind() != gvk {
+					continue
+				}
+
+				obj := new(T)
+				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, obj); err != nil {
+					return nil, fmt.Errorf("failed to convert to unstructured: %w", err)
+				}
+				objs = append(objs, *obj)
+			}
+		}
+	}
+	return objs, nil
+}

--- a/internal/common/manifest_helpers_test.go
+++ b/internal/common/manifest_helpers_test.go
@@ -1,0 +1,214 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func fakeBackupCr(name, applyWave, backupResource string) *velerov1.Backup {
+	backup := &velerov1.Backup{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       BackupGvk.Kind,
+			APIVersion: BackupGvk.Group + "/" + BackupGvk.Version,
+		},
+	}
+	backup.SetName(name)
+	backup.SetNamespace("ns")
+	backup.SetAnnotations(map[string]string{ApplyWaveAnn: applyWave})
+
+	backup.Spec = velerov1.BackupSpec{
+		IncludedNamespaces:               []string{"openshift-test"},
+		IncludedNamespaceScopedResources: []string{backupResource},
+	}
+	return backup
+}
+
+func fakeRestoreCr(name, applyWave, backupName string) *velerov1.Restore {
+	restore := &velerov1.Restore{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       RestoreGvk.Kind,
+			APIVersion: RestoreGvk.Group + "/" + RestoreGvk.Version,
+		},
+	}
+	restore.SetName(name)
+	restore.SetNamespace("ns")
+	restore.SetAnnotations(map[string]string{ApplyWaveAnn: applyWave})
+
+	restore.Spec = velerov1.RestoreSpec{
+		BackupName: backupName,
+	}
+	return restore
+}
+
+func TestSortBackupCrs(t *testing.T) {
+	testcases := []struct {
+		name           string
+		resources      []*velerov1.Backup
+		expectedResult [][]*velerov1.Backup
+	}{
+		{
+			name: "Multiple resources contain the same wave number",
+			resources: []*velerov1.Backup{
+				fakeBackupCr("c_backup", "3", "fakeResource"),
+				fakeBackupCr("d_backup", "10", "fakeResource"),
+				fakeBackupCr("a_backup", "3", "fakeResource"),
+				fakeBackupCr("b_backup", "1", "fakeResource"),
+				fakeBackupCr("f_backup", "100", "fakeResource"),
+				fakeBackupCr("e_backup", "100", "fakeResource"),
+			},
+			expectedResult: [][]*velerov1.Backup{{
+				fakeBackupCr("b_backup", "1", "fakeResource"),
+			}, {
+				fakeBackupCr("a_backup", "3", "fakeResource"),
+				fakeBackupCr("c_backup", "3", "fakeResource"),
+			}, {
+				fakeBackupCr("d_backup", "10", "fakeResource"),
+			}, {
+				fakeBackupCr("e_backup", "100", "fakeResource"),
+				fakeBackupCr("f_backup", "100", "fakeResource"),
+			},
+			},
+		},
+		{
+			name: "Multiple resources have no wave number",
+			resources: []*velerov1.Backup{
+				fakeBackupCr("c_backup", "", "fakeResource"),
+				fakeBackupCr("d_backup", "10", "fakeResource"),
+				fakeBackupCr("a_backup", "3", "fakeResource"),
+				fakeBackupCr("b_backup", "1", "fakeResource"),
+				fakeBackupCr("f_backup", "100", "fakeResource"),
+				fakeBackupCr("e_backup", "100", "fakeResource"),
+				fakeBackupCr("g_backup", "", "fakeResource"),
+			},
+			expectedResult: [][]*velerov1.Backup{{
+				fakeBackupCr("b_backup", "1", "fakeResource"),
+			}, {
+				fakeBackupCr("a_backup", "3", "fakeResource"),
+			}, {
+				fakeBackupCr("d_backup", "10", "fakeResource"),
+			}, {
+				fakeBackupCr("e_backup", "100", "fakeResource"),
+				fakeBackupCr("f_backup", "100", "fakeResource"),
+			}, {
+				fakeBackupCr("c_backup", "", "fakeResource"),
+				fakeBackupCr("g_backup", "", "fakeResource"),
+			},
+			},
+		},
+		{
+			name: "All resources have no wave number",
+			resources: []*velerov1.Backup{
+				fakeBackupCr("c_backup", "", "fakeResource"),
+				fakeBackupCr("d_backup", "", "fakeResource"),
+				fakeBackupCr("a_backup", "", "fakeResource"),
+				fakeBackupCr("b_backup", "", "fakeResource"),
+				fakeBackupCr("f_backup", "", "fakeResource"),
+				fakeBackupCr("e_backup", "", "fakeResource"),
+			},
+			expectedResult: [][]*velerov1.Backup{{
+				fakeBackupCr("a_backup", "", "fakeResource"),
+				fakeBackupCr("b_backup", "", "fakeResource"),
+				fakeBackupCr("c_backup", "", "fakeResource"),
+				fakeBackupCr("d_backup", "", "fakeResource"),
+				fakeBackupCr("e_backup", "", "fakeResource"),
+				fakeBackupCr("f_backup", "", "fakeResource"),
+			},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, _ := SortAndGroupByApplyWave[*velerov1.Backup](tc.resources)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestSortRestoreCrs(t *testing.T) {
+	testcases := []struct {
+		name           string
+		resources      []*velerov1.Restore
+		expectedResult [][]*velerov1.Restore
+	}{
+		{
+			name: "Multiple resources contain the same wave number",
+			resources: []*velerov1.Restore{
+				fakeRestoreCr("c_Restore", "3", "backup1"),
+				fakeRestoreCr("d_Restore", "10", "backup1"),
+				fakeRestoreCr("a_Restore", "3", "backup1"),
+				fakeRestoreCr("b_Restore", "1", "backup1"),
+				fakeRestoreCr("f_Restore", "100", "backup1"),
+				fakeRestoreCr("e_Restore", "100", "backup1"),
+			},
+			expectedResult: [][]*velerov1.Restore{{
+				fakeRestoreCr("b_Restore", "1", "backup1"),
+			}, {
+				fakeRestoreCr("a_Restore", "3", "backup1"),
+				fakeRestoreCr("c_Restore", "3", "backup1"),
+			}, {
+				fakeRestoreCr("d_Restore", "10", "backup1"),
+			}, {
+				fakeRestoreCr("e_Restore", "100", "backup1"),
+				fakeRestoreCr("f_Restore", "100", "backup1"),
+			},
+			},
+		},
+		{
+			name: "Multiple resources have no wave number",
+			resources: []*velerov1.Restore{
+				fakeRestoreCr("c_Restore", "", "backup1"),
+				fakeRestoreCr("d_Restore", "10", "backup1"),
+				fakeRestoreCr("a_Restore", "3", "backup1"),
+				fakeRestoreCr("b_Restore", "1", "backup1"),
+				fakeRestoreCr("f_Restore", "100", "backup1"),
+				fakeRestoreCr("e_Restore", "100", "backup1"),
+				fakeRestoreCr("g_Restore", "", "backup1"),
+			},
+			expectedResult: [][]*velerov1.Restore{{
+				fakeRestoreCr("b_Restore", "1", "backup1"),
+			}, {
+				fakeRestoreCr("a_Restore", "3", "backup1"),
+			}, {
+				fakeRestoreCr("d_Restore", "10", "backup1"),
+			}, {
+				fakeRestoreCr("e_Restore", "100", "backup1"),
+				fakeRestoreCr("f_Restore", "100", "backup1"),
+			}, {
+				fakeRestoreCr("c_Restore", "", "backup1"),
+				fakeRestoreCr("g_Restore", "", "backup1"),
+			},
+			},
+		},
+		{
+			name: "All resources have no wave number",
+			resources: []*velerov1.Restore{
+				fakeRestoreCr("c_Restore", "", "backup1"),
+				fakeRestoreCr("d_Restore", "", "backup1"),
+				fakeRestoreCr("a_Restore", "", "backup1"),
+				fakeRestoreCr("b_Restore", "", "backup1"),
+				fakeRestoreCr("f_Restore", "", "backup1"),
+				fakeRestoreCr("e_Restore", "", "backup1"),
+			},
+			expectedResult: [][]*velerov1.Restore{{
+				fakeRestoreCr("a_Restore", "", "backup1"),
+				fakeRestoreCr("b_Restore", "", "backup1"),
+				fakeRestoreCr("c_Restore", "", "backup1"),
+				fakeRestoreCr("d_Restore", "", "backup1"),
+				fakeRestoreCr("e_Restore", "", "backup1"),
+				fakeRestoreCr("f_Restore", "", "backup1"),
+			},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, _ := SortAndGroupByApplyWave[*velerov1.Restore](tc.resources)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}

--- a/internal/extramanifest/extramanifest_test.go
+++ b/internal/extramanifest/extramanifest_test.go
@@ -55,6 +55,8 @@ kind: SriovNetworkNodePolicy
 metadata:
   name: sriov-nnp-mh
   namespace: openshift-sriov-network-operator
+  annotations:
+    lca.openshift.io/apply-wave: "1"   
   spec:
     deviceType: netdevice
     isRdma: false
@@ -64,6 +66,8 @@ kind: SriovNetworkNodePolicy
 metadata:
   name: sriov-nnp-fh
   namespace: openshift-sriov-network-operator
+  annotations:
+    lca.openshift.io/apply-wave: "3"
   spec:
     deviceType: netdevice
     isRdma: true
@@ -75,6 +79,8 @@ kind: SriovNetwork
 metadata:
   name: sriov-nw-mh
   namespace: openshift-sriov-network-operator
+  annotations:
+    lca.openshift.io/apply-wave: "1"
   spec:
     resourceName: mh
 `
@@ -189,10 +195,10 @@ func TestExportExtraManifests(t *testing.T) {
 
 	// Check that the manifests were exported to the correct files
 	expectedFilePaths := []string{
-		filepath.Join(toDir, ExtraManifestPath, "0_SriovNetwork_sriov-nw-mh_openshift-sriov-network-operator.yaml"),
-		filepath.Join(toDir, ExtraManifestPath, "1_SriovNetwork_sriov-nw-fh_openshift-sriov-network-operator.yaml"),
-		filepath.Join(toDir, ExtraManifestPath, "2_SriovNetworkNodePolicy_sriov-nnp-mh_openshift-sriov-network-operator.yaml"),
-		filepath.Join(toDir, ExtraManifestPath, "3_SriovNetworkNodePolicy_sriov-nnp-fh_openshift-sriov-network-operator.yaml"),
+		filepath.Join(toDir, ExtraManifestPath, "group2", "1_SriovNetworkNodePolicy_sriov-nnp-fh_openshift-sriov-network-operator.yaml"),
+		filepath.Join(toDir, ExtraManifestPath, "group1", "1_SriovNetworkNodePolicy_sriov-nnp-mh_openshift-sriov-network-operator.yaml"),
+		filepath.Join(toDir, ExtraManifestPath, "group3", "1_SriovNetwork_sriov-nw-fh_openshift-sriov-network-operator.yaml"),
+		filepath.Join(toDir, ExtraManifestPath, "group1", "2_SriovNetwork_sriov-nw-mh_openshift-sriov-network-operator.yaml"),
 	}
 
 	for _, expectedFile := range expectedFilePaths {


### PR DESCRIPTION
Sort, group by and apply extra manifests with respect to `apply-wave`
annotation

Refactor sort, group by and load grouped manifests to use generics to
remove code duplications

Signed-off-by: Saeid Askari <saskari@redhat.com>