### PR TITLE
OCPBUGS-30190: Cleanup stale Backups during Prep stage

### DIFF
--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -287,16 +287,17 @@ func (r *ImageBasedUpgradeReconciler) validateIBUSpec(ctx context.Context, ibu *
 		return fmt.Errorf("failed to validate seed image OCP version: %w", err)
 	}
 
-	// If OADP configmap is provided, validate the configmap and check if OADP operator is available
+	// If OADP configmap is provided, check if OADP operator is available, validate the configmap
+	// and remove stale Backups from object storage if any.
 	if len(ibu.Spec.OADPContent) != 0 {
-		err := r.BackupRestore.ValidateOadpConfigmaps(ctx, ibu.Spec.OADPContent)
-		if err != nil {
-			return fmt.Errorf("failed to validate oadp configMap: %w", err)
-		}
-
-		err = r.BackupRestore.CheckOadpOperatorAvailability(ctx)
+		err := r.BackupRestore.CheckOadpOperatorAvailability(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to check oadp operator availability: %w", err)
+		}
+
+		err = r.BackupRestore.ValidateOadpConfigmaps(ctx, ibu.Spec.OADPContent)
+		if err != nil {
+			return fmt.Errorf("failed to validate oadp configMap: %w", err)
 		}
 	}
 

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -444,6 +444,18 @@ func (h *BRHandler) ValidateOadpConfigmaps(ctx context.Context, content []lcav1a
 			return NewBRFailedValidationError("OADP", errMsg)
 		}
 	}
+
+	// Check for any stale backup CRs in this cluster
+	if allStaleBackupsRemoved, err := h.CleanupStaleBackups(ctx, backups); err != nil {
+		errMsg := fmt.Sprintf("Failed to cleanup stale Backups: %s", err)
+		h.Log.Error(nil, errMsg)
+		return NewBRFailedValidationError("OADP", errMsg)
+	} else if !allStaleBackupsRemoved {
+		errMsg := fmt.Sprintf("Failed to delete all the stale Backup CRs: %s", err)
+		h.Log.Error(nil, errMsg)
+		return NewBRFailedValidationError("OADP", errMsg)
+	}
+
 	h.Log.Info("OADP configMaps are validated", "configMaps", content)
 	return nil
 }

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -84,6 +84,7 @@ var (
 // BackuperRestorer interface also used for mocks
 type BackuperRestorer interface {
 	CleanupBackups(ctx context.Context) (bool, error)
+	CleanupStaleBackups(ctx context.Context, backups []*velerov1.Backup) (bool, error)
 	CleanupDeleteBackupRequests(ctx context.Context) error
 	CheckOadpOperatorAvailability(ctx context.Context) error
 	EnsureOadpConfiguration(ctx context.Context) error

--- a/internal/backuprestore/mocks/mock_backuprestore.go
+++ b/internal/backuprestore/mocks/mock_backuprestore.go
@@ -86,6 +86,21 @@ func (mr *MockBackuperRestorerMockRecorder) CleanupDeleteBackupRequests(ctx any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupDeleteBackupRequests", reflect.TypeOf((*MockBackuperRestorer)(nil).CleanupDeleteBackupRequests), ctx)
 }
 
+// CleanupStaleBackups mocks base method.
+func (m *MockBackuperRestorer) CleanupStaleBackups(ctx context.Context, backups []*v1.Backup) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupStaleBackups", ctx, backups)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CleanupStaleBackups indicates an expected call of CleanupStaleBackups.
+func (mr *MockBackuperRestorerMockRecorder) CleanupStaleBackups(ctx, backups any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupStaleBackups", reflect.TypeOf((*MockBackuperRestorer)(nil).CleanupStaleBackups), ctx, backups)
+}
+
 // EnsureOadpConfiguration mocks base method.
 func (m *MockBackuperRestorer) EnsureOadpConfiguration(ctx context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
If the target cluster is reinstalled before cleaning up any previous Backups from the object storage, OADP may sync those stale Backup CRs back to this cluster, even though they are labeled with a different `clusterID`.

Handling those stale Backups early during the `Prep` stage would save the time required to delete those (via `DeleteBackupRequest` CR with OADP) from the `Upgrade` stage.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>


/cc @Missxiaoguo @jc-rh @browsell 