### PR TITLE
Add automatic cleanup for DeleteBackupRequests CRs when manualCleanUp annotation is set

### DIFF
--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -143,11 +143,14 @@ func (r *ImageBasedUpgradeReconciler) cleanup(
 		handleError(err, "failed to cleanup precaching resources.")
 	}
 
-	r.Log.Info("Cleaning up Backup CRs")
+	r.Log.Info("Cleaning up DeleteBackupRequest and Backup CRs")
+	if err := r.BackupRestore.CleanupDeleteBackupRequests(ctx); err != nil {
+		handleError(err, "failed to cleanup DeleteBackupRequest CRs.")
+	}
 	if allRemoved, err := r.BackupRestore.CleanupBackups(ctx); err != nil {
 		handleError(err, "failed to cleanup backups.")
 	} else if !allRemoved {
-		err := errors.New("failed to delete all the backup CRs.")
+		err := errors.New("failed to delete all the backup CRs")
 		handleError(err, err.Error())
 	}
 

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -84,6 +84,7 @@ var (
 // BackuperRestorer interface also used for mocks
 type BackuperRestorer interface {
 	CleanupBackups(ctx context.Context) (bool, error)
+	CleanupDeleteBackupRequests(ctx context.Context) error
 	CheckOadpOperatorAvailability(ctx context.Context) error
 	EnsureOadpConfiguration(ctx context.Context) error
 	ExportOadpConfigurationToDir(ctx context.Context, toDir, oadpNamespace string) error

--- a/internal/backuprestore/mocks/mock_backuprestore.go
+++ b/internal/backuprestore/mocks/mock_backuprestore.go
@@ -72,6 +72,20 @@ func (mr *MockBackuperRestorerMockRecorder) CleanupBackups(ctx any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupBackups", reflect.TypeOf((*MockBackuperRestorer)(nil).CleanupBackups), ctx)
 }
 
+// CleanupDeleteBackupRequests mocks base method.
+func (m *MockBackuperRestorer) CleanupDeleteBackupRequests(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupDeleteBackupRequests", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupDeleteBackupRequests indicates an expected call of CleanupDeleteBackupRequests.
+func (mr *MockBackuperRestorerMockRecorder) CleanupDeleteBackupRequests(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupDeleteBackupRequests", reflect.TypeOf((*MockBackuperRestorer)(nil).CleanupDeleteBackupRequests), ctx)
+}
+
 // EnsureOadpConfiguration mocks base method.
 func (m *MockBackuperRestorer) EnsureOadpConfiguration(ctx context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
When facing network issues with the S3 storage backed, the user might need to also have automatic cleanup for the DeleteBackupRequests CRs that are leftover.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>