### PR TITLE
postpivot: Fix ssh key machineconfig filenames

### DIFF
--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -535,8 +535,9 @@ func (p *PostPivot) createSSHKeyMachineConfigs(sshKey string) error {
 				Config: rawExt,
 			},
 		}
+		fname := fmt.Sprintf(sshMachineConfig, role) + ".json"
 		if err := utils.MarshalToFile(mc, path.Join(p.workingDir, common.ClusterConfigDir,
-			common.ManifestsDir, fmt.Sprintf(sshMachineConfig, role))); err != nil {
+			common.ManifestsDir, fname)); err != nil {
 			return fmt.Errorf("failed to marshal ssh key into file for role %s, err: %w", role, err)
 		}
 	}


### PR DESCRIPTION
The machineconfig manifests generated by postpivot for updating the ssh keys were missing a filename extension, so were ignored by the oc apply command that applies the manifests directory. As a result, the 99-master-ssh and 99-worker-ssh machineconfigs were not being updated as expected. Adding the .json extension to the filenames resolves the issue.