### PR TITLE
[release-4.15] Fix lca bundle with workload.openshift.io/allowed annotation

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -61,6 +61,18 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.14.0 <4.15.0'
+    operatorframework.io/suggested-namespace: openshift-lifecycle-agent
+    operatorframework.io/suggested-namespace-template: |-
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "openshift-lifecycle-agent",
+          "annotations": {
+            "workload.openshift.io/allowed": "management"
+          }
+        }
+      }
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.28.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -79,6 +79,8 @@ metadata:
     provider: Red Hat
     repository: https://github.com/openshift-kni/lifecycle-agent
     support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: lifecycle-agent.v4.15.0
   namespace: openshift-lifecycle-agent
 spec:

--- a/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
+++ b/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
@@ -18,6 +18,18 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.14.0 <4.15.0'
+    operatorframework.io/suggested-namespace: openshift-lifecycle-agent
+    operatorframework.io/suggested-namespace-template: |-
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "openshift-lifecycle-agent",
+          "annotations": {
+            "workload.openshift.io/allowed": "management"
+          }
+        }
+      }
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     provider: Red Hat
     repository: https://github.com/openshift-kni/lifecycle-agent

--- a/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
+++ b/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
@@ -34,6 +34,8 @@ metadata:
     provider: Red Hat
     repository: https://github.com/openshift-kni/lifecycle-agent
     support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: lifecycle-agent.v4.15.0
   namespace: openshift-lifecycle-agent
 spec:


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift-kni/lifecycle-agent/pull/346

(we had some conflicts with the version, hence the manual cherry-pick - we kept the 4.15.0 version in the bundle)

/assign donpenney @rauhersu