### PR TITLE
OCPBUGS-32704: (seedgen) Avoid printing out seed cluster's pull-secret in LCA logs

### DIFF
--- a/controllers/seedgen_controller.go
+++ b/controllers/seedgen_controller.go
@@ -219,7 +219,7 @@ func (r *SeedGeneratorReconciler) waitForPullSecretOverride(ctx context.Context,
 	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer deadlineCancel()
 	err := wait.PollUntilContextCancel(deadlineCtx, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		r.Log.Info("Waiting for MCO to override pull-secret file", "image registry auth file location", common.ImageRegistryAuthFile)
+		r.Log.Info("Waiting for MCO to override pull-secret file")
 		dockerConfigJSON, err := os.ReadFile(filepath.Join(common.Host, common.ImageRegistryAuthFile))
 		if err != nil {
 			r.Log.Info(fmt.Sprintf("Failed to read %s file with error %s, will retry",


### PR DESCRIPTION
Avoid printing out this info in the operator's logs in case the user may have configured an external aggregation log tool to extract those logs automatically through the network.