### PR TITLE
MGMT-17746: Move using lca-cli as binary in IBI iso

### DIFF
--- a/ib-cli/installationiso/data/install-rhcos-and-restore-seed.sh
+++ b/ib-cli/installationiso/data/install-rhcos-and-restore-seed.sh
@@ -5,7 +5,6 @@ set -e # Halt on error
 seed_image=${1:-$SEED_IMAGE}
 seed_version=${2:-$SEED_VERSION}
 installation_disk=${3:-$INSTALLATION_DISK}
-lca_image=${4:-$LCA_IMAGE}
 extra_partition_start=${5:-$EXTRA_PARTITION_START}
 extra_partition_number=5
 extra_partition_label=varlibcontainers
@@ -59,4 +58,9 @@ if [ -n "${SHUTDOWN}" ]; then
     additional_flags="${additional_flags} --shutdown"
 fi
 
-podman run --privileged --security-opt label=type:unconfined_t --rm --pid=host --authfile "${authfile}" -v /:/host --entrypoint /usr/local/bin/lca-cli "${lca_image}" ibi --seed-image "${seed_image}" --authfile "${authfile}" --seed-version "${seed_version}" --pullSecretFile "${pull_secret}" ${additional_flags}
+
+podman create --name lca-cli "${seed_image}" lca-cli
+podman cp lca-cli:lca-cli /usr/local/bin/lca-cli
+podman rm lca-cli
+
+/usr/local/bin/lca-cli ibi --seed-image "${seed_image}" --authfile "${authfile}" --seed-version "${seed_version}" --pullSecretFile "${pull_secret}" ${additional_flags}

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -88,9 +88,9 @@ func GetConfigMaps(ctx context.Context, c client.Client, configMaps []v1alpha1.C
 
 // PathInsideChroot returns filepath removing host fs prefix
 func PathInsideChroot(filename string) (string, error) {
-	relPath, err := filepath.Rel(Host, filename)
+	relPath, err := filepath.Rel(PathOutsideChroot("/"), filename)
 	if err != nil {
-		return "", fmt.Errorf("failed to get relative path of %s inside of %s: %w", filename, Host, err)
+		return "", fmt.Errorf("failed to get relative path of %s inside of %s: %w", filename, PathOutsideChroot("/"), err)
 	}
 	return filepath.Join("/", relPath), nil
 }

--- a/internal/prep/prep.go
+++ b/internal/prep/prep.go
@@ -139,7 +139,7 @@ func SetupStateroot(log logr.Logger, ops ops.Ops, ostreeClient ostreeclient.ICli
 		}
 	}()
 
-	workspace, err := filepath.Rel(common.Host, workspaceOutsideChroot)
+	workspace, err := common.PathInsideChroot(workspaceOutsideChroot)
 	if err != nil {
 		return fmt.Errorf("failed to get workspace relative path %w", err)
 	}

--- a/lca-cli/cmd/ibi.go
+++ b/lca-cli/cmd/ibi.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
@@ -65,7 +67,15 @@ func init() {
 
 func runIBI() {
 	log.Info("IBI preparation process has started")
-	hostCommandsExecutor := ops.NewChrootExecutor(log, true, common.Host)
+	var hostCommandsExecutor ops.Execute
+
+	// if we run in container we will get /host as a host path and should use chroot executor
+	if _, err := os.Stat(common.Host); err == nil {
+		hostCommandsExecutor = ops.NewChrootExecutor(log, true, common.Host)
+	} else {
+		hostCommandsExecutor = ops.NewRegularExecutor(log, true)
+	}
+
 	rpmOstreeClient := ostree.NewClient("lca-cli", hostCommandsExecutor)
 	ostreeClient := ostreeclient.NewClient(hostCommandsExecutor, true)
 

--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -82,9 +82,16 @@ func (s *SeedCreator) CreateSeedImage() error {
 		return fmt.Errorf("failed to backup dir for seed image to %s: %w", s.backupDir, err)
 	}
 
+	lcaBinaryPath := "/usr/local/bin/lca-cli"
 	s.log.Info("Copy lca-cli binary")
-	err := cp.Copy("/usr/local/bin/lca-cli", "/var/usrlocal/bin/lca-cli", cp.Options{AddPermission: os.FileMode(0o777)})
+	err := cp.Copy(lcaBinaryPath, "/var/usrlocal/bin/lca-cli", cp.Options{AddPermission: os.FileMode(0o777)})
 	if err != nil {
+		return fmt.Errorf("failed to copy lca-cli binary: %w", err)
+	}
+
+	// copied to backup dir in order to be included in the seed image without being part of the var archive
+	s.log.Info("Copy lca-cli binary, into backup dir")
+	if err := cp.Copy(lcaBinaryPath, path.Join(s.backupDir, "lca-cli"), cp.Options{AddPermission: os.FileMode(0o777)}); err != nil {
 		return fmt.Errorf("failed to copy lca-cli binary: %w", err)
 	}
 


### PR DESCRIPTION
In order to remove dependency between ibi installer and lca image, we want to use lca-cli that is part of seed image. for this we are going to copy lca-cli from seed image and run it as binary. Changing ibi installation script to copy binary from seed image. Adding lca-cli as part of seed image without need to untar var. Small changes in order to allow ibipreparation logic to run in as binary still leaving an option to run it as container