### PR TITLE
OCPBUGS-30063: Restore fix for IBU with no rhcos delta

### DIFF
--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -253,10 +253,6 @@ func (r *ImageBasedUpgradeReconciler) SetupStateroot(ctx context.Context, ibu *l
 		return fmt.Errorf("failed to setup stateroot: %w", err)
 	}
 
-	if err := r.RPMOstreeClient.RpmOstreeCleanup(); err != nil {
-		return fmt.Errorf("failed rpm-ostree cleanup -b: %w", err)
-	}
-
 	if err := r.RebootClient.WriteIBUAutoRollbackConfigFile(ibu); err != nil {
 		return fmt.Errorf("failed to write auto-rollback config: %w", err)
 	}

--- a/internal/ostreeclient/mock_ostreeclient.go
+++ b/internal/ostreeclient/mock_ostreeclient.go
@@ -11,6 +11,7 @@ package ostreeclient
 import (
 	reflect "reflect"
 
+	rpmostreeclient "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -38,17 +39,17 @@ func (m *MockIClient) EXPECT() *MockIClientMockRecorder {
 }
 
 // Deploy mocks base method.
-func (m *MockIClient) Deploy(osname, refsepc string, kargs []string) error {
+func (m *MockIClient) Deploy(osname, refsepc string, kargs []string, rpmOstreeClient rpmostreeclient.IClient, ibi bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Deploy", osname, refsepc, kargs)
+	ret := m.ctrl.Call(m, "Deploy", osname, refsepc, kargs, rpmOstreeClient, ibi)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Deploy indicates an expected call of Deploy.
-func (mr *MockIClientMockRecorder) Deploy(osname, refsepc, kargs any) *gomock.Call {
+func (mr *MockIClientMockRecorder) Deploy(osname, refsepc, kargs, rpmOstreeClient, ibi any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockIClient)(nil).Deploy), osname, refsepc, kargs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockIClient)(nil).Deploy), osname, refsepc, kargs, rpmOstreeClient, ibi)
 }
 
 // GetDeployment mocks base method.

--- a/internal/prep/prep.go
+++ b/internal/prep/prep.go
@@ -197,7 +197,7 @@ func SetupStateroot(log logr.Logger, ops ops.Ops, ostreeClient ostreeclient.ICli
 		return fmt.Errorf("failed to build kargs: %w", err)
 	}
 
-	if err = ostreeClient.Deploy(osname, seedBootedRef, kargs); err != nil {
+	if err = ostreeClient.Deploy(osname, seedBootedRef, kargs, rpmOstreeClient, ibi); err != nil {
 		return fmt.Errorf("failed ostree admin deploy: %w", err)
 	}
 


### PR DESCRIPTION
In an IBU where both releases have the same underlying rhcos image, the parent commit of the deployment has unique commit IDs (due to import from seed), but the same checksum. This previously caused a failure after creating the deployment, which was resolved with: https://github.com/openshift-kni/lifecycle-agent/pull/203/commits

The fix required two changes:
- Add the "--no-prune" option to the "ostree admin deploy" command
- Add a call to "rpm-ostree cleanup -b" to update the base refs

Code restructuring in a later update moved the "rpm-ostree cleanup -b" call later in the workflow, inadvertently leading to the no-delta IBU failure reoccurring.

This update moves the cleanup step into the function calling "ostree admin deploy", with a clarifying comment explaining that it must immediately follow the deploy command.