### PR TITLE
OCPBUGS-32939: [IBU] Add localVolume presence check in CleanupStaleBackups

### DIFF
--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -492,9 +492,11 @@ func (h *BRHandler) CleanupStaleBackups(ctx context.Context, backups []*velerov1
 			continue
 		}
 
-		// Check cluster ID label of existingBackup
 		labels := existingBackup.GetLabels()
-		if labels != nil && labels[clusterIDLabel] != clusterID {
+		hasLocalVolumes := h.searchForLocalVolumes(backup)
+
+		// Check cluster ID label and localVolume presence in existingBackup CR
+		if labels != nil && labels[clusterIDLabel] != clusterID && !hasLocalVolumes {
 			staleBackupList.Items = append(staleBackupList.Items, *existingBackup)
 
 			deleteBackupRequest := &velerov1.DeleteBackupRequest{

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -397,6 +397,7 @@ func (h *BRHandler) ValidateOadpConfigmaps(ctx context.Context, content []lcav1a
 		return err
 	}
 	for _, backup := range backups {
+		// Dry-run the Backup CR to detect early issues
 		err := h.Create(ctx, backup, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		if err != nil {
 			if k8serrors.IsInvalid(err) {
@@ -405,41 +406,12 @@ func (h *BRHandler) ValidateOadpConfigmaps(ctx context.Context, content []lcav1a
 				h.Log.Error(err, errMsg)
 				return NewBRFailedValidationError("backup", errMsg)
 			}
-
 			if !k8serrors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create backup with dry run: %w", err)
 			}
 		}
-	}
 
-	restores, err := common.ExtractResourcesFromConfigmaps[*velerov1.Restore](configmaps, common.RestoreGvk)
-	if err != nil {
-		return err
-	}
-	for _, restore := range restores {
-		err := h.Create(ctx, restore, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
-		if err != nil {
-			if k8serrors.IsInvalid(err) {
-				errMsg := fmt.Sprintf("Invalid Restore %s detected in configmap, error: %s. Please update the invalid Restore in configmap.",
-					restore.GetName(), err.Error())
-				h.Log.Error(err, errMsg)
-				return NewBRFailedValidationError("restore", errMsg)
-			}
-
-			if !k8serrors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create Restore with dry run: %w", err)
-			}
-		}
-	}
-
-	if len(backups) == 0 || len(restores) == 0 || len(backups) != len(restores) {
-		errMsg := "Both backup and restore CRs should be specified in OADP configmaps and each backup CR should be paired with a corresponding restore CR."
-		h.Log.Error(nil, errMsg)
-		return NewBRFailedValidationError("OADP", errMsg)
-	}
-
-	// Check if we can apply backup label to objects included in apply-backup annotation
-	for _, backup := range backups {
+		// Check if we can apply backup label to objects included in apply-backup annotation
 		payload := []byte(fmt.Sprintf(`[{"op":"add","path":"/metadata/labels","value":{"%s":"%s"}}]`, backupLabel, backup.GetName()))
 		objs, err := getObjsFromAnnotations(backup)
 		if err != nil {
@@ -453,8 +425,26 @@ func (h *BRHandler) ValidateOadpConfigmaps(ctx context.Context, content []lcav1a
 		}
 	}
 
-	// Check if the backup CRs defined in restore CRs exist in OADP configmaps
+	restores, err := common.ExtractResourcesFromConfigmaps[*velerov1.Restore](configmaps, common.RestoreGvk)
+	if err != nil {
+		return err
+	}
 	for _, restore := range restores {
+		// Dry-run the Restore CR to detect early issues
+		err := h.Create(ctx, restore, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		if err != nil {
+			if k8serrors.IsInvalid(err) {
+				errMsg := fmt.Sprintf("Invalid Restore %s detected in configmap, error: %s. Please update the invalid Restore in configmap.",
+					restore.GetName(), err.Error())
+				h.Log.Error(err, errMsg)
+				return NewBRFailedValidationError("restore", errMsg)
+			}
+			if !k8serrors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create Restore with dry run: %w", err)
+			}
+		}
+
+		// Check if the backup CRs defined in restore CRs exist in OADP configmaps
 		found := false
 		for _, backup := range backups {
 			if restore.Spec.BackupName == backup.Name {
@@ -467,6 +457,12 @@ func (h *BRHandler) ValidateOadpConfigmaps(ctx context.Context, content []lcav1a
 			h.Log.Error(nil, errMsg)
 			return NewBRFailedValidationError("OADP", errMsg)
 		}
+	}
+
+	if len(backups) == 0 || len(restores) == 0 || len(backups) != len(restores) {
+		errMsg := "Both backup and restore CRs should be specified in OADP configmaps and each backup CR should be paired with a corresponding restore CR."
+		h.Log.Error(nil, errMsg)
+		return NewBRFailedValidationError("OADP", errMsg)
 	}
 
 	// Check for any stale backup CRs in this cluster

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -381,6 +381,16 @@ func patchObj(ctx context.Context, client dynamic.Interface, obj *ObjMetadata, i
 	return nil
 }
 
+func (h *BRHandler) searchForLocalVolumes(backup *velerov1.Backup) bool {
+	for _, resource := range backup.Spec.IncludedNamespaceScopedResources {
+		if strings.Contains(strings.ToLower(resource), "localvolume") {
+			h.Log.Info("localVolume found in Backup CR, skipping its deletion")
+			return true
+		}
+	}
+	return false
+}
+
 func (h *BRHandler) ValidateOadpConfigmaps(ctx context.Context, content []lcav1alpha1.ConfigMapRef) error {
 	configmaps, err := common.GetConfigMaps(ctx, h.Client, content)
 	if err != nil {

--- a/internal/backuprestore/common_test.go
+++ b/internal/backuprestore/common_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 )
 
 func TestSetBackupLabelSelector(t *testing.T) {
@@ -11,5 +12,50 @@ func TestSetBackupLabelSelector(t *testing.T) {
 		backup := fakeBackupCr("backupName", "1", "b")
 		setBackupLabelSelector(backup)
 		assert.Equal(t, backup.GetName(), backup.Spec.LabelSelector.MatchLabels[backupLabel])
+	})
+}
+
+func TestSearchForLocalVolumes(t *testing.T) {
+	handler := &BRHandler{}
+
+	// Create Backup CRs for different scenarios
+	t.Run("no local volumes found", func(t *testing.T) {
+		backup := &velerov1.Backup{
+			Spec: velerov1.BackupSpec{
+				IncludedNamespaceScopedResources: []string{"deployment", "service"},
+			},
+		}
+		found := handler.searchForLocalVolumes(backup)
+		assert.False(t, found, "Expected no local volumes to be found")
+	})
+	t.Run("local volume found", func(t *testing.T) {
+		handler := &BRHandler{}
+		backup := &velerov1.Backup{
+			Spec: velerov1.BackupSpec{
+				IncludedNamespaceScopedResources: []string{"localvolume", "service"},
+			},
+		}
+		found := handler.searchForLocalVolumes(backup)
+		assert.True(t, found, "Expected local volume to be found")
+	})
+	t.Run("local volume with capital letters found", func(t *testing.T) {
+		handler := &BRHandler{}
+		backup := &velerov1.Backup{
+			Spec: velerov1.BackupSpec{
+				IncludedNamespaceScopedResources: []string{"LocalVolume", "service"},
+			},
+		}
+		found := handler.searchForLocalVolumes(backup)
+		assert.True(t, found, "Expected local volume to be found")
+	})
+	t.Run("local volume with defined group found", func(t *testing.T) {
+		handler := &BRHandler{}
+		backup := &velerov1.Backup{
+			Spec: velerov1.BackupSpec{
+				IncludedNamespaceScopedResources: []string{"localvolumes.storage.openshift.io", "service"},
+			},
+		}
+		found := handler.searchForLocalVolumes(backup)
+		assert.True(t, found, "Expected local volume to be found")
 	})
 }


### PR DESCRIPTION
Adds a check to the CleanupStaleBackups function to detect if a localVolume is specified in the resources in Backup CRs, and ignores its cleanup.

Also, refactors a bit the ValidateOadpConfigmaps function to reduce time complexity.

/cc @browsell @Missxiaoguo @donpenney 