### PR TITLE
OCPBUGS-32206: [IBU] LVMS volume contents not restored 

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -356,6 +356,15 @@ spec:
           - list
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - lca.openshift.io
           resources:
           - imagebasedupgrades

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -143,6 +143,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - lca.openshift.io
   resources:
   - imagebasedupgrades

--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -164,6 +164,9 @@ func (r *ImageBasedUpgradeReconciler) cleanup(
 	if err := r.BackupRestore.CleanupBackups(ctx); err != nil {
 		handleError(err, "failed to cleanup backups")
 	}
+	if err := r.BackupRestore.RestorePVsReclaimPolicy(ctx); err != nil {
+		handleError(err, "failed to restore persistentVolumeReclaimPolicy in PVs created by LVMS")
+	}
 
 	r.Log.Info("Cleaning up IBU files")
 	if err := cleanupIBUFiles(); err != nil {

--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -480,6 +480,10 @@ func (u *UpgHandler) HandleBackup(ctx context.Context, ibu *lcav1alpha1.ImageBas
 		return doNotRequeue(), nil
 	}
 
+	if err := u.BackupRestore.PatchPVsReclaimPolicy(ctx); err != nil {
+		return requeueWithError(fmt.Errorf("failed to patch LVMS PVs with Retain as persistentVolumeReclaimPolicy: %w", err))
+	}
+
 	// trigger and track each group
 	for index, backups := range sortedBackupGroups {
 		u.Log.Info("Processing backup", "groupIndex", index+1, "totalGroups", len(sortedBackupGroups))

--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -561,11 +561,16 @@ func (u *UpgHandler) HandleRestore(ctx context.Context) (ctrl.Result, error) {
 		// Restores are waiting for condition
 		return requeueWithMediumInterval(), nil
 	}
-
 	u.Log.Info("All restores succeeded")
+
+	if err := u.BackupRestore.RestorePVsReclaimPolicy(ctx); err != nil {
+		return requeueWithError(fmt.Errorf("failed to restore persistentVolumeReclaimPolicy in PVs created by LVMS: %w", err))
+	}
+
 	if err := os.RemoveAll(common.PathOutsideChroot(backuprestore.OadpPath)); err != nil {
 		return requeueWithError(fmt.Errorf("error while removing OADP path: %w", err))
 	}
 	u.Log.Info("OADP path removed", "path", backuprestore.OadpPath)
+
 	return doNotRequeue(), nil
 }

--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -137,6 +137,7 @@ func TestImageBasedUpgradeReconciler_handleBackup(t *testing.T) {
 			//setup
 
 			mockBackuprestore.EXPECT().GetSortedBackupsFromConfigmap(gomock.Any(), gomock.Any()).Return(tt.inputVelero, nil)
+			mockBackuprestore.EXPECT().PatchPVsReclaimPolicy(gomock.Any()).Return(nil)
 
 			for _, track := range tt.trackers {
 				mockBackuprestore.EXPECT().CleanupStaleBackups(gomock.Any(), gomock.Any()).Return(nil)
@@ -332,6 +333,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 		healthCheckError                                error
 		getSortedBackupsFromConfigmapReturn             func() ([][]*velerov1.Backup, error)
 		getStartOrTrackBackupReturn                     func() (*backuprestore.BackupTracker, error)
+		getPatchPVsReclaimPolicyReturn                  func() error
 		getCleanupStaleBackupsReturn                    func() error
 		remountSysrootReturn                            func() error
 		exportOadpConfigurationToDirReturn              func() error
@@ -449,6 +451,9 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 			},
 			getSortedBackupsFromConfigmapReturn: func() ([][]*velerov1.Backup, error) {
 				return [][]*velerov1.Backup{{&velerov1.Backup{}}}, nil
+			},
+			getPatchPVsReclaimPolicyReturn: func() error {
+				return nil
 			},
 			getCleanupStaleBackupsReturn: func() error {
 				return nil
@@ -717,6 +722,9 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.getSortedBackupsFromConfigmapReturn != nil {
 				mockBackuprestore.EXPECT().GetSortedBackupsFromConfigmap(gomock.Any(), gomock.Any()).Return(tt.getSortedBackupsFromConfigmapReturn())
+			}
+			if tt.getPatchPVsReclaimPolicyReturn != nil {
+				mockBackuprestore.EXPECT().PatchPVsReclaimPolicy(gomock.Any()).Return(tt.getPatchPVsReclaimPolicyReturn())
 			}
 			if tt.getCleanupStaleBackupsReturn != nil {
 				mockBackuprestore.EXPECT().CleanupStaleBackups(gomock.Any(), gomock.Any()).Return(tt.getCleanupStaleBackupsReturn())

--- a/docs/image-based-upgrade.md
+++ b/docs/image-based-upgrade.md
@@ -149,24 +149,24 @@ LCA will reject the stage transition if it is an invalid transition.
 
 This table presents a comprehensive list of conditions and valid next stages based on the current stage.
 
-|Current Stage|Condition         |Status|Reason        |After Pivot|Valid Next Stages|
-|-------------|------------------|------|--------------|-----------|-----------------|
-|`Idle`       |Idle              |True  |Idle          |N/A        |Prep             |
-|             |                  |False |Aborting      |False      |N/A              |
-|             |                  |False |Finalizing    |True       |N/A              |
-|             |                  |False |AbortFailed   |False      |N/A              |
-|             |                  |False |FinalizeFailed|True       |N/A              |
-|`Prep`       |PrepInProgress    |True  |InProgress    |False      |Idle             |
-|             |PrepCompleted     |False |Failed        |False      |Idle             |
-|             |                  |True  |Completed     |False      |Idle, Upgrade    |
-|`Upgrade`    |UpgradeInProgress |True  |InProgress    |False      |Idle             |
-|             |                  |True  |InProgress    |True       |Rollback         |
-|             |UpgradeCompleted  |False |Failed        |False      |Idle             |
-|             |                  |False |Failed        |True       |Rollback         |
-|             |                  |True  |Completed     |True       |Idle, Rollback   |
-|`Rollback`   |RollbackInProgress|True  |InProgress    |True       |N/A              |
-|             |RollbackCompleted |False |Failed        |True       |N/A              |
-|             |                  |True  |Completed     |True       |Idle             |
+| Current Stage | Condition          | Status | Reason         | After Pivot | Valid Next Stages |
+|---------------|--------------------|--------|----------------|-------------|-------------------|
+| `Idle`        | Idle               | True   | Idle           | N/A         | Prep              |
+|               |                    | False  | Aborting       | False       | N/A               |
+|               |                    | False  | Finalizing     | True        | N/A               |
+|               |                    | False  | AbortFailed    | False       | N/A               |
+|               |                    | False  | FinalizeFailed | True        | N/A               |
+| `Prep`        | PrepInProgress     | True   | InProgress     | False       | Idle              |
+|               | PrepCompleted      | False  | Failed         | False       | Idle              |
+|               |                    | True   | Completed      | False       | Idle, Upgrade     |
+| `Upgrade`     | UpgradeInProgress  | True   | InProgress     | False       | Idle              |
+|               |                    | True   | InProgress     | True        | Rollback          |
+|               | UpgradeCompleted   | False  | Failed         | False       | Idle              |
+|               |                    | False  | Failed         | True        | Rollback          |
+|               |                    | True   | Completed      | True        | Idle, Rollback    |
+| `Rollback`    | RollbackInProgress | True   | InProgress     | True        | N/A               |
+|               | RollbackCompleted  | False  | Failed         | True        | N/A               |
+|               |                    | True   | Completed      | True        | Idle              |
 
 If unexpected rejection occurs that block any spec changes, the annotation `lca.openshift.io/trigger-reconcile` serves as a backdoor to trigger the reconciliation for LCA to rectify the situation by adding or updating the annotation in the IBU CR.
 
@@ -226,7 +226,7 @@ The "Prep" stage will:
 - Pull the seed image
 - Perform the following validations:
   - If the oadpContent is populated, validate that the specified configmap has been applied and is valid
-  - If the extraManifests is popluated, validate that the specified configmap has been applied and is valid
+  - If the extraManifests is populated, validate that the specified configmap has been applied and is valid
     - If a required CRD is missing from the current stateroot, a warning message will be included in the prep status condition for user to verify before proceeding to the upgrade stage
   - Validate that the desired upgrade version matches the version of the seed image
   - Validate the version of the LCA in the seed image is compatible with the version on the running SNO
@@ -310,6 +310,7 @@ oc patch imagebasedupgrades.lca.openshift.io upgrade -p='{"spec": {"stage": "Upg
 Pre-pivot:
 
 - LCA collects the required cluster specific info/artifacts and stores them in the new state root. This includes hostname, nmconnection files, cluster ID, NodeIP and various OCP platform CRs(i.e., imagecontentimagecontentsourcepolicies, localvolumes.local.storage.openshift.io) from etcd.
+- If LVMS is used, automatically update dynamic PVs with `.spec.persistentVolumeReclaimPolicy=Delete` to `Retain`.
 - Applies OADP backup CRs as specified by the `oadpContent` field in the IBU spec. Refer to [backuprestore-with-oadp](backuprestore-with-oadp.md).
 - Stores OADP restore CRs as specified by the `oadpContent` field in the IBU spec to the new state root. Refer to [backuprestore-with-oadp](backuprestore-with-oadp.md).
 - Stores CRs specified by the `extraManifests` field in the IBU spec as well as the CRs described in the ZTP policies bound to the cluster for the target OCP version to the new state root.
@@ -324,13 +325,14 @@ Pivot
 Post-Pivot
 
 - Before OCP is started, a systemd service will run which will restore the basic platform configuration and regenerate the platform certificates using the [recert tool](https://github.com/rh-ecosystem-edge/recert).
-- Once LCA starts it will restore the saved IBU CR.
+- Once LCA starts, it will restore the saved IBU CR.
 - Restore the remaining platform configuration.
 - Wait for the platform to recover - Cluster/day2 operators and MCP are stable.
 - Apply extra manifests that were saved pre-pivot.
-- Apply any OADP restore CRs that were saved pre-pivot. Platform artifacts will be restored first including ACM artifacts if the system is managed by ACM.
+- Apply any OADP restore CRs that were saved pre-pivot. Platform artifacts will be restored first, including ACM artifacts if the system is managed by ACM.
+- If LVMS is used, automatically restores the `.spec.persistentVolumeReclaimPolicy` field of PVs to its original (pre-pivot) value.
 
-Upon completion, the condition will be updated to "Upgrade Completed".
+Upon completion, the condition will be updated to `Upgrade completed`.
 
 After the upgrade has been completed, the upgrade needs to be finalized. This can be done at anytime prior to the next upgrade attempt.
 This is the point of no return, it will be no longer be possible to rollback/abort once the finalize has been done.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,3 +47,120 @@ dataprotectionapplication-1   Available   33s              8d    true
 ```
 
 Otherwise, user should manually remove all backup resources `backups.velero.io`, `restores.velero.io` and `deletebackuprequests.velero.io`. Then add `lca.openshift.io/manual-cleanup-done` annotation to IBU CR.
+
+## LVMS volume contents not restored
+
+When LVMS is used to provide dynamic PV storage, it may not restore the PV contents when it is not configured correctly.
+Below, we provide some common symptoms and solutions in order to aid the user while troubleshooting such cases.
+
+### Missing lvms-related fields in Backup CR
+
+#### Symptom (missing backups fields)
+
+```shell
+-> oc describe pod <sample-app-name>
+
+... TRUNCATED ...
+
+Events:
+  Type     Reason            Age                From               Message
+  ----     ------            ----               ----               -------
+  Warning  FailedScheduling  58s (x2 over 66s)  default-scheduler  0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
+  Normal   Scheduled         56s                default-scheduler  Successfully assigned default/db-777b7ff898-g8gg6 to sno1.inbound.bos2.lab
+  Warning  FailedMount       24s (x7 over 55s)  kubelet            MountVolume.SetUp failed for volume "pvc-e8bf06ad-62a2-418b-ab29-c09e64d5550e" : rpc error: code = Unknown desc = VolumeID is not found
+```
+
+#### Resolution (missing backups fields)
+
+The reason for this issue is that the application has restored its PVC and PV manifests correctly, but the
+`logicalvolume` associated to this PV hasn't been restored properly after pivot.
+Steps for its resolution were described in [Section 1.1 - Backup resource when LVMS is used](backuprestore-with-oadp.md#11-backup-resource-when-lvms-is-used),
+and basically relates to also include `logicalvolumes.topolvm.io` in the application's Backup CR (see sample below).
+
+```yaml
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  labels:
+    velero.io/storage-location: default
+  name: small-app
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - test
+  includedNamespaceScopedResources:
+  - secrets
+  - persistentvolumeclaims
+  - deployments
+  - statefulsets
+  includedClusterScopedResources:
+  - persistentVolumes              # <- required field
+  - volumesnapshotcontents         # <- required field
+  - logicalvolumes.topolvm.io      # <- required field
+```
+
+### Missing lvms-related fields in Restore CR
+
+#### Symptom (missing restore fields)
+
+The same expected resources for the app are restored (see symptoms below), but the **PV contents were not preserved
+after upgrading**.
+
+before pivot
+
+```shell
+-> oc get pv,pvc,logicalvolumes.topolvm.io -A
+
+NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM            STORAGECLASS   REASON   AGE
+persistentvolume/pvc-e8bf06ad-62a2-418b-ab29-c09e64d5550e   1Gi        RWO            Retain           Bound    default/pvc-db   lvms-vg1                4h45m
+
+NAMESPACE   NAME                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+default     persistentvolumeclaim/pvc-db   Bound    pvc-e8bf06ad-62a2-418b-ab29-c09e64d5550e   1Gi        RWO            lvms-vg1       4h45m
+
+NAMESPACE   NAME                                                                AGE
+            logicalvolume.topolvm.io/pvc-e8bf06ad-62a2-418b-ab29-c09e64d5550e   4h45m
+```
+
+after pivot
+
+```shell
+-> oc get pv,pvc,logicalvolumes.topolvm.io -A
+
+NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM            STORAGECLASS   REASON   AGE
+persistentvolume/pvc-e8bf06ad-62a2-418b-ab29-c09e64d5550e   1Gi        RWO            Delete           Bound    default/pvc-db   lvms-vg1                19s
+
+NAMESPACE   NAME                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+default     persistentvolumeclaim/pvc-db   Bound    pvc-e8bf06ad-62a2-418b-ab29-c09e64d5550e   1Gi        RWO            lvms-vg1       19s
+
+NAMESPACE   NAME                                                                AGE
+            logicalvolume.topolvm.io/pvc-e8bf06ad-62a2-418b-ab29-c09e64d5550e   18s
+```
+
+> **Note:** The PVs contents can be easily recovered at any moment by just setting rollback in the IBU CR.
+
+#### Resolution (missing restore fields)
+
+The reason for this issue was that the `logicalvolume` status was not preserved in the Restore CR, this is important
+because it explicitly instructs Velero about the reference to the volumes that need to be preserved after pivoting.
+
+Steps were described in [Section 1.1 - Backup resource when LVMS is used](backuprestore-with-oadp.md#11-backup-resource-when-lvms-is-used),
+and basically relates to also include the corresponding fields in the application's Restore CR (see sample below).
+
+```yaml
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: sample-vote-app
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+  annotations:
+    lca.openshift.io/apply-wave: "3"
+spec:
+  backupName:
+    sample-vote-app
+  restorePVs: true                 # <- required field
+  restoreStatus:                   # <- required field
+    includedResources:             # <- required field
+      - logicalvolumes             # <- required field
+```

--- a/internal/backuprestore/backup_test.go
+++ b/internal/backuprestore/backup_test.go
@@ -484,7 +484,7 @@ func TestGetObjsFromAnnotations(t *testing.T) {
 		{
 			name:       "empty",
 			annotation: "",
-			expected:   []ObjMetadata{},
+			expected:   []ObjMetadata(nil),
 		},
 	}
 

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -88,6 +88,7 @@ type BackuperRestorer interface {
 	CleanupDeleteBackupRequests(ctx context.Context) error
 	CheckOadpOperatorAvailability(ctx context.Context) error
 	PatchPVsReclaimPolicy(ctx context.Context) error
+	RestorePVsReclaimPolicy(ctx context.Context) error
 	EnsureOadpConfiguration(ctx context.Context) error
 	ExportOadpConfigurationToDir(ctx context.Context, toDir, oadpNamespace string) error
 	ExportRestoresToDir(ctx context.Context, configMaps []lcav1alpha1.ConfigMapRef, toDir string) error

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -68,6 +68,10 @@ const (
 
 	// OadpNs is the namespace used for everything related OADP e.g configsMaps, DataProtectionApplicationm, Restore, etc
 	OadpNs = "openshift-adp"
+
+	topolvmValue                   = "topolvm.io"
+	topolvmAnnotation              = "pv.kubernetes.io/provisioned-by"
+	updatedReclaimPolicyAnnotation = "lca.openshift.io/updated-reclaim-policy" // used to identify LVMS PVs updated by LCA
 )
 
 var (
@@ -83,6 +87,7 @@ type BackuperRestorer interface {
 	CleanupStaleBackups(ctx context.Context, backups []*velerov1.Backup) error
 	CleanupDeleteBackupRequests(ctx context.Context) error
 	CheckOadpOperatorAvailability(ctx context.Context) error
+	PatchPVsReclaimPolicy(ctx context.Context) error
 	EnsureOadpConfiguration(ctx context.Context) error
 	ExportOadpConfigurationToDir(ctx context.Context, toDir, oadpNamespace string) error
 	ExportRestoresToDir(ctx context.Context, configMaps []lcav1alpha1.ConfigMapRef, toDir string) error

--- a/internal/backuprestore/mocks/mock_backuprestore.go
+++ b/internal/backuprestore/mocks/mock_backuprestore.go
@@ -171,6 +171,20 @@ func (mr *MockBackuperRestorerMockRecorder) LoadRestoresFromOadpRestorePath() *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadRestoresFromOadpRestorePath", reflect.TypeOf((*MockBackuperRestorer)(nil).LoadRestoresFromOadpRestorePath))
 }
 
+// PatchPVsReclaimPolicy mocks base method.
+func (m *MockBackuperRestorer) PatchPVsReclaimPolicy(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchPVsReclaimPolicy", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchPVsReclaimPolicy indicates an expected call of PatchPVsReclaimPolicy.
+func (mr *MockBackuperRestorerMockRecorder) PatchPVsReclaimPolicy(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchPVsReclaimPolicy", reflect.TypeOf((*MockBackuperRestorer)(nil).PatchPVsReclaimPolicy), ctx)
+}
+
 // StartOrTrackBackup mocks base method.
 func (m *MockBackuperRestorer) StartOrTrackBackup(ctx context.Context, backups []*v1.Backup) (*backuprestore.BackupTracker, error) {
 	m.ctrl.T.Helper()

--- a/internal/backuprestore/mocks/mock_backuprestore.go
+++ b/internal/backuprestore/mocks/mock_backuprestore.go
@@ -185,6 +185,20 @@ func (mr *MockBackuperRestorerMockRecorder) PatchPVsReclaimPolicy(ctx any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchPVsReclaimPolicy", reflect.TypeOf((*MockBackuperRestorer)(nil).PatchPVsReclaimPolicy), ctx)
 }
 
+// RestorePVsReclaimPolicy mocks base method.
+func (m *MockBackuperRestorer) RestorePVsReclaimPolicy(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestorePVsReclaimPolicy", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestorePVsReclaimPolicy indicates an expected call of RestorePVsReclaimPolicy.
+func (mr *MockBackuperRestorerMockRecorder) RestorePVsReclaimPolicy(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestorePVsReclaimPolicy", reflect.TypeOf((*MockBackuperRestorer)(nil).RestorePVsReclaimPolicy), ctx)
+}
+
 // StartOrTrackBackup mocks base method.
 func (m *MockBackuperRestorer) StartOrTrackBackup(ctx context.Context, backups []*v1.Backup) (*backuprestore.BackupTracker, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Adds support for LVMS in LCA.

The implemented workflow is as follows:
- pre-pivot: LCA patches to `Retain` all PVs created by LVMS and with a Reclaim Policy of `Delete`.
- post-pivot: LCA restores back to `Delete` the Reclaim Policy of all PVs created by LVMS.
- rollback -> idle: LCA restores back to `Delete` the Reclaim Policy of all PVs previously patched.

Also added docs and a couple of entries to the troubleshooting guide.

/cc @browsell @Missxiaoguo @donpenney @jakobmoellerdev