### PR TITLE
OCPBUGS-29821: Fix lca bundle with workload.openshift.io/allowed annotation

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -61,6 +61,18 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.14.0 <4.16.0'
+    operatorframework.io/suggested-namespace: openshift-lifecycle-agent
+    operatorframework.io/suggested-namespace-template: |-
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "openshift-lifecycle-agent",
+          "annotations": {
+            "workload.openshift.io/allowed": "management"
+          }
+        }
+      }
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.28.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
+++ b/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
@@ -18,6 +18,18 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.14.0 <4.16.0'
+    operatorframework.io/suggested-namespace: openshift-lifecycle-agent
+    operatorframework.io/suggested-namespace-template: |-
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "openshift-lifecycle-agent",
+          "annotations": {
+            "workload.openshift.io/allowed": "management"
+          }
+        }
+      }
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     provider: Red Hat
     repository: https://github.com/openshift-kni/lifecycle-agent


### PR DESCRIPTION
When workload-partitioning is enabled on the OCP cluster where the operator is going to be deployed, the operator's namespace requires the `"[workload.openshift.io/allowed](http://workload.openshift.io/allowed)": "management"` annotation to be successfully deployed.

Signed-off-by: Leonardo Ochoa-Aday <[lochoa@redhat.com](mailto:lochoa@redhat.com)>

/cc @rauhersu @jc-rh @browsell 