### PR TITLE
OCPBUGS-30190: Improve CleanupStaleBackups function

### DIFF
--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -551,11 +551,14 @@ func (h *BRHandler) CleanupStaleBackups(ctx context.Context, backups []*velerov1
 		existingBackup, err := getBackup(ctx, h.Client, backup.Name, backup.Namespace)
 		if err != nil {
 			return false, err
+		} else if existingBackup == nil {
+			// Backup isn't found, continue to the next one
+			continue
 		}
 
 		// Check cluster ID label of existingBackup
-		labels := backup.GetLabels()
-		if labels[clusterIDLabel] != clusterID {
+		labels := existingBackup.GetLabels()
+		if labels != nil && labels[clusterIDLabel] != clusterID {
 			staleBackupList.Items = append(staleBackupList.Items, *existingBackup)
 
 			deleteBackupRequest := &velerov1.DeleteBackupRequest{


### PR DESCRIPTION
This fixes the `CleanupStaleBackups` function for when there aren't Backups in the cluster. If the `getBackup` call returns `nil`, it now continues to the next one, avoiding any possible panic.

/cc @browsell @Missxiaoguo 