### PR TITLE
CNF-11524: Log error list of deletebackuprequest

### DIFF
--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -139,7 +138,7 @@ func (r *ImageBasedUpgradeReconciler) cleanup(
 	var handleError = func(err error, msg string) {
 		successful = false
 		r.Log.Error(err, msg)
-		errorMessage += msg + " "
+		errorMessage += err.Error() + " "
 	}
 
 	r.Log.Info("Terminating precaching worker thread, will wait up to 30 seconds")
@@ -162,11 +161,8 @@ func (r *ImageBasedUpgradeReconciler) cleanup(
 	if err := r.BackupRestore.CleanupDeleteBackupRequests(ctx); err != nil {
 		handleError(err, "failed to cleanup DeleteBackupRequest CRs.")
 	}
-	if allRemoved, err := r.BackupRestore.CleanupBackups(ctx); err != nil {
-		handleError(err, "failed to cleanup backups.")
-	} else if !allRemoved {
-		err := errors.New("failed to delete all the backup CRs")
-		handleError(err, err.Error())
+	if err := r.BackupRestore.CleanupBackups(ctx); err != nil {
+		handleError(err, "failed to cleanup backups")
 	}
 
 	r.Log.Info("Cleaning up IBU files")

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -83,8 +83,8 @@ var (
 
 // BackuperRestorer interface also used for mocks
 type BackuperRestorer interface {
-	CleanupBackups(ctx context.Context) (bool, error)
-	CleanupStaleBackups(ctx context.Context, backups []*velerov1.Backup) (bool, error)
+	CleanupBackups(ctx context.Context) error
+	CleanupStaleBackups(ctx context.Context, backups []*velerov1.Backup) error
 	CleanupDeleteBackupRequests(ctx context.Context) error
 	CheckOadpOperatorAvailability(ctx context.Context) error
 	EnsureOadpConfiguration(ctx context.Context) error
@@ -446,12 +446,8 @@ func (h *BRHandler) ValidateOadpConfigmaps(ctx context.Context, content []lcav1a
 	}
 
 	// Check for any stale backup CRs in this cluster
-	if allStaleBackupsRemoved, err := h.CleanupStaleBackups(ctx, backups); err != nil {
+	if err := h.CleanupStaleBackups(ctx, backups); err != nil {
 		errMsg := fmt.Sprintf("Failed to cleanup stale Backups: %s", err)
-		h.Log.Error(nil, errMsg)
-		return NewBRFailedValidationError("OADP", errMsg)
-	} else if !allStaleBackupsRemoved {
-		errMsg := fmt.Sprintf("Failed to delete all the stale Backup CRs: %s", err)
 		h.Log.Error(nil, errMsg)
 		return NewBRFailedValidationError("OADP", errMsg)
 	}

--- a/internal/backuprestore/mocks/mock_backuprestore.go
+++ b/internal/backuprestore/mocks/mock_backuprestore.go
@@ -58,12 +58,11 @@ func (mr *MockBackuperRestorerMockRecorder) CheckOadpOperatorAvailability(ctx an
 }
 
 // CleanupBackups mocks base method.
-func (m *MockBackuperRestorer) CleanupBackups(ctx context.Context) (bool, error) {
+func (m *MockBackuperRestorer) CleanupBackups(ctx context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupBackups", ctx)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // CleanupBackups indicates an expected call of CleanupBackups.
@@ -87,12 +86,11 @@ func (mr *MockBackuperRestorerMockRecorder) CleanupDeleteBackupRequests(ctx any)
 }
 
 // CleanupStaleBackups mocks base method.
-func (m *MockBackuperRestorer) CleanupStaleBackups(ctx context.Context, backups []*v1.Backup) (bool, error) {
+func (m *MockBackuperRestorer) CleanupStaleBackups(ctx context.Context, backups []*v1.Backup) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupStaleBackups", ctx, backups)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // CleanupStaleBackups indicates an expected call of CleanupStaleBackups.


### PR DESCRIPTION
Instead of creating deletebackuprequest for each backup and then wait for the backups to be deleted, poll the deletebackuprequest CRs themselves and wait for them to be processed and log the error list if there is any.
After that check all the backups are deleted.