### PR TITLE
CNF-11452: seedgen: Remove hubKubeconfig and hub interaction

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -350,14 +350,6 @@ In addition, a `Secret` named `seedgen` is required in the `openshift-lifecycle-
 to provide the following information in the `Data` section:
 
 - `seedAuth`: base64-encoded auth file for write-access to the registry for pushing the generated seed image
-- `hubKubeconfig`: (Optional) base64-encoded kubeconfig for admin access to the hub, in order to deregister the seed
-  cluster from ACM. If this is not present in the secret, the ACM cleanup will be skipped.
-
-If the `hubKubeconfig` is provided, LCA will deregister the cluster from ACM and cleanup the node prior to generating
-the seed image. The `ManagedCluster` resource is saved prior to deletion from the hub in order to restore it after the
-seed image has been generated, reregistering the cluster with ACM.
-
-NOTE: Automatic restore of the `ManagedCluster` has not yet been implemented.
 
 ```yaml
 ---
@@ -369,7 +361,6 @@ metadata:
 type: Opaque
 data:
   seedAuth: <encoded authfile>
-  hubKubeconfig: <encoded kubeconfig>
 ---
 apiVersion: lca.openshift.io/v1alpha1
 kind: SeedGenerator

--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -295,15 +295,6 @@ spec:
           - update
           - watch
         - apiGroups:
-          - cluster.open-cluster-management.io
-          resources:
-          - managedclusters
-          verbs:
-          - delete
-          - get
-          - list
-          - watch
-        - apiGroups:
           - config.openshift.io
           resources:
           - clusteroperators

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -89,15 +89,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclusters
-  verbs:
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
   - config.openshift.io
   resources:
   - clusteroperators

--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -216,8 +216,9 @@ func (r *ImageBasedUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 			ibu.Status.ValidNextStages = getValidNextStageList(ibu, isAfterPivot)
 			// Update status
-			if updateErr := utils.UpdateIBUStatus(ctx, r.Client, ibu); updateErr != nil {
-				r.Log.Error(updateErr, "failed to update IBU CR status")
+			if err = utils.UpdateIBUStatus(ctx, r.Client, ibu); err != nil {
+				r.Log.Error(err, "failed to update IBU CR status")
+				return
 			}
 		}
 	}
@@ -237,8 +238,8 @@ func (r *ImageBasedUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	ibu.Status.ValidNextStages = getValidNextStageList(ibu, isAfterPivot)
 
 	// Update status
-	if updateErr := utils.UpdateIBUStatus(ctx, r.Client, ibu); updateErr != nil {
-		r.Log.Error(updateErr, "failed to update IBU CR status")
+	if err = utils.UpdateIBUStatus(ctx, r.Client, ibu); err != nil {
+		r.Log.Error(err, "failed to update IBU CR status")
 	}
 
 	return

--- a/controllers/seedgen_controller.go
+++ b/controllers/seedgen_controller.go
@@ -655,6 +655,7 @@ func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen
 	setSeedGenStatusInProgress(seedgen, "Starting seed generation")
 	if err := r.updateStatus(ctx, seedgen); err != nil {
 		r.Log.Error(err, "failed to update seedgen CR status")
+		return
 	}
 
 	nextReconcile = doNotRequeue()
@@ -668,6 +669,7 @@ func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen
 	setSeedGenStatusInProgress(seedgen, "Pulling recert image")
 	if err := r.updateStatus(ctx, seedgen); err != nil {
 		r.Log.Error(err, "failed to update seedgen CR status")
+		return
 	}
 
 	if err := r.pullRecertImagePullSpec(seedgen); err != nil {
@@ -679,6 +681,7 @@ func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen
 	setSeedGenStatusInProgress(seedgen, "Preparing for seed generation")
 	if err := r.updateStatus(ctx, seedgen); err != nil {
 		r.Log.Error(err, "failed to update seedgen CR status")
+		return
 	}
 
 	// Get the seedgen secret
@@ -726,6 +729,7 @@ func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen
 	setSeedGenStatusInProgress(seedgen, "Cleaning cluster resources")
 	if err := r.updateStatus(ctx, seedgen); err != nil {
 		r.Log.Error(err, "failed to update seedgen CR status")
+		return
 	}
 
 	// Clean up cluster resources
@@ -772,6 +776,7 @@ func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen
 	setSeedGenStatusInProgress(seedgen, msgLaunchingImager)
 	if err := r.updateStatus(ctx, seedgen); err != nil {
 		r.Log.Error(err, "failed to update seedgen CR status")
+		return
 	}
 
 	// Save the seedgen CR in order to restore it after the imager is complete

--- a/controllers/seedgen_controller.go
+++ b/controllers/seedgen_controller.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -59,7 +58,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
 // SeedGeneratorReconciler reconciles a SeedGenerator object
@@ -74,10 +72,9 @@ type SeedGeneratorReconciler struct {
 }
 
 var (
-	lcaImage               string
-	seedgenAuthFile        = filepath.Join(utils.SeedgenWorkspacePath, "auth.json")
-	storedManagedClusterCR = filepath.Join(utils.SeedgenWorkspacePath, "managedcluster.json")
-	imagerContainerName    = "lca_image_builder"
+	lcaImage            string
+	seedgenAuthFile     = filepath.Join(utils.SeedgenWorkspacePath, "auth.json")
+	imagerContainerName = "lca_image_builder"
 )
 
 const (
@@ -120,7 +117,6 @@ var phases = struct {
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=delete
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;delete
-//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=get;list;watch;delete
 
 // getPhase determines the reconciler phase based on the seedgen CR status conditions
@@ -157,114 +153,6 @@ func getPhase(seedgen *seedgenv1alpha1.SeedGenerator) seedgenReconcilerPhase {
 
 	// Reconciler phase is phaseGenerating
 	return phases.PhaseGenerating
-}
-
-// Create an API client for hub requests (ACM)
-func (r *SeedGeneratorReconciler) createHubClient(hubKubeconfig []byte) (hubClient client.Client, err error) {
-	config, err := clientcmd.RESTConfigFromKubeConfig(hubKubeconfig)
-	if err != nil {
-		err = fmt.Errorf("failed RESTConfigFromKubeConfig: %w", err)
-		return
-	}
-
-	hubClient, err = client.New(config, client.Options{Scheme: r.Scheme})
-	if err != nil {
-		err = fmt.Errorf("failed to create hub client: %w", err)
-		return
-	}
-
-	return
-}
-
-// Collect and save the data needed to restore the ACM registration, then delete the managedcluster from the hub
-func (r *SeedGeneratorReconciler) deregisterFromHub(ctx context.Context, hubClient client.Client, clusterName string) error {
-	// Save the managedcluster
-	managedcluster := &clusterv1.ManagedCluster{}
-	if err := hubClient.Get(ctx, types.NamespacedName{Name: clusterName}, managedcluster); err != nil {
-		// If not found, do nothing.
-		if client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("failed to get ManagedCluster: %w", err)
-		}
-		return nil
-	}
-
-	// The hubClient.Get() request isn't setting the GVK, so do it using the scheme data
-	// TODO: This may be due to issues with the RESTMapper or Scheme, where this CRD doesn't exist
-	// on the SNO, so maybe we need a separate resource discovery mechanism, or distinct scheme?
-	typeMeta, err := commonUtils.TypeMetaForObject(r.Scheme, managedcluster)
-	if err != nil {
-		return fmt.Errorf("failed to get typeMeta for ManagedCluster: %w", err)
-	}
-	managedcluster.TypeMeta = *typeMeta
-
-	if err := commonUtils.MarshalToFile(managedcluster, common.PathOutsideChroot(storedManagedClusterCR)); err != nil {
-		return fmt.Errorf("failed to write managedcluster to %s: %w", storedManagedClusterCR, err)
-	}
-
-	// Ensure that the dependent resources are deleted
-	deleteOpts := []client.DeleteOption{
-		client.PropagationPolicy(metav1.DeletePropagationForeground),
-	}
-
-	// Deregister from ACM on the hub
-	if err := hubClient.Delete(ctx, managedcluster, deleteOpts...); client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("failed to delete managedcluster from hub: %w", err)
-	}
-
-	// TODO: For some reason, the managedcluster deletion is returning immediately, rather than
-	// blocking while the deletion occurs in the foreground. Maybe because it's deleting on the hub?
-	// As a workaround, we'll poll until the cluster is deleted.
-	interval := 10 * time.Second
-	maxRetries := 90 // ~15 minutes
-	current := 0
-	r.Log.Info("Waiting until managedcluster is deleted")
-	for r.managedClusterExists(ctx, hubClient, clusterName) {
-		if current < maxRetries {
-			time.Sleep(interval)
-			current += 1
-		} else {
-			return fmt.Errorf("timed out waiting for managedcluster deletion")
-		}
-	}
-
-	return nil
-}
-
-func (r *SeedGeneratorReconciler) reregisterWithHub(ctx context.Context, hubClient client.Client, filePath string) error {
-	// Restore the managedcluster
-	managedcluster := &clusterv1.ManagedCluster{}
-
-	if err := lcautils.ReadYamlOrJSONFile(filePath, managedcluster); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("unable to read stored managedcluster file (%s): %w", filePath, err)
-	}
-
-	// Clear the ResourceVersion, otherwise the restore will fail
-	managedcluster.SetResourceVersion("")
-
-	if err := hubClient.Create(ctx, managedcluster); err != nil {
-		return fmt.Errorf("failed to create ManagedCluster: %w", err)
-	}
-
-	if err := os.Rename(filePath, filePath+".bak"); err != nil {
-		return fmt.Errorf("failed to rename file %s for hub registration: %w", filePath, err)
-	}
-
-	return nil
-}
-
-// Check whether the managedcluster resource exists on the hub
-func (r *SeedGeneratorReconciler) managedClusterExists(ctx context.Context, hubClient client.Client, clusterName string) bool {
-	managedcluster := &clusterv1.ManagedCluster{}
-	if err := hubClient.Get(ctx, types.NamespacedName{Name: clusterName}, managedcluster); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			r.Log.Info(fmt.Sprintf("Error when checking managedcluster existence: %s", err.Error()))
-		}
-		return false
-	}
-	return true
 }
 
 // Get a list of ACM addon namespaces present on the cluster
@@ -644,6 +532,17 @@ func (r *SeedGeneratorReconciler) validateSystem(ctx context.Context) (msg strin
 		return
 	}
 
+	// Verify that the klusterlet CRD is absent, indicating the cluster has been detached from ACM (if originally deployed via ACM)
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := r.Get(ctx, types.NamespacedName{Name: "klusterlets.operator.open-cluster-management.io"}, crd); !errors.IsNotFound(err) {
+		if err == nil {
+			msg = "Rejected: Cluster must be detached from hub prior to seed generation"
+		} else {
+			msg = "Failure occurred during check for klusterlets CRD in system validation"
+		}
+		return
+	}
+
 	// Ensure there are no ACM addons enabled on the seed SNO
 	if acmNsList := r.currentAcmAddonNamespaces(ctx); len(acmNsList) > 0 {
 		msg = fmt.Sprintf("Rejected due to presence of ACM addon(s): %s", strings.Join(acmNsList, ", "))
@@ -741,7 +640,7 @@ func (r *SeedGeneratorReconciler) setupWorkspace() error {
 }
 
 // Generate the seed image
-func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen *seedgenv1alpha1.SeedGenerator, clusterName string) (nextReconcile ctrl.Result, rc error) {
+func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen *seedgenv1alpha1.SeedGenerator) (nextReconcile ctrl.Result, rc error) {
 	// Wait for system stability before starting seed generation
 	r.Log.Info("Checking system health")
 	if err := healthcheck.HealthChecks(ctx, r.NoncachedClient, r.Log); err != nil {
@@ -807,35 +706,6 @@ func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen
 		rc = fmt.Errorf("could not find seedAuth in %s secret", utils.SeedGenSecretName)
 		setSeedGenStatusFailed(seedgen, rc.Error())
 		return
-	}
-
-	if hubKubeconfig, exists := seedGenSecret.Data["hubKubeconfig"]; exists {
-		// Create client for access to hub
-		hubClient, err := r.createHubClient(hubKubeconfig)
-		if err != nil {
-			rc = fmt.Errorf("failed to create hub client: %w", err)
-			setSeedGenStatusFailed(seedgen, rc.Error())
-			return
-		}
-
-		if r.managedClusterExists(ctx, hubClient, clusterName) {
-			// Save the ACM resources from hub needed for re-import
-			r.Log.Info("Collecting ACM import data")
-			if err := r.deregisterFromHub(ctx, hubClient, clusterName); err != nil {
-				rc = fmt.Errorf("failed to deregister from hub: %w", err)
-				setSeedGenStatusFailed(seedgen, rc.Error())
-				return
-			}
-
-			// In the success case, the pod will block until terminated by the imager container.
-			// Create a deferred function to restore the ManagedCluster in the case where a failure happens
-			// before that point.
-			defer r.restoreManagedCluster(ctx, clusterName)
-		} else {
-			r.Log.Info("ManagedCluster does not exist on hub")
-		}
-	} else {
-		r.Log.Info(fmt.Sprintf("No hubKubeconfig found in secret %s. Skipping hub interaction", utils.SeedGenSecretName))
 	}
 
 	// Get the cluster's pull-secret
@@ -956,55 +826,18 @@ func (r *SeedGeneratorReconciler) generateSeedImage(ctx context.Context, seedgen
 	return
 }
 
-func (r *SeedGeneratorReconciler) restoreManagedCluster(ctx context.Context, clusterName string) error {
-	// Get the seedgen secret
-	seedGenSecret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: utils.SeedGenSecretName, Namespace: common.LcaNamespace}, seedGenSecret); err != nil {
-		return fmt.Errorf("could not access secret %s in %s: %w", utils.SeedGenSecretName, common.LcaNamespace, err)
-	}
-
-	if hubKubeconfig, exists := seedGenSecret.Data["hubKubeconfig"]; exists {
-		filePath := common.PathOutsideChroot(storedManagedClusterCR)
-		if _, err := os.Stat(filePath); err == nil {
-			// The hubKubeconfig exists and there's a stored ManagedCluster CR. Restore it.
-
-			// Create client for access to hub
-			hubClient, err := r.createHubClient(hubKubeconfig)
-			if err != nil {
-				return fmt.Errorf("failed to create hub client: %w", err)
-			}
-
-			if r.managedClusterExists(ctx, hubClient, clusterName) {
-				r.Log.Info("ManagedCluster exists on hub, no need to restore")
-			} else {
-				// Save the ACM resources from hub needed for re-import
-				r.Log.Info("Reregistering cluster with ACM")
-				if err := r.reregisterWithHub(ctx, hubClient, filePath); err != nil {
-					return fmt.Errorf("failed to reregister with ACM: %w", err)
-				}
-			}
-		} else {
-			r.Log.Info("Found hubKubeconfig, but no saved ManagedCluster. Skipping restore")
-		}
-	} else {
-		r.Log.Info(fmt.Sprintf("No hubKubeconfig found in secret %s. Skipping hub interaction", utils.SeedGenSecretName))
-	}
-
-	return nil
-}
-
 // finishSeedgen runs after the imager container completes and restores kubelet, once the LCA operator restarts
-func (r *SeedGeneratorReconciler) finishSeedgen(ctx context.Context, clusterName string) error {
-	if err := r.restoreManagedCluster(ctx, clusterName); err != nil {
-		return err
-	}
-
+func (r *SeedGeneratorReconciler) finishSeedgen() error {
 	// Check exit status of lca_cli container
 	if err := r.checkImagerStatus(); err != nil {
 		return fmt.Errorf("imager container status check failed: %w", err)
 	}
 
-	return r.wipeExistingWorkspace()
+	if err := r.wipeExistingWorkspace(); err != nil {
+		return fmt.Errorf("failed to wipe workspace: %w", err)
+	}
+
+	return nil
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -1036,12 +869,6 @@ func (r *SeedGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if lcaImage, err = r.getLcaImage(ctx); err != nil {
-		rc = err
-		return
-	}
-
-	clusterName, err := commonUtils.GetClusterName(ctx, r.Client)
-	if err != nil {
 		rc = err
 		return
 	}
@@ -1088,7 +915,7 @@ func (r *SeedGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		nextReconcile = requeueImmediately()
 	case phases.PhaseGenerating:
 		r.Log.Info(fmt.Sprintf("Generating seed image: %s", seedgen.Spec.SeedImage))
-		if nextReconcile, err = r.generateSeedImage(ctx, seedgen, clusterName); err != nil {
+		if nextReconcile, err = r.generateSeedImage(ctx, seedgen); err != nil {
 			_ = r.wipeExistingWorkspace()
 
 			// CR Status will have been updated by generateSeedImage, so just log the failure
@@ -1101,7 +928,7 @@ func (r *SeedGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			r.Log.Error(err, "failed to update seedgen CR status")
 		}
 
-		if err = r.finishSeedgen(ctx, clusterName); err != nil {
+		if err = r.finishSeedgen(); err != nil {
 			r.Log.Error(err, "Seed generation failed")
 			setSeedGenStatusFailed(seedgen, fmt.Sprintf("Seed generation failed: %s", err))
 		} else {


### PR DESCRIPTION
Due to the potential issues stemming from ACM automatically re-importing the cluster, the support for hubKubeconfig and LCA deletion/restoration of the ManagedCluster CR had been dropped. The seedgen system validation now verifies that the cluster is not being actively managed by ACM prior to starting seed image generation, by checking for the klusterlets CRD. If present, this indicates ACM is managing the cluster, and the seedgen request is rejected.