### PR TITLE
OCPBUGS-33182: Include acls and xattrs in tar commands for seed image

### DIFF
--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -122,3 +122,5 @@ var CertPrefixes = []string{
 	"localhost-serving-signer",
 	"service-network-serving-signer",
 }
+
+var TarOpts = []string{"--selinux", "--xattrs", "--xattrs-include=*", "--acls"}

--- a/lca-cli/ops/ops.go
+++ b/lca-cli/ops/ops.go
@@ -260,9 +260,10 @@ func (o *ops) ExtractTarWithSELinux(srcPath, destPath string) error {
 		return fmt.Errorf("failed to get path for file %s inside chroot: %w", tarExec, err)
 	}
 
-	if _, err = o.hostCommandsExecutor.Execute(
-		tarExecInsideChroot, "xzf", srcPath, "-C", destPath, "--selinux",
-	); err != nil {
+	tarArgs := []string{"xzf", srcPath, "-C", destPath}
+	tarArgs = append(tarArgs, common.TarOpts...)
+
+	if _, err = o.hostCommandsExecutor.Execute(tarExecInsideChroot, tarArgs...); err != nil {
 		return fmt.Errorf("failed to extract tar with SELinux with sourcePath %s and destPath %s: %w", srcPath, destPath, err)
 	}
 	return nil

--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -324,7 +324,8 @@ func (s *SeedCreator) backupVar() error {
 		// We're handling the excluded patterns in bash, we need to single quote them to prevent expansion
 		tarArgs = append(tarArgs, "--exclude", fmt.Sprintf("'%s'", pattern))
 	}
-	tarArgs = append(tarArgs, "--selinux", common.VarFolder)
+	tarArgs = append(tarArgs, common.VarFolder)
+	tarArgs = append(tarArgs, common.TarOpts...)
 
 	// Run the tar command
 	_, err := s.ops.RunBashInHostNamespace("tar", tarArgs...)
@@ -349,7 +350,8 @@ func (s *SeedCreator) backupEtc() error {
 		// We're handling the excluded patterns in bash, we need to single quote them to prevent expansion
 		tarArgs = append(tarArgs, "--exclude", fmt.Sprintf("'%s'", pattern))
 	}
-	tarArgs = append(tarArgs, "--selinux", "-T", "-")
+	tarArgs = append(tarArgs, "-T", "-")
+	tarArgs = append(tarArgs, common.TarOpts...)
 
 	args := []string{"admin", "config-diff", "|", "awk", `'$1 == "D" {print "/etc/" $2}'`, ">",
 		path.Join(s.backupDir, "/etc.deletions")}
@@ -376,7 +378,8 @@ func (s *SeedCreator) backupOstree() error {
 	ostreeTar := s.backupDir + "/ostree.tgz"
 
 	// Execute 'tar' command and backup /etc
-	args := []string{"czf", ostreeTar, "--selinux", "-C", "/ostree/repo", "."}
+	args := []string{"czf", ostreeTar, "-C", "/ostree/repo", "."}
+	args = append(args, common.TarOpts...)
 	if _, err := s.ops.RunBashInHostNamespace("tar", args...); err != nil {
 		return fmt.Errorf("failed backing ostree with args %s: %w", args, err)
 	}


### PR DESCRIPTION
In order to maintain file capabilities, which are extended attributes, the --xattrs tar command option is required.