### PR TITLE
MGMT-16964 Update kdump timestamp in the new stateroot during prep stage

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
-	cp "github.com/otiai10/copy"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -38,6 +36,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+	cp "github.com/otiai10/copy"
 
 	"github.com/openshift-kni/lifecycle-agent/api/v1alpha1"
 )
@@ -177,4 +178,19 @@ func RemoveDuplicates[T comparable](list []T) []T {
 		mp[item] = true
 	}
 	return result
+}
+
+// TouchFile update the access and modification times of a file to the current time
+func TouchFile(filename string) error {
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", filename, err)
+	}
+	defer file.Close()
+
+	// Update the access and modification times to the current time
+	if err := os.Chtimes(filename, time.Now(), time.Now()); err != nil {
+		return fmt.Errorf("failed to update %s: %w", filename, err)
+	}
+	return nil
 }


### PR DESCRIPTION
kdump need to have a timestamp post the time the state root was generated. This should save about a minute we currently spend generating this kdump. 
See https://issues.redhat.com/browse/OCPEDGE-663 for more info

Note that LCA will update kdump only in case it exists in the seed, kdump isn't enabled by default but it should be enabled as part of DU profile.
 
In case the seed image containes kdump the LCA log during prep stage will show:
```
2024-02-20T19:30:42Z	INFO	controllers.ImageBasedUpgrade	Looking for kdump under :/host/ostree/deploy/rhcos_4.15.0_rc.5/var/lib/kdump/*
2024-02-20T19:30:42Z	INFO	controllers.ImageBasedUpgrade	Updating kdump: /host/ostree/deploy/rhcos_4.15.0_rc.5/var/lib/kdump/initramfs-5.14.0-284.50.1.el9_2.x86_64kdump.img
2024-02-20T19:30:42Z	INFO	controllers.ImageBasedUpgrade	Updating kdump: /host/ostree/deploy/rhcos_4.15.0_rc.5/var/lib/kdump/initramfs-5.14.0-284.50.1.rt14.335.el9_2.x86_64kdump.img
```
