### PR TITLE
Adds force in IBI flow to format containers partition if already existed

### DIFF
--- a/ib-cli/installationiso/data/install-rhcos-and-restore-seed.sh
+++ b/ib-cli/installationiso/data/install-rhcos-and-restore-seed.sh
@@ -22,7 +22,7 @@ if [[ "$create_extra_partition" == "true" ]]; then
     # Create new partition for /var/lib/containers
     sfdisk ${installation_disk} <<< write
     sgdisk --new $extra_partition_number:$extra_partition_start --change-name $extra_partition_number:$extra_partition_label ${installation_disk}
-    mkfs.xfs ${installation_disk}$extra_partition_number
+    mkfs.xfs -f ${installation_disk}$extra_partition_number
 fi
 
 


### PR DESCRIPTION
This change fixes an issue where the partition for local container storage already existed bfore writing the IBI ISO to disk:

~~~
Mar 13 11:32:32 localhost.localdomain install-rhcos-and-restore-seed.sh[2380]: Information: Moved requested sector from 853816974 to 853815296 in
Mar 13 11:32:32 localhost.localdomain install-rhcos-and-restore-seed.sh[2380]: order to align on 2048-sector boundaries.
Mar 13 11:32:32 localhost.localdomain install-rhcos-and-restore-seed.sh[2380]: Setting name!
Mar 13 11:32:32 localhost.localdomain install-rhcos-and-restore-seed.sh[2380]: partNum is 4
Mar 13 11:32:32 localhost.localdomain install-rhcos-and-restore-seed.sh[2380]: The operation has completed successfully.
Mar 13 11:32:32 localhost.localdomain kernel:  sda: sda1 sda2 sda3 sda4 sda5
Mar 13 11:32:32 localhost.localdomain install-rhcos-and-restore-seed.sh[2391]: mkfs.xfs: /dev/sda5 appears to contain an existing filesystem (xfs).
Mar 13 11:32:32 localhost.localdomain install-rhcos-and-restore-seed.sh[2391]: mkfs.xfs: Use the -f option to force overwrite.
Mar 13 11:32:32 localhost.localdomain systemd[1]: install-rhcos-and-restore-seed.service: Main process exited, code=exited, status=1/FAILURE
Mar 13 11:32:32 localhost.localdomain systemd[1]: install-rhcos-and-restore-seed.service: Failed with result 'exit-code'.
~~~

cc/ @eranco74 @javipolo 