### PR TITLE
MGMT-17364: Allow providing subnet for IBI installation

### DIFF
--- a/api/seedreconfig/seedreconfig.go
+++ b/api/seedreconfig/seedreconfig.go
@@ -92,6 +92,11 @@ type SeedReconfiguration struct {
 
 	// PullSecret is the secret to use when pulling images. Equivalent to install-config.yaml's pullSecret.
 	PullSecret string `json:"pull_secret,omitempty"`
+
+	// MachineNetwork is the subnet provided by user for the ocp cluster.
+	// This will be used to create the node network and choose ip address for the node.
+	// Equivalent to install-config.yaml's machineNetwork.
+	MachineNetwork string `json:"machine_network,omitempty"`
 }
 
 type KubeConfigCryptoRetention struct {


### PR DESCRIPTION
[MGMT-17364](https://issues.redhat.com//browse/MGMT-17364): Allow providing subnet for IBI installation
Adding new api field MachineNetwork it will be used to set nodeip hint that will point nodeip-configuration to the right ip