### PR TITLE
OCPBUGS-32939: Drop "Add check for localVolume presence in CleanupStaleBackups"

### DIFF
--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -504,11 +504,9 @@ func (h *BRHandler) CleanupStaleBackups(ctx context.Context, backups []*velerov1
 			continue
 		}
 
+		// Check cluster ID label of existingBackup
 		labels := existingBackup.GetLabels()
-		hasLocalVolumes := h.searchForLocalVolumes(backup)
-
-		// Check cluster ID label and localVolume presence in existingBackup CR
-		if labels != nil && labels[clusterIDLabel] != clusterID && !hasLocalVolumes {
+		if labels != nil && labels[clusterIDLabel] != clusterID {
 			staleBackupList.Items = append(staleBackupList.Items, *existingBackup)
 
 			deleteBackupRequest := &velerov1.DeleteBackupRequest{

--- a/internal/backuprestore/common.go
+++ b/internal/backuprestore/common.go
@@ -388,16 +388,6 @@ func patchObj(ctx context.Context, client dynamic.Interface, obj *ObjMetadata, i
 	return nil
 }
 
-func (h *BRHandler) searchForLocalVolumes(backup *velerov1.Backup) bool {
-	for _, resource := range backup.Spec.IncludedNamespaceScopedResources {
-		if strings.Contains(strings.ToLower(resource), "localvolume") {
-			h.Log.Info("localVolume found in Backup CR, skipping its deletion")
-			return true
-		}
-	}
-	return false
-}
-
 func (h *BRHandler) ValidateOadpConfigmaps(ctx context.Context, content []lcav1alpha1.ConfigMapRef) error {
 	configmaps, err := common.GetConfigMaps(ctx, h.Client, content)
 	if err != nil {

--- a/internal/backuprestore/common_test.go
+++ b/internal/backuprestore/common_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 )
 
 func TestSetBackupLabelSelector(t *testing.T) {
@@ -12,50 +11,5 @@ func TestSetBackupLabelSelector(t *testing.T) {
 		backup := fakeBackupCr("backupName", "1", "b")
 		setBackupLabelSelector(backup)
 		assert.Equal(t, backup.GetName(), backup.Spec.LabelSelector.MatchLabels[backupLabel])
-	})
-}
-
-func TestSearchForLocalVolumes(t *testing.T) {
-	handler := &BRHandler{}
-
-	// Create Backup CRs for different scenarios
-	t.Run("no local volumes found", func(t *testing.T) {
-		backup := &velerov1.Backup{
-			Spec: velerov1.BackupSpec{
-				IncludedNamespaceScopedResources: []string{"deployment", "service"},
-			},
-		}
-		found := handler.searchForLocalVolumes(backup)
-		assert.False(t, found, "Expected no local volumes to be found")
-	})
-	t.Run("local volume found", func(t *testing.T) {
-		handler := &BRHandler{}
-		backup := &velerov1.Backup{
-			Spec: velerov1.BackupSpec{
-				IncludedNamespaceScopedResources: []string{"localvolume", "service"},
-			},
-		}
-		found := handler.searchForLocalVolumes(backup)
-		assert.True(t, found, "Expected local volume to be found")
-	})
-	t.Run("local volume with capital letters found", func(t *testing.T) {
-		handler := &BRHandler{}
-		backup := &velerov1.Backup{
-			Spec: velerov1.BackupSpec{
-				IncludedNamespaceScopedResources: []string{"LocalVolume", "service"},
-			},
-		}
-		found := handler.searchForLocalVolumes(backup)
-		assert.True(t, found, "Expected local volume to be found")
-	})
-	t.Run("local volume with defined group found", func(t *testing.T) {
-		handler := &BRHandler{}
-		backup := &velerov1.Backup{
-			Spec: velerov1.BackupSpec{
-				IncludedNamespaceScopedResources: []string{"localvolumes.storage.openshift.io", "service"},
-			},
-		}
-		found := handler.searchForLocalVolumes(backup)
-		assert.True(t, found, "Expected local volume to be found")
 	})
 }


### PR DESCRIPTION
Dropping commit [094f0d5](https://github.com/openshift-kni/lifecycle-agent/commit/094f0d50e13302a4edcea62769ca520353196264) since it is not needed anymore. There was a race in the [ensureBackupsDeleted](https://github.com/openshift-kni/lifecycle-agent/blob/main/internal/backuprestore/backup.go#L566-L590) function - fixed in [PR#471](https://github.com/openshift-kni/lifecycle-agent/pull/471/files) - that was provoking [OCPBUGS-32939](https://issues.redhat.com//browse/OCPBUGS-32939).

Moreover, a check to ignore existing "localvolume" Backup CRs during `Prep` stage should not be added, given that LCA will try to create a Backup CR with the same name and this could provoke issues during the pre-pivot step.

```
{"name":"upgrade"}, "namespace": "", "name": "upgrade", "reconcileID": "c269c50a-e1b6-4f6d-adc6-026541173f50", "error": "failed to run pre pivots without errors: error while handling backup: error while starting or tracking backup: failed to create backup: backups.velero.io \"localvolume\" already exists"}
```

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>