### PR TITLE
fix policy watch error (Failed to watch *v1.Policy: unknown)

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -498,6 +498,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -285,6 +285,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/internal/extramanifest/policy.go
+++ b/internal/extramanifest/policy.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// +kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list
+// +kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list;watch
 
 // This annotation helps with the ordering as well as whether the policy should be applied. This is the same expectation as
 // the normal ZTP process post non-image-based cluster installation.


### PR DESCRIPTION
A non fatal log shows up during pre pivot
```
E0417 21:11:51.138232   58444 reflector.go:147] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:208: Failed to watch *v1.Policy: unknown (get policies.policy.open-cluster-management.io)
``` 

Controller-runtime client automatically starts a watch on resources that's been previously fetched with`Get`...this is should suppress it

/cc @Missxiaoguo @jc-rh @donpenney 