### PR TITLE
MGMT-17586: [IBI] Shutdown the node after the RHCOS image is written to the disk

### DIFF
--- a/ib-cli/cmd/createiso.go
+++ b/ib-cli/cmd/createiso.go
@@ -40,6 +40,7 @@ var (
 	workDir             string
 	precacheBestEffort  bool
 	precacheDisabled    bool
+	shutdown            bool
 )
 
 func addFlags(cmd *cobra.Command) {
@@ -55,6 +56,8 @@ func addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&workDir, "dir", "d", "", "The working directory for creating the ISO.")
 	cmd.Flags().BoolVarP(&precacheBestEffort, "precache-best-effort", "", false, "Set image precache to best effort mode")
 	cmd.Flags().BoolVarP(&precacheDisabled, "precache-disabled", "", false, "Disable precaching, no image precaching will run")
+	cmd.Flags().BoolVarP(&shutdown, "shutdown", "", false, "Shutdown of the host after the preparation process is done.")
+
 	cmd.MarkFlagRequired("installation-disk")
 	cmd.MarkFlagRequired("extra-partition-start")
 	cmd.MarkFlagRequired("dir")
@@ -97,7 +100,7 @@ func createIso() error {
 	}
 	isoCreator := installationiso.NewInstallationIso(log, op, workDir)
 	if err = isoCreator.Create(seedImage, seedVersion, authFile, pullSecretFile, sshPublicKeyFile, lcaImage, rhcosLiveIso,
-		installationDisk, extraPartitionStart, precacheBestEffort, precacheDisabled); err != nil {
+		installationDisk, extraPartitionStart, precacheBestEffort, precacheDisabled, shutdown); err != nil {
 		err = fmt.Errorf("failed to create installation ISO: %w", err)
 		log.Errorf(err.Error())
 		return err

--- a/ib-cli/installationiso/data/ibi-butane.template
+++ b/ib-cli/installationiso/data/ibi-butane.template
@@ -42,6 +42,9 @@ systemd:
         {{else if .PrecacheBestEffort}}
         Environment=PRECACHE_BEST_EFFORT=true
         {{end}}
+        {{if .Shutdown}}
+        Environment=SHUTDOWN=true
+        {{end}}
         Type=oneshot
         RemainAfterExit=yes
         ExecStart=/usr/local/bin/install-rhcos-and-restore-seed.sh

--- a/ib-cli/installationiso/data/install-rhcos-and-restore-seed.sh
+++ b/ib-cli/installationiso/data/install-rhcos-and-restore-seed.sh
@@ -55,4 +55,8 @@ if [ -n "${PRECACHE_BEST_EFFORT}" ]; then
     additional_flags="${additional_flags} --precache-best-effort"
 fi
 
+if [ -n "${SHUTDOWN}" ]; then
+    additional_flags="${additional_flags} --shutdown"
+fi
+
 podman run --privileged --security-opt label=type:unconfined_t --rm --pid=host --authfile "${authfile}" -v /:/host --entrypoint /usr/local/bin/lca-cli "${lca_image}" ibi --seed-image "${seed_image}" --authfile "${authfile}" --seed-version "${seed_version}" --pullSecretFile "${pull_secret}" ${additional_flags}

--- a/ib-cli/installationiso/installationiso.go
+++ b/ib-cli/installationiso/installationiso.go
@@ -32,6 +32,7 @@ type IgnitionData struct {
 	ExtraPartitionStart string
 	PrecacheBestEffort  bool
 	PrecacheDisabled    bool
+	Shutdown            bool
 }
 
 //go:embed data/*
@@ -57,14 +58,14 @@ const (
 )
 
 func (r *InstallationIso) Create(seedImage, seedVersion, authFile, pullSecretFile, sshPublicKeyPath, lcaImage,
-	rhcosLiveIsoUrl, installationDisk string, extraPartitionStart string, precacheBestEffort, precacheDisabled bool) error {
+	rhcosLiveIsoUrl, installationDisk string, extraPartitionStart string, precacheBestEffort, precacheDisabled, shutdown bool) error {
 	r.log.Info("Creating IBI installation ISO")
 	err := r.validate()
 	if err != nil {
 		return err
 	}
 	err = r.createIgnitionFile(seedImage, seedVersion, authFile, pullSecretFile, sshPublicKeyPath, lcaImage,
-		installationDisk, extraPartitionStart, precacheBestEffort, precacheDisabled)
+		installationDisk, extraPartitionStart, precacheBestEffort, precacheDisabled, shutdown)
 	if err != nil {
 		return err
 	}
@@ -88,10 +89,10 @@ func (r *InstallationIso) validate() error {
 }
 
 func (r *InstallationIso) createIgnitionFile(seedImage, seedVersion, authFile, pullSecretFile, sshPublicKeyPath, lcaImage,
-	installationDisk string, extraPartitionStart string, precacheBestEffort, precacheDisabled bool) error {
+	installationDisk string, extraPartitionStart string, precacheBestEffort, precacheDisabled, shutdown bool) error {
 	r.log.Info("Generating Ignition Config")
 	err := r.renderButaneConfig(seedImage, seedVersion, authFile, pullSecretFile, sshPublicKeyPath, lcaImage,
-		installationDisk, extraPartitionStart, precacheBestEffort, precacheDisabled)
+		installationDisk, extraPartitionStart, precacheBestEffort, precacheDisabled, shutdown)
 	if err != nil {
 		return err
 	}
@@ -151,7 +152,7 @@ func (r *InstallationIso) embedIgnitionToIso() error {
 }
 
 func (r *InstallationIso) renderButaneConfig(seedImage, seedVersion, authFile, pullSecretFile, sshPublicKeyPath, lcaImage,
-	installationDisk string, extraPartitionStart string, precacheBestEffort, precacheDisabled bool) error {
+	installationDisk string, extraPartitionStart string, precacheBestEffort, precacheDisabled, shutdown bool) error {
 	r.log.Debug("Generating butane config")
 	var sshPublicKey []byte
 	var err error
@@ -198,6 +199,9 @@ func (r *InstallationIso) renderButaneConfig(seedImage, seedVersion, authFile, p
 	}
 	if precacheDisabled {
 		templateData.PrecacheDisabled = true
+	}
+	if shutdown {
+		templateData.Shutdown = true
 	}
 
 	template, err := folder.ReadFile(ibiButaneTemplateFilePath)

--- a/lca-cli/cmd/ibi.go
+++ b/lca-cli/cmd/ibi.go
@@ -41,6 +41,7 @@ var (
 	pullSecretFile     string
 	precacheBestEffort bool
 	precacheDisabled   bool
+	shutdown           bool
 )
 
 func init() {
@@ -54,6 +55,8 @@ func init() {
 	ibi.Flags().StringVarP(&pullSecretFile, "pullSecretFile", "p", "", "The path to the pull secret file for precache process.")
 	ibi.Flags().BoolVarP(&precacheBestEffort, "precache-best-effort", "", false, "Set image precache to best effort mode")
 	ibi.Flags().BoolVarP(&precacheDisabled, "precache-disabled", "", false, "Disable precaching, no image precaching will run")
+	ibi.Flags().BoolVarP(&shutdown, "shutdown", "", false, "Shutdown of the host after the preparation process is done.")
+
 	ibi.MarkFlagRequired("seed-image")
 	ibi.MarkFlagRequired("seed-version")
 	ibi.MarkFlagRequired("authfile")
@@ -67,7 +70,7 @@ func runIBI() {
 	ostreeClient := ostreeclient.NewClient(hostCommandsExecutor, true)
 
 	ibiRunner := ibipreparation.NewIBIPrepare(log, ops.NewOps(log, hostCommandsExecutor), rpmOstreeClient, ostreeClient,
-		seedImage, authFile, pullSecretFile, seedVersion, precacheBestEffort, precacheDisabled)
+		seedImage, authFile, pullSecretFile, seedVersion, precacheBestEffort, precacheDisabled, shutdown)
 	if err := ibiRunner.Run(); err != nil {
 		log.Fatal(err)
 	}

--- a/lca-cli/ops/mock_ops.go
+++ b/lca-cli/ops/mock_ops.go
@@ -37,6 +37,21 @@ func (m *MockOps) EXPECT() *MockOpsMockRecorder {
 	return m.recorder
 }
 
+// Chroot mocks base method.
+func (m *MockOps) Chroot(chrootPath string) (func() error, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Chroot", chrootPath)
+	ret0, _ := ret[0].(func() error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Chroot indicates an expected call of Chroot.
+func (mr *MockOpsMockRecorder) Chroot(chrootPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chroot", reflect.TypeOf((*MockOps)(nil).Chroot), chrootPath)
+}
+
 // ExtractTarWithSELinux mocks base method.
 func (m *MockOps) ExtractTarWithSELinux(srcPath, destPath string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
[MGMT-17586](https://issues.redhat.com//browse/MGMT-17586): [IBI] Shutdown the node after the RHCOS image is written to the disk.

In order to run shutdown command after chroot we need to unchroot adding such option as helper function.
