### PR TITLE
OCPBUGS-29483: Ensure initMonitorTimeoutSeconds positive values only

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -92,8 +92,9 @@ type AutoRollbackOnFailure struct {
 	DisabledForUpgradeCompletion bool `json:"disabledForUpgradeCompletion,omitempty"` // If true, disable auto-rollback for Upgrade completion handler
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	DisabledInitMonitor bool `json:"disabledInitMonitor,omitempty"` // If true, disable LCA Init Monitor watchdog, which triggers auto-rollback if timeout occurs before upgrade completion
+	// +kubebuilder:validation:Minimum=0
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
-	InitMonitorTimeoutSeconds int `json:"initMonitorTimeoutSeconds,omitempty"` // LCA Init Monitor watchdog timeout, in seconds. Value <= 0 is treated as "use default" when writing config file in Prep stage
+	InitMonitorTimeoutSeconds int `json:"initMonitorTimeoutSeconds,omitempty"` // LCA Init Monitor watchdog timeout, in seconds. Value = 0 is treated as "use default" when writing config file in Prep stage
 }
 
 // ConfigMapRef defines a reference to a config map

--- a/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
+++ b/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
@@ -69,6 +69,7 @@ spec:
                   disabledInitMonitor:
                     type: boolean
                   initMonitorTimeoutSeconds:
+                    minimum: 0
                     type: integer
                 type: object
               extraManifests:

--- a/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
+++ b/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
@@ -69,6 +69,7 @@ spec:
                   disabledInitMonitor:
                     type: boolean
                   initMonitorTimeoutSeconds:
+                    minimum: 0
                     type: integer
                 type: object
               extraManifests:


### PR DESCRIPTION
If the user provides a negative value for initMonitorTimeoutSeconds, it will be rejected when validating the IBU spec.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>

