### PR TITLE
CNF-11876: remove autoRollback config params from spec (except InitMonitorTimeoutSeconds) and use annotations instead

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -435,48 +435,47 @@ Bootloader updated; bootconfig swap: yes; bootversion: boot.0.1, deployment coun
 
 In an IBU, the LCA provides capability for automatic rollback upon failure at certain points of the upgrade, after the
 Upgrade stage reboot. The automatic rollback feature is enabled by default in an IBU. To disable it, there are
-configuration options in the `ImageBasedUpgrade` CRD that can be defined:
+configuration options with annotation:
 
-- In the `prepare-installation-configuration` systemd service-unit (`prepare-installation-configuration`). Disabled by
-  setting `.spec.autoRollbackOnFailure.disabledForPostRebootConfig: true` in the IBU `upgrade` CR
-- In the `installation-configuration` systemd service-unit (`lca-cli postpivot`). Disabled by
-  setting `.spec.autoRollbackOnFailure.disabledForPostRebootConfig: true` in the IBU `upgrade` CR
-- In the LCA IBU post-reboot Upgrade stage handler. Disabled by
-  setting `.spec.autoRollbackOnFailure.disabledForUpgradeCompletion: true` in the IBU `upgrade` CR
+- In the `prepare-installation-configuration` systemd service-unit (`prepare-installation-configuration`). Disabled with annotation `auto-rollback-on-failure.lca.openshift.io/post-reboot-config='Disabled'` in the IBU `upgrade` CR
+- In the `installation-configuration` systemd service-unit (`lca-cli postpivot`). Disabled with annotation `auto-rollback-on-failure.lca.openshift.io/post-reboot-config='Disabled'` in the IBU `upgrade` CR
+- In the LCA IBU post-reboot Upgrade stage handler. Disabled with annotation `auto-rollback-on-failure.lca.openshift.io/upgrade-completion: Disabled` in the IBU `upgrade` CR
 
 These values can be set via patch command, for example:
 
 ```console
 # Disable automatic rollback for the post-reboot config service-units
-oc patch imagebasedupgrades.lca.openshift.io upgrade --type=merge -p='{"spec": {"autoRollbackOnFailure": {"disabledForPostRebootConfig": true}}}'
+oc -n  openshift-lifecycle-agent annotate ibu upgrade auto-rollback-on-failure.lca.openshift.io/post-reboot-config='Disabled'
 
 # Disable automatic rollback for the post-reboot Upgrade stage handler
-oc patch imagebasedupgrades.lca.openshift.io upgrade --type=merge -p='{"spec": {"autoRollbackOnFailure": {"disabledForUpgradeCompletion": true}}}'
+oc -n  openshift-lifecycle-agent annotate ibu upgrade auto-rollback-on-failure.lca.openshift.io/upgrade-completion='Disabled'
 
 # Reset to default
-oc patch imagebasedupgrades.lca.openshift.io upgrade --type json -p='[{"op": "replace", "path": "/spec/autoRollbackOnFailure", "value": {} }]'
+oc -n  openshift-lifecycle-agent annotate ibu upgrade auto-rollback-on-failure.lca.openshift.io/post-reboot-config-
+oc -n  openshift-lifecycle-agent annotate ibu upgrade auto-rollback-on-failure.lca.openshift.io/upgrade-completion-
 ```
 
 Alternatively, use `oc edit ibu upgrade` and add the following to the `.spec` section:
 
 ```yaml
-  autoRollbackOnFailure:
-    disabledForPostRebootConfig: true
-    disabledForUpgradeCompletion: true
+metadata:
+  annotations:
+    auto-rollback-on-failure.lca.openshift.io/post-reboot-config: Disabled
+    auto-rollback-on-failure.lca.openshift.io/upgrade-completion: Disabled
 ```
 
 In addition, there is an `lca-init-monitor.service` that runs post-reboot with a configurable timeout. When LCA marks
 the upgrade complete, it shuts down this monitor. If this point is not reached within the configured timeout, the
-init-monitor will trigger an automatic rollback. This can be configured via the `.spec.autoRollbackOnFailure` fields:
+init-monitor will trigger an automatic rollback.:
 
-- To disable the init-monitor automatic rollback, set `.spec.autoRollbackOnFailure.disabledInitMonitor` to `true`
+- To disable the init-monitor automatic rollback annotate with `auto-rollback-on-failure.lca.openshift.io/init-monitor='Disabled'`
 - Configure the timeout value, in seconds, by setting `.spec.autoRollbackOnFailure.initMonitorTimeoutSeconds`
 
 These values can be set via patch command, for example:
 
 ```console
 # Disable automatic rollback for the init-monitor
-oc patch imagebasedupgrades.lca.openshift.io upgrade --type=merge -p='{"spec": {"autoRollbackOnFailure": {"disabledInitMonitor": true}}}'
+oc -n  openshift-lifecycle-agent annotate ibu upgrade auto-rollback-on-failure.lca.openshift.io/init-monitor='Disabled'
 
 # Set the init-monitor timeout to one hour. The default timeout is 30 minutes (1800 seconds)
 oc patch imagebasedupgrades.lca.openshift.io upgrade --type=merge -p='{"spec": {"autoRollbackOnFailure": {"initMonitorTimeoutSeconds": 3600}}}'
@@ -486,12 +485,16 @@ oc patch imagebasedupgrades.lca.openshift.io upgrade --type=merge -p='{"spec": {
 
 # Reset to default
 oc patch imagebasedupgrades.lca.openshift.io upgrade --type json -p='[{"op": "replace", "path": "/spec/autoRollbackOnFailure", "value": {} }]'
+oc -n  openshift-lifecycle-agent annotate ibu upgrade auto-rollback-on-failure.lca.openshift.io/init-monitor-
 ```
 
 Alternatively, use `oc edit ibu upgrade` and add the following to the `.spec` section:
 
 ```yaml
+metadata:
+  annotations:
+    auto-rollback-on-failure.lca.openshift.io/init-monitor: Disabled
+spec:
   autoRollbackOnFailure:
-    disabledInitMonitor: true
     initMonitorTimeoutSeconds: 3600
 ```

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -98,18 +98,6 @@ type SeedImageRef struct {
 // AutoRollbackOnFailure defines automatic rollback settings if the upgrade fails or if the upgrade does not
 // complete within the specified time limit.
 type AutoRollbackOnFailure struct {
-	// DisabledForPostRebootConfig when set to true, disables automatic rollback when the reconfiguration of the
-	// cluster fails upon the first reboot.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	DisabledForPostRebootConfig bool `json:"disabledForPostRebootConfig,omitempty"` // If true, disable auto-rollback for post-reboot config service-unit(s)
-	// DisabledForUpgradeCompletion when set to true, disables automatic rollback after the Lifecycle Agent reports
-	// a failed upgrade upon completion.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	DisabledForUpgradeCompletion bool `json:"disabledForUpgradeCompletion,omitempty"` // If true, disable auto-rollback for Upgrade completion handler
-	// DisabledInitMonitor when set to true, disables automatic rollback when the upgrade does not complete after
-	// reboot within the time frame specified in the initMonitorTimeoutSeconds field.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	DisabledInitMonitor bool `json:"disabledInitMonitor,omitempty"` // If true, disable LCA Init Monitor watchdog, which triggers auto-rollback if timeout occurs before upgrade completion
 	// InitMonitorTimeoutSeconds defines the time frame in seconds. If not defined or set to 0, the default value of
 	// 1800 seconds (30 minutes) is used.
 	// +kubebuilder:validation:Minimum=0

--- a/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
+++ b/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
@@ -65,21 +65,6 @@ spec:
                   if the upgrade fails or if the upgrade does not complete within
                   the specified time limit.
                 properties:
-                  disabledForPostRebootConfig:
-                    description: DisabledForPostRebootConfig when set to true, disables
-                      automatic rollback when the reconfiguration of the cluster fails
-                      upon the first reboot.
-                    type: boolean
-                  disabledForUpgradeCompletion:
-                    description: DisabledForUpgradeCompletion when set to true, disables
-                      automatic rollback after the Lifecycle Agent reports a failed
-                      upgrade upon completion.
-                    type: boolean
-                  disabledInitMonitor:
-                    description: DisabledInitMonitor when set to true, disables automatic
-                      rollback when the upgrade does not complete after reboot within
-                      the time frame specified in the initMonitorTimeoutSeconds field.
-                    type: boolean
                   initMonitorTimeoutSeconds:
                     description: InitMonitorTimeoutSeconds defines the time frame
                       in seconds. If not defined or set to 0, the default value of

--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -111,25 +111,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Auto Rollback On Failure
         path: autoRollbackOnFailure
-      - description: DisabledForPostRebootConfig when set to true, disables automatic
-          rollback when the reconfiguration of the cluster fails upon the first reboot.
-        displayName: Disabled For Post Reboot Config
-        path: autoRollbackOnFailure.disabledForPostRebootConfig
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: DisabledForUpgradeCompletion when set to true, disables automatic
-          rollback after the Lifecycle Agent reports a failed upgrade upon completion.
-        displayName: Disabled For Upgrade Completion
-        path: autoRollbackOnFailure.disabledForUpgradeCompletion
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: DisabledInitMonitor when set to true, disables automatic rollback
-          when the upgrade does not complete after reboot within the time frame specified
-          in the initMonitorTimeoutSeconds field.
-        displayName: Disabled Init Monitor
-        path: autoRollbackOnFailure.disabledInitMonitor
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: InitMonitorTimeoutSeconds defines the time frame in seconds.
           If not defined or set to 0, the default value of 1800 seconds (30 minutes)
           is used.

--- a/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
+++ b/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
@@ -65,21 +65,6 @@ spec:
                   if the upgrade fails or if the upgrade does not complete within
                   the specified time limit.
                 properties:
-                  disabledForPostRebootConfig:
-                    description: DisabledForPostRebootConfig when set to true, disables
-                      automatic rollback when the reconfiguration of the cluster fails
-                      upon the first reboot.
-                    type: boolean
-                  disabledForUpgradeCompletion:
-                    description: DisabledForUpgradeCompletion when set to true, disables
-                      automatic rollback after the Lifecycle Agent reports a failed
-                      upgrade upon completion.
-                    type: boolean
-                  disabledInitMonitor:
-                    description: DisabledInitMonitor when set to true, disables automatic
-                      rollback when the upgrade does not complete after reboot within
-                      the time frame specified in the initMonitorTimeoutSeconds field.
-                    type: boolean
                   initMonitorTimeoutSeconds:
                     description: InitMonitorTimeoutSeconds defines the time frame
                       in seconds. If not defined or set to 0, the default value of

--- a/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
+++ b/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
@@ -66,25 +66,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Auto Rollback On Failure
         path: autoRollbackOnFailure
-      - description: DisabledForPostRebootConfig when set to true, disables automatic
-          rollback when the reconfiguration of the cluster fails upon the first reboot.
-        displayName: Disabled For Post Reboot Config
-        path: autoRollbackOnFailure.disabledForPostRebootConfig
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: DisabledForUpgradeCompletion when set to true, disables automatic
-          rollback after the Lifecycle Agent reports a failed upgrade upon completion.
-        displayName: Disabled For Upgrade Completion
-        path: autoRollbackOnFailure.disabledForUpgradeCompletion
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: DisabledInitMonitor when set to true, disables automatic rollback
-          when the upgrade does not complete after reboot within the time frame specified
-          in the initMonitorTimeoutSeconds field.
-        displayName: Disabled Init Monitor
-        path: autoRollbackOnFailure.disabledInitMonitor
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: InitMonitorTimeoutSeconds defines the time frame in seconds.
           If not defined or set to 0, the default value of 1800 seconds (30 minutes)
           is used.

--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -286,10 +286,12 @@ var getStaterootVarPath = func(stateroot string) string {
 var CheckHealth = healthcheck.HealthChecks
 
 func (u *UpgHandler) autoRollbackIfEnabled(ibu *lcav1alpha1.ImageBasedUpgrade, msg string) {
-	// Check whether auto-rollback is desired
-	if ibu.Spec.AutoRollbackOnFailure.DisabledForUpgradeCompletion {
-		// Auto-rollback is not enabled, so do nothing
-		return
+	// Check whether auto-rollback is disabled using annotation
+	if val, exists := ibu.GetAnnotations()[common.AutoRollbackOnFailureUpgradeCompletionAnnotation]; exists {
+		if val == common.AutoRollbackDisableValue {
+			u.Log.Info("Auto-rollback upgrade completion is disabled")
+			return
+		}
 	}
 
 	u.Log.Info("Automatically rolling back due to failure")

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -65,6 +65,17 @@ const (
 	IBUAutoRollbackInitMonitorTimeoutDefaultSeconds = 1800
 	IBUInitMonitorService                           = "lca-init-monitor.service"
 	IBUInitMonitorServiceFile                       = "/etc/systemd/system/" + IBUInitMonitorService
+	// AutoRollbackOnFailurePostRebootConfigAnnotation configure automatic rollback when the reconfiguration of the cluster fails upon the first reboot.
+	// Only acceptable value is AutoRollbackDisableValue. Any other value is treated as "Enabled".
+	AutoRollbackOnFailurePostRebootConfigAnnotation = "auto-rollback-on-failure.lca.openshift.io/post-reboot-config"
+	// AutoRollbackOnFailureUpgradeCompletionAnnotation configure automatic rollback after the Lifecycle Agent reports a failed upgrade upon completion.
+	// Only acceptable value is AutoRollbackOnFailureDisableValue. Any other value is treated as "Enabled".
+	AutoRollbackOnFailureUpgradeCompletionAnnotation = "auto-rollback-on-failure.lca.openshift.io/upgrade-completion"
+	// AutoRollbackOnFailureInitMonitorAnnotation configure automatic rollback LCA Init Monitor watchdog, which triggers auto-rollback if timeout occurs before upgrade completion
+	// Only acceptable value is AutoRollbackDisableValue. Any other value is treated as "Enabled".
+	AutoRollbackOnFailureInitMonitorAnnotation = "auto-rollback-on-failure.lca.openshift.io/init-monitor"
+	// AutoRollbackDisableValue value that decides if rollback is disabled
+	AutoRollbackDisableValue = "Disabled"
 
 	LcaNamespace = "openshift-lifecycle-agent"
 	Host         = "/host"

--- a/internal/reboot/reboot.go
+++ b/internal/reboot/reboot.go
@@ -83,15 +83,34 @@ func (c *RebootClient) WriteIBUAutoRollbackConfigFile(ibu *lcav1alpha1.ImageBase
 	if monitorTimeout <= 0 {
 		monitorTimeout = common.IBUAutoRollbackInitMonitorTimeoutDefaultSeconds
 	}
+	c.log.Info("Auto-rollback init monitor timeout", "monitorTimeout", monitorTimeout)
+
+	// check autoRollback's InitMonitor config from annotation
+	initMonitorEnabled := true
+	if val, exists := ibu.GetAnnotations()[common.AutoRollbackOnFailureInitMonitorAnnotation]; exists {
+		if val == common.AutoRollbackDisableValue {
+			initMonitorEnabled = false
+		}
+	}
+	c.log.Info("Auto-rollback init monitor config", "initMonitorEnabled", initMonitorEnabled)
 
 	rollbackCfg := IBUAutoRollbackConfig{
-		InitMonitorEnabled: !ibu.Spec.AutoRollbackOnFailure.DisabledInitMonitor,
+		InitMonitorEnabled: initMonitorEnabled,
 		InitMonitorTimeout: monitorTimeout,
 		EnabledComponents:  make(map[string]bool),
 	}
 
-	rollbackCfg.EnabledComponents[InstallationConfigurationComponent] = !ibu.Spec.AutoRollbackOnFailure.DisabledForPostRebootConfig
-	rollbackCfg.EnabledComponents[PostPivotComponent] = !ibu.Spec.AutoRollbackOnFailure.DisabledForPostRebootConfig
+	// check autoRollback's PostReboot config from annotation
+	postRebootConfigEnabled := true
+	if val, exists := ibu.GetAnnotations()[common.AutoRollbackOnFailurePostRebootConfigAnnotation]; exists {
+		if val == common.AutoRollbackDisableValue {
+			postRebootConfigEnabled = false
+		}
+	}
+	c.log.Info("Auto-rollback post reboot config", "postRebootConfigEnabled", postRebootConfigEnabled)
+
+	rollbackCfg.EnabledComponents[InstallationConfigurationComponent] = postRebootConfigEnabled
+	rollbackCfg.EnabledComponents[PostPivotComponent] = postRebootConfigEnabled
 
 	if err := lcautils.MarshalToFile(rollbackCfg, cfgfile); err != nil {
 		return fmt.Errorf("failed to write rollback config file in %s: %w", cfgfile, err)


### PR DESCRIPTION
The autoRollback configs are now done using annotations and must only be configured for debug purposes. 