### PR TITLE
OCPBUGS-30063: Add version info to kargs for deploy in IBU

### DIFF
--- a/internal/prep/prep.go
+++ b/internal/prep/prep.go
@@ -197,6 +197,11 @@ func SetupStateroot(log logr.Logger, ops ops.Ops, ostreeClient ostreeclient.ICli
 		return fmt.Errorf("failed to build kargs: %w", err)
 	}
 
+	if !ibi {
+		// Append a unique karg
+		kargs = append(kargs, "--karg", "ibu="+expectedVersion)
+	}
+
 	if err = ostreeClient.Deploy(osname, seedBootedRef, kargs, rpmOstreeClient, ibi); err != nil {
 		return fmt.Errorf("failed ostree admin deploy: %w", err)
 	}


### PR DESCRIPTION
In the case where we're doing an IBU to a release with the same rhcos base image on a cluster that has previously been upgraded via IBU, we end up with the exact same set of boot loader config options in the deployments for both the old and new stateroots. This causes a problem for ostree, which is using the set of config options when comparing deployments to determine whether the boot loader entries need to be updated. When we're swapping deployments in order to pivot to the new release, the deployment boot serials get reassigned, however, as the deployments are in separate stateroots. Without also updating the boot loader entries, ostree ends up unable to correlate these entries with the boot links it has now swapped.

In order to avoid this issue, this update adds a karg to the new deployment with the image version, ensuring it will be unique when compared to the original deployment.

When doing a no-delta IBU from a cluster that has not previously undergone an IBU, the boot loader config options already have some differences when compared to the new deployment created for the seed, so this scenario does not occur.