### PR TITLE
CNF-11934: Change the matching versions of target-ocp-version label

### DIFF
--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -135,8 +135,7 @@ func (u *UpgHandler) PrePivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedUp
 	u.Log.Info("Handling backups with OADP operator")
 	ctrlResult, err := u.HandleBackup(ctx, ibu)
 	if err != nil {
-		if backuprestore.IsBRNotFoundError(err) ||
-			backuprestore.IsBRFailedValidationError(err) ||
+		if backuprestore.IsBRFailedValidationError(err) ||
 			backuprestore.IsBRFailedError(err) {
 
 			utils.SetUpgradeStatusFailed(ibu, err.Error())
@@ -164,26 +163,12 @@ func (u *UpgHandler) PrePivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedUp
 		u.Log.Error(updateErr, "failed to update IBU CR status")
 	}
 
-	if len(ibu.Spec.OADPContent) > 0 {
-		u.Log.Info("Writing OadpConfiguration CRs into new stateroot")
-		if err := u.BackupRestore.ExportOadpConfigurationToDir(ctx, staterootVarPath, backuprestore.OadpNs); err != nil {
-			if backuprestore.IsBRFailedError(err) {
-				utils.SetUpgradeStatusFailed(ibu, err.Error())
-				return doNotRequeue(), nil
-			}
-			return requeueWithError(fmt.Errorf("error while exporting OADP configuration: %w", err))
-		}
-	} else {
-		u.Log.Info("OADPContent list empty, will not write OadpConfiguration CRs into new stateroot")
-	}
-
-	u.Log.Info("Writing Restore CRs into new stateroot")
-	if err := u.BackupRestore.ExportRestoresToDir(ctx, ibu.Spec.OADPContent, staterootVarPath); err != nil {
-		if backuprestore.IsBRFailedValidationError(err) {
+	if err := u.exportOadpConfigurationAndRestore(ctx, ibu, staterootVarPath); err != nil {
+		if backuprestore.IsBRFailedError(err) || backuprestore.IsBRFailedValidationError(err) {
 			utils.SetUpgradeStatusFailed(ibu, err.Error())
 			return doNotRequeue(), nil
 		}
-		return requeueWithError(fmt.Errorf("error while exporting restores: %w", err))
+		return requeueWithError(fmt.Errorf("error while exporting OADP configuration and restores: %w", err))
 	}
 
 	utils.SetUpgradeStatusInProgress(ibu, "Exporting Policy and Config Manifests")
@@ -197,7 +182,7 @@ func (u *UpgHandler) PrePivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedUp
 			utils.SetUpgradeStatusFailed(ibu, err.Error())
 			return doNotRequeue(), nil
 		}
-		return requeueWithError(fmt.Errorf("error while handling manifests: %w", err))
+		return requeueWithError(fmt.Errorf("error while exporting manifests: %w", err))
 	}
 
 	utils.SetUpgradeStatusInProgress(ibu, "Exporting Cluster and LVM configuration")
@@ -219,15 +204,8 @@ func (u *UpgHandler) PrePivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedUp
 	u.resetProgressMessage(ctx, ibu)
 
 	u.Log.Info("Save the IBU CR to the new state root before pivot")
-
-	lcaConfigDir := filepath.Join(staterootPath, common.LCAConfigDir)
-	if err := os.MkdirAll(lcaConfigDir, 0o700); err != nil {
-		return requeueWithError(err)
-	}
-
-	filePath := filepath.Join(staterootPath, utils.IBUFilePath)
-	if err := lcautils.MarshalToFile(ibu, filePath); err != nil {
-		return requeueWithError(fmt.Errorf("error while saving IBU CR to the new state root: %w", err))
+	if err := exportIBUToNewStateroot(ibu, staterootPath); err != nil {
+		return requeueWithError(fmt.Errorf("error while exporting IBU CR to the new state root: %w", err))
 	}
 
 	u.Log.Info("Save a copy of the IBU in the current stateroot for rollback")
@@ -235,15 +213,8 @@ func (u *UpgHandler) PrePivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedUp
 		return requeueWithError(fmt.Errorf("error while exporting for uncontrolled rollback: %w", err))
 	}
 
-	// Set the new default deployment
-	if u.OstreeClient.IsOstreeAdminSetDefaultFeatureEnabled() {
-		deploymentIndex, err := u.RPMOstreeClient.GetDeploymentIndex(stateroot)
-		if err != nil {
-			return requeueWithError(fmt.Errorf("failed to get deployment index for stateroot %s: %w", stateroot, err))
-		}
-		if err := u.OstreeClient.SetDefaultDeployment(deploymentIndex); err != nil {
-			return requeueWithError(fmt.Errorf("failed to set default deployment at index %d: %w", deploymentIndex, err))
-		}
+	if err := u.setDefaultDeploymentToNewStateroot(stateroot); err != nil {
+		return requeueWithError(fmt.Errorf("error while setting default deployment: %w", err))
 	}
 
 	// Write an event to indicate reboot attempt
@@ -258,11 +229,30 @@ func (u *UpgHandler) PrePivot(ctx context.Context, ibu *lcav1alpha1.ImageBasedUp
 	return doNotRequeue(), nil
 }
 
+// exportOadpConfigurationAndRestore exports OADP configuration and restore CRs to the new stateroot
+func (u *UpgHandler) exportOadpConfigurationAndRestore(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade, ostreeVarDir string) error {
+	if len(ibu.Spec.OADPContent) == 0 {
+		u.Log.Info("spec.oadpContent is empty. Skipping exporting OADP configuration and restore CRs")
+	}
+
+	u.Log.Info("Writing OadpConfiguration CRs into new stateroot")
+	if err := u.BackupRestore.ExportOadpConfigurationToDir(ctx, ostreeVarDir, backuprestore.OadpNs); err != nil {
+		return fmt.Errorf("failed to export OADP configuration: %w", err)
+	}
+
+	u.Log.Info("Writing Restore CRs into new stateroot")
+	if err := u.BackupRestore.ExportRestoresToDir(ctx, ibu.Spec.OADPContent, ostreeVarDir); err != nil {
+		return fmt.Errorf("failed to export restores: %w", err)
+	}
+
+	return nil
+}
+
 // extractAndExportExtraManifests extracts extra manifest from policies and/or configmaps and export them to the new stateroot
 func (u *UpgHandler) extractAndExportExtraManifests(ctx context.Context, ibu *lcav1alpha1.ImageBasedUpgrade, ostreeVarDir string) error {
 	versions, err := getMatchingTargetOcpVersionLabelVersions(ibu.Spec.SeedImageRef.Version)
 	if err != nil {
-		return fmt.Errorf("error while exporting manifests from policies: %w", err)
+		return fmt.Errorf("failed to export manifests from policies: %w", err)
 	}
 
 	// Extract from policies can be done by matching labels on the policy or the CR itself
@@ -270,11 +260,11 @@ func (u *UpgHandler) extractAndExportExtraManifests(ctx context.Context, ibu *lc
 	// as those policies must not be applied on the seed
 	labels := map[string]string{extramanifest.TargetOcpVersionLabel: strings.Join(versions, ",")}
 	if err := u.ExtraManifest.ExtractAndExportManifestFromPoliciesToDir(ctx, nil, labels, ostreeVarDir); err != nil {
-		return fmt.Errorf("error while exporting manifests from policies: %w", err)
+		return fmt.Errorf("failed to export manifests from policies: %w", err)
 	}
 
 	if err := u.ExtraManifest.ExportExtraManifestToDir(ctx, ibu.Spec.ExtraManifests, ostreeVarDir); err != nil {
-		return fmt.Errorf("error while exporting extra manifests: %w", err)
+		return fmt.Errorf("failed to export manifests from configmaps: %w", err)
 	}
 	return nil
 }
@@ -299,6 +289,33 @@ func getMatchingTargetOcpVersionLabelVersions(ocpVersion string) ([]string, erro
 		validVersions = append(validVersions, ocpVersion)
 	}
 	return validVersions, nil
+}
+
+func (u *UpgHandler) setDefaultDeploymentToNewStateroot(stateroot string) error {
+	// Set the new default deployment
+	if u.OstreeClient.IsOstreeAdminSetDefaultFeatureEnabled() {
+		deploymentIndex, err := u.RPMOstreeClient.GetDeploymentIndex(stateroot)
+		if err != nil {
+			return fmt.Errorf("failed to get deployment index for stateroot %s: %w", stateroot, err)
+		}
+		if err := u.OstreeClient.SetDefaultDeployment(deploymentIndex); err != nil {
+			return fmt.Errorf("failed to set default deployment at index %d: %w", deploymentIndex, err)
+		}
+	}
+	return nil
+}
+
+func exportIBUToNewStateroot(ibu *lcav1alpha1.ImageBasedUpgrade, staterootPath string) error {
+	lcaConfigDir := filepath.Join(staterootPath, common.LCAConfigDir)
+	if err := os.MkdirAll(lcaConfigDir, 0o700); err != nil {
+		return fmt.Errorf("failed to mkdir: %w", err)
+	}
+
+	filePath := filepath.Join(staterootPath, utils.IBUFilePath)
+	if err := lcautils.MarshalToFile(ibu, filePath); err != nil {
+		return fmt.Errorf("error while saving IBU CR to the new state root: %w", err)
+	}
+	return nil
 }
 
 // exportForUncontrolledRollback Save a copy of the IBU in the current stateroot in case of uncontrolled rollback, with Upgrade set to failed

--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -423,7 +423,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 			},
 			getSortedBackupsFromConfigmapReturn: func() ([][]*velerov1.Backup, error) {
 				return nil,
-					backuprestore.NewBRNotFoundError("this is a test - NotFound")
+					backuprestore.NewBRFailedValidationError("OADP", "this is a test - NotFound")
 			},
 			want:    doNotRequeue(),
 			wantErr: assert.NoError,
@@ -496,7 +496,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 					Type:    string(utils.ConditionTypes.UpgradeInProgress),
 					Reason:  string(utils.ConditionReasons.Failed),
 					Status:  metav1.ConditionFalse,
-					Message: "this is a test - NotFound stop reconcile",
+					Message: "failed to export OADP configuration: this is a test - NotFound stop reconcile",
 				},
 			},
 		},
@@ -556,7 +556,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 					Type:    string(utils.ConditionTypes.UpgradeInProgress),
 					Reason:  string(utils.ConditionReasons.Failed),
 					Status:  metav1.ConditionFalse,
-					Message: "ExportRestoresToDir validation failed",
+					Message: "failed to export restores: ExportRestoresToDir validation failed",
 				},
 			},
 		},
@@ -745,6 +745,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 			}
 			if tt.exportRestoresToDirReturn != nil {
 				mockBackuprestore.EXPECT().ExportRestoresToDir(gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.exportRestoresToDirReturn()).Times(1)
+				tt.args.ibu.Spec.OADPContent = []lcav1alpha1.ConfigMapRef{{Name: "atleast-one-restore-to-proceed-with-export"}}
 			}
 			if tt.extractAndExportManifestFromPoliciesToDirReturn != nil {
 				mockExtramanifest.EXPECT().ExtractAndExportManifestFromPoliciesToDir(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.extractAndExportManifestFromPoliciesToDirReturn()).Times(1)

--- a/docs/image-based-upgrade.md
+++ b/docs/image-based-upgrade.md
@@ -79,12 +79,20 @@ This is generally intended for platform configuration that is site specific and 
 
 There are two implementations of extra manifests:
 
-- If the target cluster is integrated with ZTP GitOps, the site specific manifests can be automatically extracted by the operator during the upgrade stage.
-Manifests that have the `ran.openshift.io/ztp-deploy-wave` annotation and are labeled with `lca.openshift.io/target-ocp-version: “4.y.x” will be extracted and applied after
-rebooting to the new version.
+- If the target cluster is integrated with ZTP GitOps, the site specific manifests can be automatically extracted from the policies by the operator during the upgrade stage.
+Manifests defined in the policies that have the `ran.openshift.io/ztp-deploy-wave` annotation and labeled with `lca.openshift.io/target-ocp-version: "4.y.x"` or `lca.openshift.io/target-ocp-version: "4.y"` will be extracted and applied after rebooting to the new version.
 
 - If the target cluster is not integrated with ZTP GitOps the extra manifests can be provided via configmap(s) applied to the cluster. These configmap(s) specified by the
 `extraManifests` field in the [IBU CR](#imagebasedupgrade-cr). After rebooting to the new version, these extra manifests are applied.
+
+  The annotation `lca.openshift.io/apply-wave` is supported for defining the manifest applying order. The value of the annotation should be a string number, for example:
+
+  ```yaml
+  annotations:
+    lca.openshift.io/apply-wave: "1"
+  ```
+
+  If the annotation is provided in the manifests, they will be applied in increasing order based on the annotation value. Manifests without the annotation will be applied last.
 
 ## Target SNO Prerequisites
 

--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -65,7 +65,7 @@ func (h *BRHandler) GetSortedBackupsFromConfigmap(ctx context.Context, content [
 		if k8serrors.IsNotFound(err) {
 			errMsg := fmt.Sprintf("OADP configmap not found, error: %s. Please create the configmap.", err.Error())
 			h.Log.Error(nil, errMsg)
-			return nil, NewBRNotFoundError(errMsg)
+			return nil, NewBRFailedValidationError("OADP", errMsg)
 		}
 		return nil, fmt.Errorf("failed to get oadp configMaps : %w", err)
 	}

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -119,14 +119,6 @@ func (e *BRStatusError) Error() string {
 	return fmt.Sprintf(e.ErrMessage)
 }
 
-func NewBRNotFoundError(msg string) *BRStatusError {
-	return &BRStatusError{
-		Type:       "configmap",
-		Reason:     "NotFound",
-		ErrMessage: msg,
-	}
-}
-
 func NewBRFailedError(brType, msg string) *BRStatusError {
 	return &BRStatusError{
 		Type:       brType,
@@ -149,16 +141,6 @@ func NewBRStorageBackendUnavailableError(msg string) *BRStatusError {
 		Reason:     "Unavailable",
 		ErrMessage: msg,
 	}
-}
-
-func IsBRNotFoundError(err error) bool {
-	var brErr *BRStatusError
-	if errors.As(err, &brErr) {
-		if brErr.Type == "configmap" {
-			return brErr.Reason == "NotFound"
-		}
-	}
-	return false
 }
 
 func IsBRFailedError(err error) bool {


### PR DESCRIPTION
It was required to label the manifests with the full release ocp version defined in spec.seedImageRef.version.

It's too much effort for user to label the manifests for each z-stream upgrade , especially when there may be no changes.

Update to match either full release version, X.Y.Z or X.Y

The utility function to load resources from a directory requires sub directories,
update the directory structure of policy manifests to follow that pattern.

/cc @browsell @jc-rh @donpenney 