### PR TITLE
CNF-11641: seedgen: Use RELATED_IMAGE_RECERT_IMAGE, if available

### DIFF
--- a/controllers/seedgen_controller.go
+++ b/controllers/seedgen_controller.go
@@ -419,9 +419,16 @@ func (r *SeedGeneratorReconciler) rmPreviousImagerContainer() error {
 	return nil
 }
 
+// getRecertImagePullSpec returns the recert image pull-spec, based on the following priority order:
+//   - Use recertImage from seedgen spec, if specified
+//   - If not, get the value from the recert image environment variable
+//   - If environment variable is not set, use the default value
 func (r *SeedGeneratorReconciler) getRecertImagePullSpec(seedgen *seedgenv1alpha1.SeedGenerator) (recertImage string) {
 	if seedgen.Spec.RecertImage == "" {
-		recertImage = common.DefaultRecertImage
+		recertImage = os.Getenv(common.RecertImageEnvKey)
+		if recertImage == "" {
+			recertImage = common.DefaultRecertImage
+		}
 	} else {
 		recertImage = seedgen.Spec.RecertImage
 	}

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -31,6 +31,7 @@ const (
 	ImageRegistryAuthFile = "/var/lib/kubelet/config.json"
 	KubeconfigFile        = "/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/lb-ext.kubeconfig"
 
+	RecertImageEnvKey      = "RELATED_IMAGE_RECERT_IMAGE"
 	DefaultRecertImage     = "quay.io/edge-infrastructure/recert:v0"
 	EtcdStaticPodFile      = "/etc/kubernetes/manifests/etcd-pod.yaml"
 	EtcdStaticPodContainer = "etcd"


### PR DESCRIPTION
If the seedgen CR does not define a specific recert image to use, check for the RELATED_IMAGE_RECERT_IMAGE environment variable. If set, use this as the default recert image. If not, fall back to the defined const.