### PR TITLE
Fix invalid condition

### DIFF
--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -85,7 +85,7 @@ func (r *ImageBasedUpgradeReconciler) getSeedImage(
 	}
 
 	seedHasProxy := false
-	if seedInfo == nil {
+	if seedInfo != nil {
 		// Older images may not have the seed cluster info label, in which case
 		// we assume no proxy so that if the current cluster has proxy, it will
 		// fail the compatibility check.


### PR DESCRIPTION
250e53fba735c245be768ef09fadd5080b4c531f introduced a regression which caused older seed images to stop working. The regression was caused by backwards compatibility code having an inverse condition.

This commit fixes that