### PR TITLE
CNF-11561: fix non-vendor snyk errors

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,8 @@
-# References:
-# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
-# https://docs.snyk.io/snyk-cli/commands/ignore
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 exclude:
   global:
     - vendor/**
+    - '**/*_test.go'
+version: v1.25.0
+ignore: {}
+patch: {}

--- a/internal/backuprestore/restore.go
+++ b/internal/backuprestore/restore.go
@@ -232,7 +232,7 @@ func (h *BRHandler) LoadRestoresFromOadpRestorePath() ([][]*velerov1.Restore, er
 
 		// The returned list of entries are sorted by name alphabetically
 		restoreDirPath := filepath.Join(OadpRestorePath, restoreSubDir.Name())
-		restoreYamls, err := os.ReadDir(filepath.Join(hostPath, restoreDirPath))
+		restoreYamls, err := os.ReadDir(filepath.Clean(filepath.Join(hostPath, restoreDirPath)))
 		if err != nil {
 			return nil, fmt.Errorf("failed get restore yamls in %s: %w", restoreYamls, err)
 		}

--- a/utils/crypto_dir.go
+++ b/utils/crypto_dir.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	cryptoDirMode    = 0o600
-	passwordHashFile = "kubeadmin-password-hash.txt"
+	cryptoDirMode = 0o600
+	pwHashFile    = "kubeadmin-password-hash.txt"
 )
 
 func SeedReconfigurationKubeconfigRetentionToCryptoDir(cryptoDir string, kubeconfigCryptoRetention *seedreconfig.KubeConfigCryptoRetention) error {
@@ -133,7 +133,7 @@ func BackupKubeadminPasswordHash(ctx context.Context, client runtimeclient.Clien
 		return false, fmt.Errorf("failed to get kubeadmin password: %w", err)
 	}
 
-	if err := os.WriteFile(path.Join(cryptoDir, passwordHashFile), []byte(password), cryptoDirMode); err != nil {
+	if err := os.WriteFile(path.Join(cryptoDir, pwHashFile), []byte(password), cryptoDirMode); err != nil {
 		return false, fmt.Errorf("failed to write kubeadmin password hash: %w", err)
 	}
 
@@ -141,7 +141,7 @@ func BackupKubeadminPasswordHash(ctx context.Context, client runtimeclient.Clien
 }
 
 func LoadKubeadminPasswordHash(cryptoDir string) (string, error) {
-	if _, err := os.Stat(path.Join(cryptoDir, passwordHashFile)); err != nil {
+	if _, err := os.Stat(path.Join(cryptoDir, pwHashFile)); err != nil {
 		if os.IsNotExist(err) {
 			return "", nil
 		}
@@ -149,7 +149,7 @@ func LoadKubeadminPasswordHash(cryptoDir string) (string, error) {
 		return "", fmt.Errorf("failed to check if kubeadmin password hash exists: %w", err)
 	}
 
-	password, err := os.ReadFile(path.Join(cryptoDir, passwordHashFile))
+	password, err := os.ReadFile(path.Join(cryptoDir, pwHashFile))
 	if err != nil {
 		return "", fmt.Errorf("failed to read kubeadmin password hash: %w", err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -109,15 +109,17 @@ func GetSNOMasterNode(ctx context.Context, client runtimeclient.Client) (*corev1
 	return &nodesList.Items[0], nil
 }
 
-func ReadYamlOrJSONFile(filePath string, into any) error {
-	data, err := os.ReadFile(filePath)
+func ReadYamlOrJSONFile(fp string, into any) error {
+	fp = filepath.Clean(fp)
+
+	data, err := os.ReadFile(fp)
 	if err != nil {
 		return err // nolint:wrapcheck
 	}
 
 	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
 	if err := decoder.Decode(into); err != nil {
-		return fmt.Errorf("failed to decode %s: %w", filePath, err)
+		return fmt.Errorf("failed to decode %s: %w", fp, err)
 	}
 
 	return nil


### PR DESCRIPTION
Fix remaining errors from https://github.com/openshift/release/pull/49688

The dot file was regenerated with the following
```
snyk ignore --file-path='vendor/**' --file-path-group='global'   
snyk ignore --file-path='**/*_test.go' --file-path-group='global'
```