### PR TITLE
MGMT-16968: Remove old rendered machine-configs from seed

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -392,6 +392,7 @@ spec:
           resources:
           - machineconfigs
           verbs:
+          - delete
           - get
           - list
           - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -200,6 +200,7 @@ rules:
   resources:
   - machineconfigs
   verbs:
+  - delete
   - get
   - list
   - watch


### PR DESCRIPTION
Removing machine-configs on seedcreation that are not used by mcp