### PR TITLE
CNF-11930: Move oadp storage backend connection check to healthcheck

### DIFF
--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -385,6 +385,17 @@ func (u *UpgHandler) PostPivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedU
 		return requeueWithHealthCheckInterval(), nil
 	}
 
+	err = u.BackupRestore.EnsureOadpConfiguration(ctx)
+	if err != nil {
+		if backuprestore.IsBRStorageBackendUnavailableError(err) {
+			utils.SetUpgradeStatusFailed(ibu, err.Error())
+			u.autoRollbackIfEnabled(ibu, fmt.Sprintf("Rollback due to missing DataProtectionApplication: %s", err))
+			return doNotRequeue(), nil
+		}
+		utils.SetUpgradeStatusInProgress(ibu, fmt.Sprintf("Checking Application Configuration: Failure occurred: %s", err.Error()))
+		return requeueWithError(fmt.Errorf("error while checking OADP configuration: %w", err))
+	}
+
 	// Applying extra manifests
 	utils.SetUpgradeStatusInProgress(ibu, "Applying Policy Manifests")
 	if updateErr := utils.UpdateIBUStatus(ctx, u.Client, ibu); updateErr != nil {
@@ -416,17 +427,6 @@ func (u *UpgHandler) PostPivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedU
 		}
 		utils.SetUpgradeStatusInProgress(ibu, fmt.Sprintf("Applying Config Manifests: Failure occurred: %s", err.Error()))
 		return requeueWithError(fmt.Errorf("error while applying config manifests: %w", err))
-	}
-
-	err = u.BackupRestore.EnsureOadpConfiguration(ctx)
-	if err != nil {
-		if backuprestore.IsBRStorageBackendUnavailableError(err) {
-			utils.SetUpgradeStatusFailed(ibu, err.Error())
-			u.autoRollbackIfEnabled(ibu, fmt.Sprintf("Rollback due to backup storage failure: %s", err))
-			return doNotRequeue(), nil
-		}
-		utils.SetUpgradeStatusInProgress(ibu, fmt.Sprintf("Checking Application Configuration: Failure occurred: %s", err.Error()))
-		return requeueWithError(fmt.Errorf("error while checking OADP configuration: %w", err))
 	}
 
 	// Handling restores with OADP operator

--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -908,6 +908,9 @@ func TestImageBasedUpgradeReconciler_postPivot(t *testing.T) {
 			checkHealthReturn: func(ctx context.Context, c client.Reader, l logr.Logger) error {
 				return nil
 			},
+			ensureOadpConfigurationReturn: func() error {
+				return nil
+			},
 			applyPolicyManifestsReturn: func() error {
 				return nil
 			},
@@ -937,12 +940,6 @@ func TestImageBasedUpgradeReconciler_postPivot(t *testing.T) {
 			name: "RestoreOadpConfigurations return error",
 			args: args{ibu: &lcav1alpha1.ImageBasedUpgrade{}},
 			checkHealthReturn: func(ctx context.Context, c client.Reader, l logr.Logger) error {
-				return nil
-			},
-			applyPolicyManifestsReturn: func() error {
-				return nil
-			},
-			applyExtraManifestsReturn: func() error {
 				return nil
 			},
 			ensureOadpConfigurationReturn: func() error {

--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -257,7 +257,7 @@ func (h *BRHandler) createNewBackupCr(ctx context.Context, backup *velerov1.Back
 // ExportOadpConfigurationToDir exports the OADP DataProtectionApplication CR and required storage creds to a given location
 func (h *BRHandler) ExportOadpConfigurationToDir(ctx context.Context, toDir, oadpNamespace string) error {
 	dpaList := &unstructured.UnstructuredList{}
-	dpaList.SetGroupVersionKind(dpaGvkList)
+	dpaList.SetGroupVersionKind(DpaGvkList)
 	opts := []client.ListOption{
 		client.InNamespace(oadpNamespace),
 	}

--- a/internal/backuprestore/backup_test.go
+++ b/internal/backuprestore/backup_test.go
@@ -692,8 +692,8 @@ func TestExportOadpConfigurationToDir(t *testing.T) {
 	// Test case 2: DPA with velero credentials found
 	dpa := &unstructured.Unstructured{
 		Object: map[string]any{
-			"kind":       dpaGvk.Kind,
-			"apiVersion": dpaGvk.Group + "/" + dpaGvk.Version,
+			"kind":       DpaGvk.Kind,
+			"apiVersion": DpaGvk.Group + "/" + DpaGvk.Version,
 			"metadata": map[string]any{
 				"name":      "dpa-name",
 				"namespace": oadpNs,

--- a/internal/backuprestore/restore_test.go
+++ b/internal/backuprestore/restore_test.go
@@ -333,8 +333,8 @@ func TestEnsureOadpConfigurations(t *testing.T) {
 	// Create oadp DPA file
 	dpa := &unstructured.Unstructured{
 		Object: map[string]any{
-			"kind":       dpaGvk.Kind,
-			"apiVersion": dpaGvk.Group + "/" + dpaGvk.Version,
+			"kind":       DpaGvk.Kind,
+			"apiVersion": DpaGvk.Group + "/" + DpaGvk.Version,
 			"metadata": map[string]any{
 				"name":      "oadp",
 				"namespace": OadpNs,
@@ -391,54 +391,5 @@ func fakeBackupStorageBackendWithStatus(name string, phase velerov1.BackupStorag
 		Status: velerov1.BackupStorageLocationStatus{
 			Phase: phase,
 		},
-	}
-}
-
-func TestEnsureStorageBackendAvailable(t *testing.T) {
-	testcases := []struct {
-		name        string
-		bsl         []client.Object
-		expectedErr error
-	}{
-		{
-			name: "Backup storage location is unavailable",
-			bsl: []client.Object{
-				fakeBackupStorageBackendWithStatus("oadp1", velerov1.BackupStorageLocationPhaseUnavailable),
-				fakeBackupStorageBackendWithStatus("oadp2", velerov1.BackupStorageLocationPhaseAvailable),
-			},
-			expectedErr: NewBRStorageBackendUnavailableError("BackupStorageLocation is unavailable. Name: oadp1, Error: "),
-		},
-		{
-			name: "Backup storage locations are available",
-			bsl: []client.Object{
-				fakeBackupStorageBackendWithStatus("oadp1", velerov1.BackupStorageLocationPhaseAvailable),
-				fakeBackupStorageBackendWithStatus("oadp2", velerov1.BackupStorageLocationPhaseAvailable),
-			},
-			expectedErr: nil,
-		},
-	}
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: OadpNs,
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			objs := []client.Object{ns}
-			objs = append(objs, tc.bsl...)
-			fakeClient, err := getFakeClientFromObjects(objs...)
-			if err != nil {
-				t.Errorf("error in creating fake client")
-			}
-
-			handler := &BRHandler{
-				Client: fakeClient,
-				Log:    ctrl.Log.WithName("BackupRestore"),
-			}
-
-			err = handler.ensureStorageBackendAvailable(context.Background(), OadpNs)
-			assert.Equal(t, err, tc.expectedErr)
-		})
 	}
 }


### PR DESCRIPTION
When oadp DPA is applied and reconciled, check the connectivity of the storage backend. Sometimes it may simply require more time to come up or be due to a temporary connection issue. Moving the storage backend check into healthcheck could help to ensure the connectivity of storage at each stage.


/cc @donpenney @browsell 
