### PR TITLE
Update bundle-run target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,9 +206,9 @@ bundle-check: bundle
 	hack/check-git-tree.sh
 
 .PHONY: bundle-run
-bundle-run: # Install bundle on cluster using operator sdk. Index image is require due to upstream issue: https://github.com/operator-framework/operator-registry/issues/984
+bundle-run: # Install bundle on cluster using operator sdk.
 	oc create ns openshift-lifecycle-agent
-	$(OPERATOR_SDK) --index-image=quay.io/operator-framework/opm:v1.28.0 --security-context-config restricted -n openshift-lifecycle-agent run bundle $(BUNDLE_IMG)
+	$(OPERATOR_SDK) --security-context-config restricted -n openshift-lifecycle-agent run bundle $(BUNDLE_IMG)
 
 .PHONY: bundle-upgrade
 bundle-upgrade: # Upgrade bundle on cluster using operator sdk.


### PR DESCRIPTION
The operator-sdk --index-image option is not required for the operator-sdk run bundle command.