### PR TITLE
CNF-10889: Validate the count of manifests extracted from policies

### DIFF
--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -748,7 +748,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 				tt.args.ibu.Spec.OADPContent = []lcav1alpha1.ConfigMapRef{{Name: "atleast-one-restore-to-proceed-with-export"}}
 			}
 			if tt.extractAndExportManifestFromPoliciesToDirReturn != nil {
-				mockExtramanifest.EXPECT().ExtractAndExportManifestFromPoliciesToDir(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.extractAndExportManifestFromPoliciesToDirReturn()).Times(1)
+				mockExtramanifest.EXPECT().ExtractAndExportManifestFromPoliciesToDir(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.extractAndExportManifestFromPoliciesToDirReturn()).Times(1)
 			}
 			if tt.exportExtraManifestToDirReturn != nil {
 				mockExtramanifest.EXPECT().ExportExtraManifestToDir(gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.exportExtraManifestToDirReturn()).Times(1)
@@ -1112,34 +1112,4 @@ func TestImageBasedUpgradeReconciler_postPivot(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGetMatchingVersion(t *testing.T) {
-	tests := []struct {
-		targetOCPversion string
-		expected         []string
-	}{
-		{
-			targetOCPversion: "4.15.2-ec.3",
-			expected:         []string{"4.15.2-ec.3", "4.15.2", "4.15"},
-		},
-		{
-			targetOCPversion: "4.15.2",
-			expected:         []string{"4.15.2", "4.15"},
-		},
-		{
-			targetOCPversion: "4.16.0-0.ci-2024-04-11-051453",
-			expected:         []string{"4.16.0-0.ci-2024-04-11-051453", "4.16.0", "4.16"},
-		},
-	}
-
-	t.Run("TargetOCPversion test", func(t *testing.T) {
-		for _, tc := range tests {
-			result, err := getMatchingTargetOcpVersionLabelVersions(tc.targetOCPversion)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			assert.ElementsMatch(t, tc.expected, result)
-		}
-	})
 }

--- a/docs/image-based-upgrade.md
+++ b/docs/image-based-upgrade.md
@@ -81,6 +81,54 @@ There are two implementations of extra manifests:
 
 - If the target cluster is integrated with ZTP GitOps, the site specific manifests can be automatically extracted from the policies by the operator during the upgrade stage.
 Manifests defined in the policies that have the `ran.openshift.io/ztp-deploy-wave` annotation and labeled with `lca.openshift.io/target-ocp-version: "4.y.x"` or `lca.openshift.io/target-ocp-version: "4.y"` will be extracted and applied after rebooting to the new version.
+For example,
+
+  ```yaml
+  kind: Policy
+  apiVersion: policy.open-cluster-management.io/v1
+  metadata:
+    name: example-policy
+    annotations:
+      ran.openshift.io/ztp-deploy-wave: "1"
+  spec:
+    policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: example-policy-config
+        spec:
+          object-templates:
+          - objectDefinition:
+              apiVersion: operators.coreos.com/v1alpha1
+              kind: CatalogSource
+              metadata:
+                name: redhat-operators-new
+                namespace: openshift-marketplace
+                labels:
+                  lca.openshift.io/target-ocp-version: "4.16"
+              spec:
+                displayName: Red Hat Operators Catalog
+                image: registry.redhat.io/redhat/redhat-operator-index:v4.16
+                publisher: Red Hat
+                sourceType: grpc
+                updateStrategy:
+                  registryPoll:
+                    interval: 1h
+  ...
+  ```
+
+  If the annotation `lca.openshift.io/target-ocp-version-manifest-count` is specified in the IBU CR, LCA will verify that the number of manifests labeled with `lca.openshift.io/target-ocp-version` extracted from policies matches the count provided in the annotation during the prep and upgrade stages.
+  For example,
+
+  ```yaml
+  apiVersion: lca.openshift.io/v1alpha1
+  kind: ImageBasedUpgrade
+  metadata:
+    annotations:
+      lca.openshift.io/target-ocp-version-manifest-count: "5"
+    name: upgrade
+  ```
 
 - If the target cluster is not integrated with ZTP GitOps the extra manifests can be provided via configmap(s) applied to the cluster. These configmap(s) specified by the
 `extraManifests` field in the [IBU CR](#imagebasedupgrade-cr). After rebooting to the new version, these extra manifests are applied.

--- a/internal/extramanifest/mocks/mock_extramanifest.go
+++ b/internal/extramanifest/mocks/mock_extramanifest.go
@@ -14,6 +14,7 @@ import (
 
 	v1alpha1 "github.com/openshift-kni/lifecycle-agent/api/v1alpha1"
 	gomock "go.uber.org/mock/gomock"
+	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 //go:generate mockgen -source ../extramanifest.go -destination mock_extramanifest.go -write_generate_directive
@@ -70,17 +71,32 @@ func (mr *MockEManifestHandlerMockRecorder) ExportExtraManifestToDir(ctx, extraM
 }
 
 // ExtractAndExportManifestFromPoliciesToDir mocks base method.
-func (m *MockEManifestHandler) ExtractAndExportManifestFromPoliciesToDir(ctx context.Context, policyLabels, objectLabels map[string]string, toDir string) error {
+func (m *MockEManifestHandler) ExtractAndExportManifestFromPoliciesToDir(ctx context.Context, policyLabels, objectLabels, validationAnns map[string]string, toDir string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtractAndExportManifestFromPoliciesToDir", ctx, policyLabels, objectLabels, toDir)
+	ret := m.ctrl.Call(m, "ExtractAndExportManifestFromPoliciesToDir", ctx, policyLabels, objectLabels, validationAnns, toDir)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ExtractAndExportManifestFromPoliciesToDir indicates an expected call of ExtractAndExportManifestFromPoliciesToDir.
-func (mr *MockEManifestHandlerMockRecorder) ExtractAndExportManifestFromPoliciesToDir(ctx, policyLabels, objectLabels, toDir any) *gomock.Call {
+func (mr *MockEManifestHandlerMockRecorder) ExtractAndExportManifestFromPoliciesToDir(ctx, policyLabels, objectLabels, validationAnns, toDir any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractAndExportManifestFromPoliciesToDir", reflect.TypeOf((*MockEManifestHandler)(nil).ExtractAndExportManifestFromPoliciesToDir), ctx, policyLabels, objectLabels, toDir)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractAndExportManifestFromPoliciesToDir", reflect.TypeOf((*MockEManifestHandler)(nil).ExtractAndExportManifestFromPoliciesToDir), ctx, policyLabels, objectLabels, validationAnns, toDir)
+}
+
+// ValidateAndExtractManifestFromPolicies mocks base method.
+func (m *MockEManifestHandler) ValidateAndExtractManifestFromPolicies(ctx context.Context, policyLabels, objectLabels, validationAnns map[string]string) ([][]*unstructured.Unstructured, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateAndExtractManifestFromPolicies", ctx, policyLabels, objectLabels, validationAnns)
+	ret0, _ := ret[0].([][]*unstructured.Unstructured)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateAndExtractManifestFromPolicies indicates an expected call of ValidateAndExtractManifestFromPolicies.
+func (mr *MockEManifestHandlerMockRecorder) ValidateAndExtractManifestFromPolicies(ctx, policyLabels, objectLabels, validationAnns any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndExtractManifestFromPolicies", reflect.TypeOf((*MockEManifestHandler)(nil).ValidateAndExtractManifestFromPolicies), ctx, policyLabels, objectLabels, validationAnns)
 }
 
 // ValidateExtraManifestConfigmaps mocks base method.

--- a/internal/extramanifest/policy.go
+++ b/internal/extramanifest/policy.go
@@ -23,6 +23,7 @@ import (
 // This annotation helps with the ordering as well as whether the policy should be applied. This is the same expectation as
 // the normal ZTP process post non-image-based cluster installation.
 const ztpDeployWaveAnnotation = "ran.openshift.io/ztp-deploy-wave"
+const TargetOcpVersionManifestCountAnnotation = "lca.openshift.io/target-ocp-version-manifest-count"
 const TargetOcpVersionLabel = "lca.openshift.io/target-ocp-version"
 
 // GetPolicies gets the policies matching the labels from the namespace and sort them by the ztp wave annotation value


### PR DESCRIPTION
When "lca.openshift.io/target-ocp-version-manifest-count" annotation is provided in the IBU, verify that the labeled manifests found in the policies matches the number of expected manifests in both Prep and Upgrade stages






/cc @browsell @jc-rh @pixelsoccupied @donpenney 