### PR TITLE
OCPBUGS-32488: Fix config file error check in init monitor watchdog

### DIFF
--- a/lca-cli/initmonitor/initmonitor.go
+++ b/lca-cli/initmonitor/initmonitor.go
@@ -1,6 +1,7 @@
 package initmonitor
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -46,7 +47,7 @@ func NewInitMonitor(scheme *runtime.Scheme, log *logrus.Logger, hostCommandsExec
 func (m *InitMonitor) RunInitMonitor() error {
 	rollbackCfg, err := m.rebootClient.ReadIBUAutoRollbackConfigFile()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 


### PR DESCRIPTION
The LCA init monitor watchdog is enabled in the seed image and will
start in both IBU and IBI, but only IBU will create the auto-rollback
configuration file. In an IBI, the file will not exist, so the watchdog
will not run. The watchdog should shut down silently in that case, but
the current error check is failing due to the error being wrapped.
Changing the check to use errors.Is will ensure the wrapped error is
checked, and the watchdog now exits without logs when the configuration
file does not exist.