### PR TITLE
OCPBUGS-32294: Add string validations for some fields in seedgen and IBU specs

### DIFF
--- a/api/seedgenerator/v1alpha1/types.go
+++ b/api/seedgenerator/v1alpha1/types.go
@@ -43,10 +43,14 @@ type SeedGenerator struct {
 // SeedGeneratorSpec defines the desired state of SeedGenerator
 type SeedGeneratorSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Seed Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern="^([a-z0-9]+://)?[\\S]+$"
 	// SeedImage defines the full pull-spec of the seed container image to be created.
 	SeedImage string `json:"seedImage,omitempty"`
 
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern="^([a-z0-9]+://)?[\\S]+$"
 	// RecertImage defines the full pull-spec of the recert container image to use.
 	RecertImage string `json:"recertImage,omitempty"`
 }

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -89,6 +89,8 @@ type SeedImageRef struct {
 	Version string `json:"version,omitempty"`
 	// Image defines the full pull-spec of the seed container image to use.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern="^([a-z0-9]+://)?[\\S]+$"
 	Image string `json:"image,omitempty"`
 	// PullSecretRef defines the reference to a secret with credentials to pull container images.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Pull Secret Reference"

--- a/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
+++ b/bundle/manifests/lca.openshift.io_imagebasedupgrades.yaml
@@ -111,6 +111,8 @@ spec:
                   image:
                     description: Image defines the full pull-spec of the seed container
                       image to use.
+                    minLength: 1
+                    pattern: ^([a-z0-9]+://)?[\S]+$
                     type: string
                   pullSecretRef:
                     description: PullSecretRef defines the reference to a secret with

--- a/bundle/manifests/lca.openshift.io_seedgenerators.yaml
+++ b/bundle/manifests/lca.openshift.io_seedgenerators.yaml
@@ -49,10 +49,14 @@ spec:
               recertImage:
                 description: RecertImage defines the full pull-spec of the recert
                   container image to use.
+                minLength: 1
+                pattern: ^([a-z0-9]+://)?[\S]+$
                 type: string
               seedImage:
                 description: SeedImage defines the full pull-spec of the seed container
                   image to be created.
+                minLength: 1
+                pattern: ^([a-z0-9]+://)?[\S]+$
                 type: string
             type: object
             x-kubernetes-validations:

--- a/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
+++ b/config/crd/bases/lca.openshift.io_imagebasedupgrades.yaml
@@ -111,6 +111,8 @@ spec:
                   image:
                     description: Image defines the full pull-spec of the seed container
                       image to use.
+                    minLength: 1
+                    pattern: ^([a-z0-9]+://)?[\S]+$
                     type: string
                   pullSecretRef:
                     description: PullSecretRef defines the reference to a secret with

--- a/config/crd/bases/lca.openshift.io_seedgenerators.yaml
+++ b/config/crd/bases/lca.openshift.io_seedgenerators.yaml
@@ -49,10 +49,14 @@ spec:
               recertImage:
                 description: RecertImage defines the full pull-spec of the recert
                   container image to use.
+                minLength: 1
+                pattern: ^([a-z0-9]+://)?[\S]+$
                 type: string
               seedImage:
                 description: SeedImage defines the full pull-spec of the seed container
                   image to be created.
+                minLength: 1
+                pattern: ^([a-z0-9]+://)?[\S]+$
                 type: string
             type: object
             x-kubernetes-validations:


### PR DESCRIPTION
Adds some validations to ensure `seedImage` and `recertImage` fields in seedgen are valid strings. As well as `.spec.SeedImageRef.Image` in the IBU CR.

/cc @donpenney @browsell @achuzhoy 