### PR TITLE
CNF-11754: Retry apply of manifest on retriable failure

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -127,12 +127,12 @@ func RetryOnConflictOrRetriable(backoff wait.Backoff, fn func() error) error {
 	return retry.OnError(backoff, isConflictOrRetriable, fn) //nolint:wrapcheck
 }
 
-func isRetriable(err error) bool {
+func IsRetriable(err error) bool {
 	return apierrors.IsInternalError(err) || apierrors.IsServiceUnavailable(err) || net.IsConnectionRefused(err)
 }
 
 func RetryOnRetriable(backoff wait.Backoff, fn func() error) error {
-	return retry.OnError(backoff, isRetriable, fn) //nolint:wrapcheck
+	return retry.OnError(backoff, IsRetriable, fn) //nolint:wrapcheck
 }
 
 func GetDesiredStaterootName(ibu *v1alpha1.ImageBasedUpgrade) string {

--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -280,6 +280,20 @@ func (p *PostPivot) waitForApi(ctx context.Context, client runtimeclient.Client)
 	})
 }
 
+func applyManifest(ctx context.Context, log *logrus.Logger, dc dynamic.Interface, rm meta.RESTMapper, m *unstructured.Unstructured) error {
+	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) { //nolint:wrapcheck
+		if err := extramanifest.ApplyExtraManifest(ctx, dc, rm, m, false); err != nil {
+			if common.IsRetriable(err) {
+				log.Infof("Retrying apply of manifest %s %s", m.GetKind(), m.GetName())
+				return false, nil
+			} else {
+				return true, err //nolint:wrapcheck
+			}
+		}
+		return true, nil
+	})
+}
+
 func (p *PostPivot) applyManifests(ctx context.Context, mPath string, dynamicClient dynamic.Interface, restMapper meta.RESTMapper) error {
 	p.log.Infof("Applying manifests from %s", mPath)
 	mFiles, err := os.ReadDir(mPath)
@@ -301,17 +315,18 @@ func (p *PostPivot) applyManifests(ctx context.Context, mPath string, dynamicCli
 			for _, m := range manifests.([]interface{}) {
 				manifest := unstructured.Unstructured{}
 				manifest.Object = m.(map[string]interface{})
-				if err := extramanifest.ApplyExtraManifest(ctx, dynamicClient, restMapper, &manifest, false); err != nil {
+				if err := applyManifest(ctx, p.log, dynamicClient, restMapper, &manifest); err != nil {
 					return fmt.Errorf("failed to apply manifest: %w", err)
 				}
 			}
 		} else {
 			manifest := unstructured.Unstructured{}
 			manifest.Object = obj
-			if err := extramanifest.ApplyExtraManifest(ctx, dynamicClient, restMapper, &manifest, false); err != nil {
+			if err := applyManifest(ctx, p.log, dynamicClient, restMapper, &manifest); err != nil {
 				return fmt.Errorf("failed to apply manifest: %w", err)
 			}
 		}
+
 		p.log.Infof("manifest applied: %s", filepath.Join(mPath, mFile.Name()))
 	}
 	return nil


### PR DESCRIPTION
Retry applying the manifest when it fails due to API server not responding. The initmonitor will eventually time out if it's not recovered.




/cc @browsell @donpenney 