### PR TITLE
MGMT-16515: Set the node IP hint file according to the node ip in the manifest

### DIFF
--- a/lca-cli/ops/mock_ops.go
+++ b/lca-cli/ops/mock_ops.go
@@ -9,6 +9,7 @@
 package ops
 
 import (
+	net "net"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -108,6 +109,21 @@ func (m *MockOps) ListBlockDevices() ([]BlockDevice, error) {
 func (mr *MockOpsMockRecorder) ListBlockDevices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBlockDevices", reflect.TypeOf((*MockOps)(nil).ListBlockDevices))
+}
+
+// ListNodeAddresses mocks base method.
+func (m *MockOps) ListNodeAddresses() ([]net.Addr, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodeAddresses")
+	ret0, _ := ret[0].([]net.Addr)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodeAddresses indicates an expected call of ListNodeAddresses.
+func (mr *MockOpsMockRecorder) ListNodeAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeAddresses", reflect.TypeOf((*MockOps)(nil).ListNodeAddresses))
 }
 
 // Mount mocks base method.


### PR DESCRIPTION
[MGMT-16515](https://issues.redhat.com//browse/MGMT-16515): Set the node IP hint file according to the node ip in the manifest

1. In case ip was provided set cidr that matches this ip in nodeip hint file
2. Adding one Network manager restart as part of physical network configuration