### PR TITLE
CNF-12656: Handle SIGTERM for stateroot setup job

### DIFF
--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/openshift-kni/lifecycle-agent/internal/prep"
+
 	"github.com/go-logr/logr"
 	"github.com/openshift-kni/lifecycle-agent/internal/extramanifest"
 	"github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
-	"github.com/openshift-kni/lifecycle-agent/internal/prep"
 	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
 	rpmostreeclient "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
 
@@ -152,13 +153,8 @@ func (r *ImageBasedUpgradeReconciler) cleanup(ctx context.Context, ibu *ibuv1.Im
 	}
 
 	r.Log.Info("Cleaning up stateroot")
-	if err := CleanupUnbootedStateroots(r.Log, r.Ops, r.OstreeClient, r.RPMOstreeClient); err != nil {
-		handleError(err, "failed to cleanup stateroots.")
-	}
-	r.Log.Info("Cleaning up stateroot setup job")
-	err := prep.DeleteStaterootSetupJob(ctx, r.Client, r.Log)
-	if err != nil {
-		handleError(err, "failed to cleanup stateroots setup job.")
+	if err := r.cleanupStateroot(ctx); err != nil {
+		handleError(err, "failed to cleanup stateroot")
 	}
 
 	r.Log.Info("Cleaning up precache")
@@ -166,6 +162,7 @@ func (r *ImageBasedUpgradeReconciler) cleanup(ctx context.Context, ibu *ibuv1.Im
 		handleError(err, "failed to cleanup precaching resources.")
 	}
 
+	r.Log.Info("Removing annotation with warning")
 	if err := extramanifest.RemoveAnnotationWarnUnknownCRD(r.Client, ibu, r.Log); err != nil {
 		handleError(err, "failed to remove extra manifest warning annotation from IBU")
 	}
@@ -187,6 +184,21 @@ func (r *ImageBasedUpgradeReconciler) cleanup(ctx context.Context, ibu *ibuv1.Im
 	}
 
 	return successful, errorMessage
+}
+
+func (r *ImageBasedUpgradeReconciler) cleanupStateroot(ctx context.Context) error {
+	r.Log.Info("Cleaning up cluster stateroot resources")
+	if err := prep.DeleteStaterootSetupJob(ctx, r.Client, r.Log); err != nil {
+		return fmt.Errorf("failed to cleanup cluster stateroot resources: %w", err)
+	}
+
+	r.Log.Info("Cleaning up unbooted stateroot resources")
+	if err := CleanupUnbootedStateroots(r.Log, r.Ops, r.OstreeClient, r.RPMOstreeClient); err != nil {
+		return fmt.Errorf("failed to clean up host stateroot resources: %w", err)
+	}
+
+	r.Log.Info("Successfully cleaned all resources related to stateroot setup")
+	return nil
 }
 
 func cleanupIBUFiles() error {
@@ -247,7 +259,7 @@ func CleanupUnbootedStateroots(log logr.Logger, ops ops.Ops, ostreeClient ostree
 	}
 
 	if failures == 0 {
-		log.Info("Stateroot cleanup successfully")
+		log.Info("Unbooted stateroot cleanup completed successfully")
 		return nil
 	}
 	return fmt.Errorf("failed to remove %d stateroots", failures)

--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -376,7 +376,7 @@ func (r *ImageBasedUpgradeReconciler) handlePrep(ctx context.Context, ibu *ibuv1
 			if _, err := prep.LaunchStaterootSetupJob(ctx, r.Client, ibu, r.Scheme, r.Log); err != nil {
 				return prepFailDoNotRequeue(r.Log, fmt.Sprintf("failed launch stateroot job: %s", err.Error()), ibu)
 			}
-			return prepInProgressRequeue(r.Log, fmt.Sprintf("Successfully launched a new job `%s` in namespace `%s`", prep.JobName, common.LcaNamespace), ibu)
+			return prepInProgressRequeue(r.Log, fmt.Sprintf("Successfully launched a new job `%s` in namespace `%s`", prep.StaterootSetupJobName, common.LcaNamespace), ibu)
 		}
 		return prepFailDoNotRequeue(r.Log, fmt.Sprintf("failed to get stateroot setup job: %s", err.Error()), ibu)
 	}
@@ -385,7 +385,7 @@ func (r *ImageBasedUpgradeReconciler) handlePrep(ctx context.Context, ibu *ibuv1
 
 	// job deletion not allowed
 	if staterootSetupJob.GetDeletionTimestamp() != nil {
-		return prepFailDoNotRequeue(r.Log, "stateroot job is marked to be deleted, this is not allowed", ibu)
+		return prepFailDoNotRequeue(r.Log, fmt.Sprintf("stateroot job is marked to be deleted, this is not allowed. job: %s, ns: %s", staterootSetupJob.GetName(), staterootSetupJob.GetNamespace()), ibu)
 	}
 
 	// check .status
@@ -395,7 +395,7 @@ func (r *ImageBasedUpgradeReconciler) handlePrep(ctx context.Context, ibu *ibuv1
 		common.LogPodLogs(staterootSetupJob, r.Log, r.Clientset)
 		return prepInProgressRequeue(r.Log, "Stateroot setup in progress", ibu)
 	case kbatch.JobFailed:
-		return prepFailDoNotRequeue(r.Log, fmt.Sprintf("stateroot setup job could not complete. Please check job logs for more, job_name: %s, job_ns: %s", staterootSetupJob.GetName(), staterootSetupJob.GetNamespace()), ibu)
+		return prepFailDoNotRequeue(r.Log, fmt.Sprintf("stateroot setup job could not complete. please check job logs for more, job_name: %s, job_ns: %s", staterootSetupJob.GetName(), staterootSetupJob.GetNamespace()), ibu)
 	case kbatch.JobComplete:
 		r.Log.Info("Stateroot job completed successfully", "completion time", staterootSetupJob.Status.CompletionTime, "total time", staterootSetupJob.Status.CompletionTime.Sub(staterootSetupJob.Status.StartTime.Time))
 	}
@@ -417,7 +417,7 @@ func (r *ImageBasedUpgradeReconciler) handlePrep(ctx context.Context, ibu *ibuv1
 
 	// job deletion not allowed
 	if precacheJob.GetDeletionTimestamp() != nil {
-		return prepFailDoNotRequeue(r.Log, "precache job is marked to be deleted, this not allowed", ibu)
+		return prepFailDoNotRequeue(r.Log, fmt.Sprintf("precache job is marked to be deleted, this not allowed. job: %s, ns: %s", precacheJob.GetName(), precacheJob.GetNamespace()), ibu)
 	}
 
 	// check .status
@@ -427,7 +427,7 @@ func (r *ImageBasedUpgradeReconciler) handlePrep(ctx context.Context, ibu *ibuv1
 		common.LogPodLogs(precacheJob, r.Log, r.Clientset) // pod logs
 		return prepInProgressRequeue(r.Log, fmt.Sprintf("Precache job in progress: %s", precache.GetPrecacheStatusFileContent()), ibu)
 	case kbatch.JobFailed:
-		return prepFailDoNotRequeue(r.Log, fmt.Sprintf("precache job could not complete. Please check job logs for more, job_name: %s, job_ns: %s", precacheJob.GetName(), precacheJob.GetNamespace()), ibu)
+		return prepFailDoNotRequeue(r.Log, fmt.Sprintf("precache job could not complete. please check job logs for more, job_name: %s, job_ns: %s", precacheJob.GetName(), precacheJob.GetNamespace()), ibu)
 	case kbatch.JobComplete:
 		r.Log.Info("Precache job completed successfully", "completion time", precacheJob.Status.CompletionTime, "total time", precacheJob.Status.CompletionTime.Sub(precacheJob.Status.StartTime.Time))
 	}

--- a/docs/image-based-upgrade.md
+++ b/docs/image-based-upgrade.md
@@ -290,14 +290,20 @@ oc patch imagebasedupgrade upgrade -n openshift-lifecycle-agent --type='json' -p
 
 The "Prep" stage will:
 
-- Pull the seed image
 - Perform the following validations:
   - If the oadpContent is populated, validate that the specified configmap has been applied and is valid
   - If the extraManifests is populated, validate that the specified configmap has been applied and is valid
     - If a required CRD is missing from the current stateroot, a warning message will be included in the IBU CRs with annotation `lca.openshift.io/warn-extramanifest-cm-unknown-crd`.
   - Validate that the desired upgrade version matches the version of the seed image
   - Validate the version of the LCA in the seed image is compatible with the version on the running SNO
+- Pull the seed image
 - Unpack the seed image and create a new ostree stateroot
+
+> [!CAUTION]
+> At this point of `Prep` stage, it is VERY important to let it run to completion.
+> To help avoid unintended consequences of accidental deletion (e.g moving to `Idle` stage while `Prep` in progress), there are blocks in place to allow it to run its normal course before continuing with the deletion request.
+> During this wait (could be up to several minutes), please refer to the pod logs for more information.
+
 - Pull all images specified by the image list built into the seed image. Refer to [precache-plugin](precache-plugin.md)
 
 Upon completion, the condition will be updated to "Prep Completed"

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -232,7 +232,7 @@ func IsJobFinished(job *kbatch.Job) (bool, kbatch.JobConditionType) {
 }
 
 func GenerateDeleteOptions() *client.DeleteOptions {
-	propagationPolicy := metav1.DeletePropagationBackground
+	propagationPolicy := metav1.DeletePropagationForeground // delete only when dependents are deleted
 
 	delOpt := client.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,


### PR DESCRIPTION
This PR aims to handle the case when Stateroot setup job may be in-progress and an unexpected  SIGTERM is received (e.g moving to Idle while Prep in progress).

The solution is broken into to two parts:

k8s: 
- The max wait time before a SIGKILL is sent is determined with TerminationGracePeriodSeconds. This is now set to 60 secs (default 30)
- PreStop lifecycle handler was investigated but not useful in our case. Generally it's used to delay the container from getting SIGTERM and in the meantime k8s does other housekeeping tasks (e.g de-registering Ingress) to avoid any race conditions.

Handler in the code: 
- Every app is expected to have it's own signal handler. In this case if seed image is present we allow the rest of the stateroot setup to go through by sleeping at most time set with TerminationGracePeriodSeconds before shutting down.

/cc @donpenney @jc-rh 