### PR TITLE
Do not store kubeadmin hash in seed image

### DIFF
--- a/lca-cli/ops/ops.go
+++ b/lca-cli/ops/ops.go
@@ -109,7 +109,7 @@ func (o *ops) RestoreOriginalSeedCrypto(recertContainerImage, authFile string) e
 	o.log.Info("Run recert --extend-expiration tool")
 	recertConfigFile := path.Join(common.BackupCertsDir, recert.RecertConfigFile)
 
-	originalPasswordHash, err := utils.LoadKubeadminPasswordHash(common.BackupDir)
+	originalPasswordHash, err := utils.LoadKubeadminPasswordHash(common.BackupCertsDir)
 	if err != nil {
 		return fmt.Errorf("failed to load kubeadmin password hash: %w", err)
 	}

--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -105,7 +105,7 @@ func (s *SeedCreator) CreateSeedImage() error {
 		if err := utils.BackupKubeconfigCrypto(ctx, s.client, common.BackupCertsDir); err != nil {
 			return fmt.Errorf("failed to backing up seed cluster certificates for recert tool: %w", err)
 		}
-		if seedHasKubeadminPassword, err = utils.BackupKubeadminPasswordHash(ctx, s.client, common.BackupDir); err != nil {
+		if seedHasKubeadminPassword, err = utils.BackupKubeadminPasswordHash(ctx, s.client, common.BackupCertsDir); err != nil {
 			return fmt.Errorf("failed to backup kubeadmin password hash: %w", err)
 		}
 		s.log.Info("Seed cluster certificates backed up successfully for recert tool")


### PR DESCRIPTION
Store the backup kubeadmin hash file in the BackupCertsDir, so it wont make it to the seed image

/cc @omertuc 