### PR TITLE
Pass `fips=1` flag to new stateroot if MC is fips

### DIFF
--- a/internal/prep/prep.go
+++ b/internal/prep/prep.go
@@ -68,6 +68,16 @@ func buildKernelArgumentsFromMCOFile(path string) ([]string, error) {
 			args[2*i+1] = string(val)
 		}
 	}
+
+	if mc.Spec.FIPS {
+		args = append(args,
+			"--karg-append", "fips=1",
+			// This is needed because /boot is on a separate partition https://access.redhat.com/solutions/137833
+			// TODO: Should we have this regardless of FIPS?
+			"--karg-append", "boot=LABEL=boot",
+		)
+	}
+
 	return args, nil
 }
 


### PR DESCRIPTION
LCA is responsible for constructing the kernel arguments for the new
stateroot. Right now it only copies the KernelArguments field of the
MachineConfig, but it should also look at the `FIPS` field and make
sure to add the `fips=1` kernel argument when it's true

Solves [OCPBUGS-29360](https://issues.redhat.com/browse/OCPBUGS-29360)