### PR TITLE
CNF-11187: Reconcile when precache job updates

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -292,8 +292,15 @@ spec:
           - delete
           - get
           - list
+          - patch
           - update
           - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs/status
+          verbs:
+          - get
         - apiGroups:
           - config.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -86,8 +86,15 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
 - apiGroups:
   - config.openshift.io
   resources:

--- a/internal/precache/constants.go
+++ b/internal/precache/constants.go
@@ -28,6 +28,7 @@ const (
 	LcaPrecacheServiceAccount string = "lifecycle-agent-controller-manager"
 	LcaPrecacheJobName        string = "lca-precache-job"
 	LcaPrecacheConfigMapName  string = "lca-precache-cm"
+	LcaPrecacheFinalizer             = "lca.precache.io/finalizer"
 )
 
 // Image paths


### PR DESCRIPTION
Currently when a precache job is launched, reconcile is requested after an arbitrary amount of time. During the reconcile wait time the system could be in any state and we can not let the user know about it immediately if an event occurs such as when the job is done.

This is fixed by taking ownership of precache job using IBU cr (OwnerReferences). Now reconcile will be triggered as soon as job updates and system is checked to see if desired state has been reached to complete prep 