### PR TITLE
CNF-11186: Raise validation error if there is a MachineConfig in extramanifests

### DIFF
--- a/internal/extramanifest/extramanifest.go
+++ b/internal/extramanifest/extramanifest.go
@@ -175,6 +175,14 @@ func (h *EMHandler) ValidateExtraManifestConfigmaps(ctx context.Context, content
 		return fmt.Errorf("failed to extract manifests from configMap: %w", err)
 	}
 
+	// MachineConfig can trigger reboot and this will result in not meeting KPI downtime requirement
+	// so raise validation error if there is a MachineConfig in extramanifests
+	for _, manifest := range manifests {
+		if manifest.GetKind() == "MachineConfig" && manifest.GetAPIVersion() == "machineconfiguration.openshift.io/v1" {
+			return NewEMFailedValidationError("Using MachingConfigs in extramanifests is not allowed")
+		}
+	}
+
 	// Apply manifest with dryrun
 	dryrun := true
 	for _, manifest := range manifests {


### PR DESCRIPTION
Extra manifests should not contain anything that will trigger a reboot
as this would result in not meeting the KPI downtime requirement.
ExtraManifest validation will raise an error if there is MachineConfig
in extramanifests