### PR TITLE
MGMT-16807: set correct no proxy and proxyStatus

### DIFF
--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -168,7 +168,8 @@ func init() {
 		&ocpV1.Infrastructure{},
 		&mcv1.MachineConfig{},
 		&ocpV1.ImageContentPolicy{},
-		&ocpV1.ImageContentPolicyList{})
+		&ocpV1.ImageContentPolicyList{},
+		&ocpV1.Network{})
 	testscheme.AddKnownTypes(operatorv1alpha1.GroupVersion,
 		&operatorv1alpha1.ImageContentSourcePolicyList{},
 		&operatorv1alpha1.ImageContentSourcePolicy{})
@@ -232,6 +233,16 @@ func TestClusterConfig(t *testing.T) {
 			Namespace: common.InstallConfigCMNamespace,
 		},
 		Data: map[string]string{"install-config": clusterCmData},
+	}
+
+	network := &ocpV1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: ocpV1.NetworkStatus{
+			ClusterNetwork: []ocpV1.ClusterNetworkEntry{{CIDR: "1.1.1.1/24"}},
+			ServiceNetwork: []string{"2.2.2.2/24"},
+		},
 	}
 
 	testcases := []struct {
@@ -472,6 +483,8 @@ func TestClusterConfig(t *testing.T) {
 				testCase.pullSecret, testCase.clusterVersion, installConfig, testCase.node,
 				testCase.idms, testCase.proxy, testCase.caBundleCM, csvDeployment, infrastructure,
 			}
+
+			k8sResources = append(k8sResources, network)
 
 			if !testCase.deleteKubeadmin {
 				k8sResources = append(k8sResources, kubeadminSecret)

--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -25,6 +25,7 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -115,6 +116,10 @@ func (p *PostPivot) PostPivotConfiguration(ctx context.Context) error {
 
 	if seedReconfiguration.APIVersion != clusterconfig_api.SeedReconfigurationVersion {
 		return fmt.Errorf("unsupported seed reconfiguration version %d", seedReconfiguration.APIVersion)
+	}
+
+	if err := p.setProxyAndProxyStatus(seedReconfiguration, seedClusterInfo); err != nil {
+		return fmt.Errorf("failed to set no proxy: %w", err)
 	}
 
 	if err := utils.RunOnce("recert", p.workingDir, p.log, p.recert, ctx, seedReconfiguration, seedClusterInfo); err != nil {
@@ -221,6 +226,48 @@ func (p *PostPivot) recert(ctx context.Context, seedReconfiguration *clusterconf
 	if err != nil {
 		return fmt.Errorf("failed recert full flow: %w", err)
 	}
+
+	return nil
+}
+
+func (p *PostPivot) setProxyAndProxyStatus(seedReconfig *clusterconfig_api.SeedReconfiguration, seedClusterInfo *seedclusterinfo.SeedClusterInfo) error {
+	if seedReconfig.Proxy != nil != seedClusterInfo.HasProxy {
+		return fmt.Errorf("seedReconfig and seedClusterInfo proxy configuration mismatch")
+	}
+
+	if seedReconfig.Proxy == nil {
+		return nil
+
+	}
+
+	set := sets.NewString(
+		"127.0.0.1",
+		"localhost",
+		".svc",
+		".cluster.local",
+		fmt.Sprintf("api-int.%s.%s", seedReconfig.ClusterName, seedReconfig.BaseDomain),
+	)
+
+	if seedReconfig.MachineNetwork == "" {
+		return fmt.Errorf("machineNetwork is empty, must be provided in case of proxy")
+
+	}
+	set.Insert(seedReconfig.MachineNetwork)
+	for _, nss := range append(seedClusterInfo.ServiceNetworks, seedClusterInfo.ClusterNetworks...) {
+		set.Insert(nss)
+	}
+
+	if len(seedReconfig.Proxy.NoProxy) > 0 {
+		for _, userValue := range strings.Split(seedReconfig.Proxy.NoProxy, ",") {
+			if userValue != "" {
+				set.Insert(userValue)
+			}
+		}
+	}
+	seedReconfig.Proxy.NoProxy = strings.Join(set.List(), ",")
+	// as we are using same logic as network operator
+	// proxy and proxy status are the same
+	seedReconfig.StatusProxy = seedReconfig.Proxy
 
 	return nil
 }

--- a/lca-cli/seedclusterinfo/seedclusterinfo.go
+++ b/lca-cli/seedclusterinfo/seedclusterinfo.go
@@ -68,6 +68,12 @@ type SeedClusterInfo struct {
 	// with a proxy from seeds that don't have one. Similarly, installing a
 	// cluster without a proxy from a seed with a proxy is also not supported.
 	HasProxy bool `json:"has_proxy"`
+
+	// The cluster network CIDR of the seed cluster that was used to create this seed
+	ClusterNetworks []string `json:"cluster_network_cidr,omitempty"`
+
+	// The service network CIDR of the seed cluster that was used to create this seed
+	ServiceNetworks []string `json:"service_network_cidr,omitempty"`
 }
 
 func NewFromClusterInfo(clusterInfo *utils.ClusterInfo, seedImagePullSpec string, hasProxy bool) *SeedClusterInfo {


### PR DESCRIPTION
[MGMT-16807](https://issues.redhat.com//browse/MGMT-16807): set correct no proxy and proxyStatus
We should create NoProxy and proxyStatus exactly same way as cluster network operator. 
Took CNO function and made it match lca. 
Added service and cluster networks to seedInfo