### PR TITLE
MGMT-17115: Save the custom catalog sources as extra manifests

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -446,6 +446,14 @@ spec:
         - apiGroups:
           - operators.coreos.com
           resources:
+          - catalogsources
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
           - clusterserviceversions
           verbs:
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -240,6 +240,14 @@ rules:
 - apiGroups:
   - operators.coreos.com
   resources:
+  - catalogsources
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
   - clusterserviceversions
   verbs:
   - delete

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/apimachinery v0.28.2
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/code-generator v0.28.2
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	open-cluster-management.io/api v0.12.0
 	open-cluster-management.io/config-policy-controller v0.12.0
 	open-cluster-management.io/governance-policy-propagator v0.12.0
@@ -119,7 +120,6 @@ require (
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	open-cluster-management.io/multicloud-operators-subscription v0.11.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -6,15 +6,18 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-logr/logr"
-	v1 "github.com/openshift/api/config/v1"
-	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+	v1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	"github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
@@ -29,6 +32,7 @@ import (
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=imagecontentsourcepolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=get;list;watch
 
 const (
 	manifestDir = "manifests"
@@ -38,8 +42,9 @@ const (
 
 	pullSecretName = "pull-secret"
 
-	idmsFileName  = "image-digest-mirror-set.json"
-	icspsFileName = "image-content-source-policy-list.json"
+	idmsFileName           = "image-digest-mirror-set.json"
+	icspsFileName          = "image-content-source-policy-list.json"
+	catalogSourcesFileName = "custom-catalog-sources.json"
 
 	caBundleCMName   = "user-ca-bundle"
 	caBundleFileName = caBundleCMName + ".json"
@@ -82,6 +87,9 @@ func (r *UpgradeClusterConfigGather) FetchClusterConfig(ctx context.Context, ost
 		return err
 	}
 	if err := r.fetchIDMS(ctx, manifestsDir); err != nil {
+		return err
+	}
+	if err := r.fetchCatalogSources(ctx, manifestsDir); err != nil {
 		return err
 	}
 
@@ -265,6 +273,24 @@ func (r *UpgradeClusterConfigGather) fetchIDMS(ctx context.Context, manifestsDir
 	return nil
 }
 
+func (r *UpgradeClusterConfigGather) fetchCatalogSources(ctx context.Context, manifestsDir string) error {
+	r.Log.Info("Fetching catalogSourcces")
+	customCatalogSources, err := r.getCustomCatalogSources(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch catalog sources %w", err)
+	}
+	if len(customCatalogSources.Items) < 1 {
+		r.Log.Info("No custom CatalogSources found, skipping")
+		return nil
+	}
+	filePath := filepath.Join(manifestsDir, catalogSourcesFileName)
+	r.Log.Info("Writing catalog source to file", "path", filePath)
+	if err := utils.MarshalToFile(customCatalogSources, filePath); err != nil {
+		return fmt.Errorf("failed to write catalog source to file %s: %w", filePath, err)
+	}
+	return nil
+}
+
 // configDirs creates and returns the directory for the given cluster configuration.
 func (r *UpgradeClusterConfigGather) configDir(ostreeVarDir string) (string, error) {
 	filesDir := filepath.Join(ostreeVarDir, common.OptOpenshift, common.ClusterConfigDir)
@@ -426,4 +452,44 @@ func (r *UpgradeClusterConfigGather) fetchNetworkConfig(ostreeDir string) error 
 	}
 	r.Log.Info("Done fetching node network files")
 	return nil
+}
+
+func (r *UpgradeClusterConfigGather) getCustomCatalogSources(ctx context.Context) (operatorsv1alpha1.CatalogSourceList, error) {
+	catalogSources := &operatorsv1alpha1.CatalogSourceList{}
+	customCatalogSources := &operatorsv1alpha1.CatalogSourceList{}
+	allNamespaces := client.ListOptions{Namespace: metav1.NamespaceAll}
+	if err := r.Client.List(ctx, catalogSources, &allNamespaces); err != nil {
+		return operatorsv1alpha1.CatalogSourceList{}, fmt.Errorf("failed to list all catalogueSources %w", err)
+	}
+
+	defaultCatalogRecources := []string{"certified-operators", "community-operators", "redhat-marketplace", "redhat-operators"}
+	for i, cs := range catalogSources.Items {
+		if slices.Contains(defaultCatalogRecources, cs.Name) {
+			r.Log.Info("Skipping default catalog source %s", "name", cs.Name)
+		} else {
+			obj := operatorsv1alpha1.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        cs.Name,
+					Namespace:   cs.Namespace,
+					Annotations: cs.GetAnnotations(),
+				},
+				Spec: cs.Spec,
+			}
+
+			typeMeta, err := r.typeMetaForObject(&catalogSources.Items[i])
+			if err != nil {
+				return operatorsv1alpha1.CatalogSourceList{}, err
+			}
+			obj.TypeMeta = *typeMeta
+
+			customCatalogSources.Items = append(customCatalogSources.Items, obj)
+		}
+	}
+	r.Log.Info("catalogSources", "APIVersion:", catalogSources.TypeMeta.APIVersion, "Kind:", catalogSources.TypeMeta.Kind)
+	typeMeta, err := r.typeMetaForObject(customCatalogSources)
+	if err != nil {
+		return operatorsv1alpha1.CatalogSourceList{}, err
+	}
+	customCatalogSources.TypeMeta = *typeMeta
+	return *customCatalogSources, nil
 }

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -25,18 +25,21 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
 	appsv1 "k8s.io/api/apps/v1"
 
-	"github.com/go-logr/logr"
-	ocpV1 "github.com/openshift/api/config/v1"
-	mcv1 "github.com/openshift/api/machineconfiguration/v1"
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/go-logr/logr"
+	ocpV1 "github.com/openshift/api/config/v1"
+	mcv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
@@ -171,7 +174,9 @@ func init() {
 		&ocpV1.ImageContentPolicyList{})
 	testscheme.AddKnownTypes(operatorv1alpha1.GroupVersion,
 		&operatorv1alpha1.ImageContentSourcePolicyList{},
-		&operatorv1alpha1.ImageContentSourcePolicy{})
+		&operatorv1alpha1.ImageContentSourcePolicy{},
+		&operatorsv1alpha1.CatalogSource{},
+		&operatorsv1alpha1.CatalogSourceList{})
 }
 
 func getFakeClientFromObjects(objs ...client.Object) (client.WithWatch, error) {
@@ -213,6 +218,23 @@ func TestClusterConfig(t *testing.T) {
 		},
 		Spec: ocpV1.ImageDigestMirrorSetSpec{ImageDigestMirrors: []ocpV1.ImageDigestMirrors{{Source: "data"}}},
 	}
+	defaultCatalogSources := &operatorsv1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "redhat-operators",
+		},
+		Spec: operatorsv1alpha1.CatalogSourceSpec{
+			Image: "registry.redhat.io/redhat/redhat-operator-index:v4.13",
+		},
+	}
+	customCatalogSources := &operatorsv1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-catalog",
+			Annotations: map[string]string{"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"},
+		},
+		Spec: operatorsv1alpha1.CatalogSourceSpec{
+			Image: "some-registry/redhat/redhat-operator-index:v4.13",
+		},
+	}
 	defaultProxy := &ocpV1.Proxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
@@ -228,6 +250,7 @@ func TestClusterConfig(t *testing.T) {
 		clusterVersion  client.Object
 		idms            client.Object
 		icsps           []client.Object
+		catalogSources  []client.Object
 		node            client.Object
 		proxy           client.Object
 		deleteKubeadmin bool
@@ -239,6 +262,7 @@ func TestClusterConfig(t *testing.T) {
 			pullSecret:     defaultPullSecret,
 			clusterVersion: defaultClusterVersion,
 			idms:           defaultIDMS,
+			catalogSources: []client.Object{defaultCatalogSources, customCatalogSources},
 			node:           validMasterNode,
 			proxy:          defaultProxy,
 			icsps:          nil,
@@ -267,6 +291,17 @@ func TestClusterConfig(t *testing.T) {
 				if assert.Equal(t, 1, len(idms.Items)) {
 					assert.Equal(t, "any", idms.Items[0].Name)
 					assert.Equal(t, "data", idms.Items[0].Spec.ImageDigestMirrors[0].Source)
+				}
+
+				// validate catalog sources
+				catalogSources := &operatorsv1alpha1.CatalogSourceList{}
+				if err := utils.ReadYamlOrJSONFile(filepath.Join(manifestsDir, catalogSourcesFileName), catalogSources); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if assert.Equal(t, 1, len(catalogSources.Items)) {
+					assert.Equal(t, customCatalogSources.Name, catalogSources.Items[0].Name)
+					assert.Equal(t, customCatalogSources.Annotations, catalogSources.Items[0].Annotations)
+					assert.Equal(t, customCatalogSources.Spec.Image, catalogSources.Items[0].Spec.Image)
 				}
 
 				seedReconfig, err := getSeedReconfigFromUcc(ucc, tempDir)
@@ -352,6 +387,62 @@ func TestClusterConfig(t *testing.T) {
 					t.Errorf("unexpected error: %v", err)
 				}
 				assert.Equal(t, 1, len(dir))
+			},
+		},
+		{
+			testCaseName:   "empty catalog sources",
+			pullSecret:     defaultPullSecret,
+			clusterVersion: defaultClusterVersion,
+			idms:           nil,
+			icsps:          nil,
+			catalogSources: nil,
+			caBundleCM:     nil,
+			node:           validMasterNode,
+			proxy:          defaultProxy,
+			expectedErr:    false,
+			validateFunc: func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather) {
+				filesDir, err := ucc.configDir(tempDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				dir, err := os.ReadDir(filepath.Join(filesDir, manifestDir))
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// expect a single file: proxy.json
+				assert.Equal(t, 1, len(dir))
+				_, err = os.Stat(filepath.Join(filesDir, manifestDir, proxyFileName))
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			testCaseName:   "no user defined catalog sources",
+			pullSecret:     defaultPullSecret,
+			clusterVersion: defaultClusterVersion,
+			idms:           nil,
+			icsps:          nil,
+			catalogSources: []client.Object{defaultCatalogSources},
+			caBundleCM:     nil,
+			node:           validMasterNode,
+			proxy:          defaultProxy,
+			expectedErr:    false,
+			validateFunc: func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather) {
+				filesDir, err := ucc.configDir(tempDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				dir, err := os.ReadDir(filepath.Join(filesDir, manifestDir))
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// expect a single file: proxy.json
+				assert.Equal(t, 1, len(dir))
+				_, err = os.Stat(filepath.Join(filesDir, manifestDir, proxyFileName))
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
 			},
 		},
 		{
@@ -459,6 +550,11 @@ func TestClusterConfig(t *testing.T) {
 			if tc.icsps != nil {
 				for _, icsp := range tc.icsps {
 					objs = append(objs, icsp)
+				}
+			}
+			if tc.catalogSources != nil {
+				for _, cs := range tc.catalogSources {
+					objs = append(objs, cs)
 				}
 			}
 


### PR DESCRIPTION
LCA should preserve the user-defined catalog sources 
This change will fetch the catalog sources pre-reboot, filter out the default catalog sources, and add the user-defined catalog sources as as extra manifests that will get applied post-reboot (before the application restore starts)