### PR TITLE
OCPBUGS-30190: Handle stale Backups during Upgrade stage

### DIFF
--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -477,6 +477,12 @@ func (u *UpgHandler) HandleBackup(ctx context.Context, ibu *lcav1alpha1.ImageBas
 	// trigger and track each group
 	for index, backups := range sortedBackupGroups {
 		u.Log.Info("Processing backup", "groupIndex", index+1, "totalGroups", len(sortedBackupGroups))
+
+		// check for any stale backup in the group
+		if err := u.BackupRestore.CleanupStaleBackups(ctx, backups); err != nil {
+			return requeueWithError(fmt.Errorf("failed to cleanup stale Backups: %w", err))
+		}
+
 		backupTracker, err := u.BackupRestore.StartOrTrackBackup(ctx, backups)
 		if err != nil {
 			return requeueWithError(fmt.Errorf("error while starting or tracking backup: %w", err))

--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -139,6 +139,7 @@ func TestImageBasedUpgradeReconciler_handleBackup(t *testing.T) {
 			mockBackuprestore.EXPECT().GetSortedBackupsFromConfigmap(gomock.Any(), gomock.Any()).Return(tt.inputVelero, nil)
 
 			for _, track := range tt.trackers {
+				mockBackuprestore.EXPECT().CleanupStaleBackups(gomock.Any(), gomock.Any()).Return(nil)
 				mockBackuprestore.EXPECT().StartOrTrackBackup(gomock.Any(), gomock.Any()).Return(track())
 			}
 
@@ -331,6 +332,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 		healthCheckError                                error
 		getSortedBackupsFromConfigmapReturn             func() ([][]*velerov1.Backup, error)
 		getStartOrTrackBackupReturn                     func() (*backuprestore.BackupTracker, error)
+		getCleanupStaleBackupsReturn                    func() error
 		remountSysrootReturn                            func() error
 		exportOadpConfigurationToDirReturn              func() error
 		exportRestoresToDirReturn                       func() error
@@ -447,6 +449,9 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 			},
 			getSortedBackupsFromConfigmapReturn: func() ([][]*velerov1.Backup, error) {
 				return [][]*velerov1.Backup{{&velerov1.Backup{}}}, nil
+			},
+			getCleanupStaleBackupsReturn: func() error {
+				return nil
 			},
 			getStartOrTrackBackupReturn: func() (*backuprestore.BackupTracker, error) {
 				return &backuprestore.BackupTracker{
@@ -712,6 +717,9 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.getSortedBackupsFromConfigmapReturn != nil {
 				mockBackuprestore.EXPECT().GetSortedBackupsFromConfigmap(gomock.Any(), gomock.Any()).Return(tt.getSortedBackupsFromConfigmapReturn())
+			}
+			if tt.getCleanupStaleBackupsReturn != nil {
+				mockBackuprestore.EXPECT().CleanupStaleBackups(gomock.Any(), gomock.Any()).Return(tt.getCleanupStaleBackupsReturn())
 			}
 			if tt.getStartOrTrackBackupReturn != nil {
 				mockBackuprestore.EXPECT().StartOrTrackBackup(gomock.Any(), gomock.Any()).Return(tt.getStartOrTrackBackupReturn())

--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -91,7 +91,7 @@ func (h *BRHandler) StartOrTrackBackup(ctx context.Context, backups []*velerov1.
 
 	for _, backup := range backups {
 		var existingBackup *velerov1.Backup
-		existingBackup, err := getBackup(ctx, h.Client, backup.Name, backup.Namespace)
+		existingBackup, err := getValidBackup(ctx, h.Client, backup.Name, backup.Namespace)
 		if err != nil {
 			return &bt, err
 		}

--- a/internal/backuprestore/backup_test.go
+++ b/internal/backuprestore/backup_test.go
@@ -50,7 +50,8 @@ import (
 const oadpNs = "openshift-adp"
 
 var (
-	testscheme = scheme.Scheme
+	testscheme    = scheme.Scheme
+	testClusterID = "42fd3c76-4a1b-4e8b-8397-1c7210fd3e36"
 )
 
 func init() {
@@ -76,6 +77,7 @@ func fakeBackupCr(name, applyWave, backupResource string) *velerov1.Backup {
 	}
 	backup.SetName(name)
 	backup.SetNamespace(oadpNs)
+	backup.SetLabels(map[string]string{clusterIDLabel: testClusterID})
 	backup.SetAnnotations(map[string]string{common.ApplyWaveAnn: applyWave})
 
 	backup.Spec = velerov1.BackupSpec{
@@ -561,7 +563,7 @@ func TestTriggerBackup(t *testing.T) {
 			Name: "version",
 		},
 		Spec: configv1.ClusterVersionSpec{
-			ClusterID: "42fd3c76-4a1b-4e8b-8397-1c7210fd3e36",
+			ClusterID: configv1.ClusterID(testClusterID),
 		},
 	}
 

--- a/internal/backuprestore/restore.go
+++ b/internal/backuprestore/restore.go
@@ -69,7 +69,7 @@ func (h *BRHandler) StartOrTrackRestore(ctx context.Context, restores []*velerov
 			// OADP is running and connects to the object storage.
 			// Ensure the backup exists before creating the restore.
 			var existingBackup *velerov1.Backup
-			existingBackup, err = getBackup(ctx, h, restore.Spec.BackupName, restore.Namespace)
+			existingBackup, err = getValidBackup(ctx, h, restore.Spec.BackupName, restore.Namespace)
 			if err != nil {
 				return rt, err
 			}


### PR DESCRIPTION
If the target cluster is reinstalled before cleaning up any previous `Backups` from the object storage, OADP may sync those stale `Backup` CRs back to this cluster, even though they are labeled with a different `clusterID`.

This piece handles those stale backups during the `Upgrade` phase, basically we added a check to use only those `Backup` / `Restore` resources that matches the `clusterID` of the target cluster. Additionally, we also incorporated the `CleanupStaleBackups` function during this stage (for the case when any `Backup` is arbitrarily / unexpectedly changed between `Prep` and `Upgrade` stages).

Signed-off-by: Leonardo Ochoa-Aday [lochoa@redhat.com](mailto:lochoa@redhat.com)

/cc @Missxiaoguo @jc-rh @browsell