### PR TITLE
OCPBUGS-31896: Moving set of sshkey before network manipulations

### DIFF
--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -98,13 +98,13 @@ func (p *PostPivot) PostPivotConfiguration(ctx context.Context) error {
 		return fmt.Errorf("failed to get cluster info from %s, err: %w", "", err)
 	}
 
-	if err := p.networkConfiguration(ctx, seedReconfiguration); err != nil {
-		return fmt.Errorf("failed to configure networking, err: %w", err)
-	}
-
 	if err := utils.RunOnce("setSSHKey", p.workingDir, p.log, p.setSSHKey,
 		seedReconfiguration, sshKeyEarlyAccessFile); err != nil {
 		return fmt.Errorf("failed to run once setSSHKey for post pivot: %w", err)
+	}
+
+	if err := p.networkConfiguration(ctx, seedReconfiguration); err != nil {
+		return fmt.Errorf("failed to configure networking, err: %w", err)
 	}
 
 	if err := utils.RunOnce("pull-secret", p.workingDir, p.log, p.createPullSecretFile,


### PR DESCRIPTION
OCPBUGS-31896: Moving set of sshkey before network manipulations in order to allow ssh connection in case something will go wrong with network config but ip will exist