### PR TITLE
`Dockerfile` should set `CGO_ENALBED=1` for FIPS compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ COPY internal internal
 COPY main main
 COPY utils utils
 
-# Build the binaries
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/manager main/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/lca-cli main/lca-cli/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/ib-cli main/ib-cli/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/precache main/precache-workload/main.go
+# Build the binaries. CGO_ENABLED=1 is required for FIPS compliance, see https://access.redhat.com/articles/openshift_fips_compliance_faq
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/manager main/main.go
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/lca-cli main/lca-cli/main.go
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/ib-cli main/ib-cli/main.go
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/precache main/precache-workload/main.go
 
 #####################################################################################################
 # Build the operator image


### PR DESCRIPTION
As far as I can tell, there was no particular reason to set `CGO_ENABLED=0` in the first place, so I'm changing it to `CGO_ENABLED=1` to ensure FIPS compliance, according to https://access.redhat.com/articles/openshift_fips_compliance_faq .

Downstream Dockerfile changes might be required as well