### PR TITLE
OCPBUGS-32040: Check status phase only for CSV healthcheck

### DIFF
--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -108,7 +108,7 @@ func AreClusterServiceVersionsReady(ctx context.Context, c client.Reader, l logr
 			l.Info(fmt.Sprintf("Skipping check of %s/%s", csv.Kind, csv.Name))
 			continue
 		}
-		if !(csv.Status.Phase == operatorsv1alpha1.CSVPhaseSucceeded && csv.Status.Reason == operatorsv1alpha1.CSVReasonInstallSuccessful) {
+		if csv.Status.Phase != operatorsv1alpha1.CSVPhaseSucceeded {
 			notready = append(notready, csv.Name)
 			l.Info(fmt.Sprintf("csv not ready: %s", csv.Name))
 		}


### PR DESCRIPTION
The CSV status phase "Succeeded" represents a succeeded CSV. The reason why it's succeeded doesn't matter. 
It's not possible that it's "Succeeded" but with an "unsucceeded" reason. 

