### PR TITLE
Enforce FIPS compatibility

### DIFF
--- a/lca-cli/cmd/create.go
+++ b/lca-cli/cmd/create.go
@@ -21,6 +21,7 @@ import (
 
 	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 	v1 "github.com/openshift/api/config/v1"
+	mcv1 "github.com/openshift/api/machineconfiguration/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/spf13/cobra"
@@ -56,6 +57,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(v1.AddToScheme(scheme))
+	utilruntime.Must(mcv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(operatorsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(ibuv1.AddToScheme(scheme))

--- a/lca-cli/seedclusterinfo/seedclusterinfo.go
+++ b/lca-cli/seedclusterinfo/seedclusterinfo.go
@@ -74,9 +74,17 @@ type SeedClusterInfo struct {
 
 	// The service network CIDR of the seed cluster that was used to create this seed
 	ServiceNetworks []string `json:"service_network_cidr,omitempty"`
+
+	// Whether the seed has a proxy configured or not. Seed clusters without
+	// FIPS cannot be used to upgrade or install clusters with FIPS. So whether
+	// or not the seed has a proxy configured is important for LCA to know so
+	// it can optionally deny the upgrade or installation of clusters with FIPS
+	// from seeds that don't have one. Similarly, installing a cluster without
+	// FIPS from a seed with FIPS is also not supported.
+	HasFIPS bool `json:"has_fips"`
 }
 
-func NewFromClusterInfo(clusterInfo *utils.ClusterInfo, seedImagePullSpec string, hasProxy bool) *SeedClusterInfo {
+func NewFromClusterInfo(clusterInfo *utils.ClusterInfo, seedImagePullSpec string, hasProxy, hasFIPS bool) *SeedClusterInfo {
 	return &SeedClusterInfo{
 		SeedClusterOCPVersion:    clusterInfo.OCPVersion,
 		BaseDomain:               clusterInfo.BaseDomain,
@@ -87,6 +95,7 @@ func NewFromClusterInfo(clusterInfo *utils.ClusterInfo, seedImagePullSpec string
 		MirrorRegistryConfigured: clusterInfo.MirrorRegistryConfigured,
 		RecertImagePullSpec:      seedImagePullSpec,
 		HasProxy:                 hasProxy,
+		HasFIPS:                  hasFIPS,
 	}
 }
 

--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -205,7 +205,12 @@ func (s *SeedCreator) gatherClusterInfo(ctx context.Context) error {
 		return fmt.Errorf("failed to get proxy information: %w", err)
 	}
 
-	seedClusterInfo := seedclusterinfo.NewFromClusterInfo(clusterInfo, s.recertContainerImage, hasProxy)
+	hasFIPS, err := utils.HasFIPS(ctx, s.client)
+	if err != nil {
+		return fmt.Errorf("failed to get proxy information: %w", err)
+	}
+
+	seedClusterInfo := seedclusterinfo.NewFromClusterInfo(clusterInfo, s.recertContainerImage, hasProxy, hasFIPS)
 
 	if err := os.MkdirAll(common.SeedDataDir, os.ModePerm); err != nil {
 		return fmt.Errorf("error creating SeedDataDir %s: %w", common.SeedDataDir, err)


### PR DESCRIPTION
Solves [MGMT-17748](https://issues.redhat.com//browse/MGMT-17748)

# Background

LCA recently added support for upgrading of FIPS-enabled clusters (see
commit 82460adaf5f3709f707b7f1126f7f180a32ed587).

# Issue

The current implementation does not enforce FIPS compatibility between
the seed image and the cluster being upgraded. This can lead to issues
when the seed image has FIPS enabled but the cluster being upgraded does
not, or vice versa.

# Solution

Add a check for FIPS compatibility between the seed image and the cluster
being upgraded.

# Implementation details

- Add a new field `HasFIPS` to the `SeedClusterInfo` struct to store
  whether the seed image has FIPS enabled or not. This field is set
  based on the value of the `FIPS` field in the `MachineConfig` object
  referenced by the `machineconfiguration.openshift.io/currentConfig`
  label of the only node in the cluster.

- Check for FIPS compatibility when pulling the seed image. If the seed
  image has FIPS enabled but the cluster being upgraded does not, or
  vice versa, return an error.