### PR TITLE
OCPBUGS-29719: Fix catalog targets in the upstream repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ catalog-build: opm ## Build a catalog image.
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+	${ENGINE} push ${CATALOG_IMG}
 
 ##@ lca-cli
 


### PR DESCRIPTION
This small fix renders a valid catalog when using the upstream catalogs to deploy LCA via OLM.