### PR TITLE
Use the new recert additional trust bundle options

### DIFF
--- a/api/seedreconfig/seedreconfig.go
+++ b/api/seedreconfig/seedreconfig.go
@@ -139,6 +139,8 @@ type SeedReconfiguration struct {
 	// In IBU case data will be taken from the upgraded cluster /etc/chrony.conf file.
 	// In IBI case data will be taken from the user provided configuration.
 	ChronyConfig string `json:"chrony_config,omitempty"`
+
+	AdditionalTrustBundle AdditionalTrustBundle `json:"additionalTrustBundle,omitempty"`
 }
 
 type KubeConfigCryptoRetention struct {
@@ -180,4 +182,16 @@ type Proxy struct {
 	// NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be used.
 	// +optional
 	NoProxy string `json:"noProxy,omitempty"`
+}
+
+type AdditionalTrustBundle struct {
+	// The contents of the "user-ca-bundle" configmap in the "openshift-config" namepace
+	UserCaBundle string `json:"userCaBundle"`
+
+	// The Proxy CR trustedCA configmap name
+	ProxyConfigmapName string `json:"proxyConfigmapName"`
+
+	// The contents of the ProxyConfigmapName configmap. Must equal
+	// UserCaBundle if ProxyConfigmapName is "user-ca-bundle"
+	ProxyConfigmapBundle string `json:"proxyConfigmapBundle"`
 }

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -10,7 +10,6 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,15 +33,10 @@ import (
 const (
 	manifestDir = "manifests"
 
-	proxyName = "cluster"
-
 	pullSecretName = "pull-secret"
 
 	idmsFileName  = "image-digest-mirror-set.json"
 	icspsFileName = "image-content-source-policy-list.json"
-
-	caBundleCMName   = "user-ca-bundle"
-	caBundleFileName = caBundleCMName + ".json"
 
 	// ssh authorized keys file created by mco from ssh machine configs
 	sshKeyFile = "/home/core/.ssh/authorized_keys.d/ignition"
@@ -83,9 +77,6 @@ func (r *UpgradeClusterConfigGather) FetchClusterConfig(ctx context.Context, ost
 	}
 
 	if err := r.fetchClusterInfo(ctx, clusterConfigPath); err != nil {
-		return err
-	}
-	if err := r.fetchCABundle(ctx, manifestsDir, clusterConfigPath); err != nil {
 		return err
 	}
 	if err := r.fetchICSPs(ctx, manifestsDir); err != nil {
@@ -162,9 +153,73 @@ func (r *UpgradeClusterConfigGather) GetKubeadminPasswordHash(ctx context.Contex
 	return kubeadminPasswordHash, nil
 }
 
+type AdditionalTrustBundle struct {
+	// The contents of the "user-ca-bundle" configmap in the "openshift-config" namespace
+	UserCaBundle string `json:"userCaBundle"`
+
+	// The Proxy CR trustedCA configmap name
+	ProxyConfigmapName string `json:"proxyConfigmapName"`
+
+	// The contents of the ProxyConfigmapName configmap. Must equal
+	// UserCaBundle if ProxyConfigmapName is "user-ca-bundle"
+	ProxyConfigmapBundle string `json:"proxyConfigmapBundle"`
+}
+
+func newAdditionalTrustBundle(userCaBundle, proxyConfigmapName, proxyConfigmapBundle string) (*AdditionalTrustBundle, error) {
+	if proxyConfigmapName == common.ClusterAdditionalTrustBundleName && userCaBundle != proxyConfigmapBundle {
+		return nil, fmt.Errorf("proxyConfigmapName is %s, but userCaBundle and proxyConfigmapBundle differ", common.ClusterAdditionalTrustBundleName)
+	}
+
+	return &AdditionalTrustBundle{
+		UserCaBundle:         userCaBundle,
+		ProxyConfigmapName:   proxyConfigmapName,
+		ProxyConfigmapBundle: proxyConfigmapBundle,
+	}, nil
+}
+
+func (r *UpgradeClusterConfigGather) GetAdditionalTrustBundle(ctx context.Context) (*AdditionalTrustBundle, error) {
+	clusterAdditionalTrustBundle, err := utils.GetAdditionalTrustBundleFromConfigmap(ctx, r.Client, common.ClusterAdditionalTrustBundleName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get additional trust bundle from configmap: %w", err)
+	}
+
+	proxy := v1.Proxy{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: common.OpenshiftProxyCRName}, &proxy); err != nil {
+		return nil, fmt.Errorf("failed to get proxy: %w", err)
+
+	}
+
+	proxyCaBundle := ""
+	switch proxy.Spec.TrustedCA.Name {
+	case "":
+		// No proxy CA bundle
+	case common.ClusterAdditionalTrustBundleName:
+		// Proxy is using the cluster's CA bundle
+		proxyCaBundle = clusterAdditionalTrustBundle
+	default:
+		// Proxy is using a different CA bundle, retrieve it from the named configmap
+		proxyCaBundle, err = utils.GetAdditionalTrustBundleFromConfigmap(ctx, r.Client, proxy.Spec.TrustedCA.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get additional trust bundle from configmap: %w", err)
+		}
+
+		if proxyCaBundle == "" {
+			// This is a very weird but probably valid OCP configuration that we prefer to not support in LCA
+			return nil, fmt.Errorf("proxy trustedCA configmap %s/%s exists but is empty", common.OpenshiftConfigNamespace, proxy.Spec.TrustedCA.Name)
+		}
+	}
+
+	additionalTrustBundle, err := newAdditionalTrustBundle(clusterAdditionalTrustBundle, proxy.Spec.TrustedCA.Name, proxyCaBundle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create additional trust bundle: %w", err)
+	}
+
+	return additionalTrustBundle, err
+}
+
 func (r *UpgradeClusterConfigGather) GetProxy(ctx context.Context) (*seedreconfig.Proxy, *seedreconfig.Proxy, error) {
 	proxy := v1.Proxy{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: proxyName}, &proxy); err != nil {
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: common.OpenshiftProxyCRName}, &proxy); err != nil {
 		return nil, nil, fmt.Errorf("failed to get proxy: %w", err)
 	}
 
@@ -206,6 +261,7 @@ func SeedReconfigurationFromClusterInfo(
 	statusProxy *seedreconfig.Proxy,
 	installConfig string,
 	chronyConfig string,
+	additionalTrustBundle *AdditionalTrustBundle,
 ) *seedreconfig.SeedReconfiguration {
 	return &seedreconfig.SeedReconfiguration{
 		APIVersion:                seedreconfig.SeedReconfigurationVersion,
@@ -225,6 +281,11 @@ func SeedReconfigurationFromClusterInfo(
 		InstallConfig:             installConfig,
 		MachineNetwork:            clusterInfo.MachineNetwork,
 		ChronyConfig:              chronyConfig,
+		AdditionalTrustBundle: seedreconfig.AdditionalTrustBundle{
+			UserCaBundle:         additionalTrustBundle.UserCaBundle,
+			ProxyConfigmapName:   additionalTrustBundle.ProxyConfigmapName,
+			ProxyConfigmapBundle: additionalTrustBundle.ProxyConfigmapBundle,
+		},
 	}
 }
 
@@ -266,6 +327,11 @@ func (r *UpgradeClusterConfigGather) fetchClusterInfo(ctx context.Context, clust
 		return err
 	}
 
+	additionalTrustBundle, err := r.GetAdditionalTrustBundle(ctx)
+	if err != nil {
+		return err
+	}
+
 	installConfig, err := r.GetInstallConfig(ctx)
 	if err != nil {
 		return err
@@ -285,6 +351,7 @@ func (r *UpgradeClusterConfigGather) fetchClusterInfo(ctx context.Context, clust
 		statusProxy,
 		installConfig,
 		chronyConfig,
+		additionalTrustBundle,
 	)
 
 	filePath := filepath.Join(clusterConfigPath, common.SeedReconfigurationFileName)
@@ -342,14 +409,6 @@ func (r *UpgradeClusterConfigGather) typeMetaForObject(o runtime.Object) (*metav
 		APIVersion: gvk.GroupVersion().String(),
 		Kind:       gvk.Kind,
 	}, nil
-}
-
-func (r *UpgradeClusterConfigGather) cleanObjectMetadata(o client.Object) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:      o.GetName(),
-		Namespace: o.GetNamespace(),
-		Labels:    o.GetLabels(),
-	}
 }
 
 func (r *UpgradeClusterConfigGather) getIDMSs(ctx context.Context) (v1.ImageDigestMirrorSetList, error) {
@@ -422,41 +481,6 @@ func (r *UpgradeClusterConfigGather) fetchICSPs(ctx context.Context, manifestsDi
 	r.Log.Info("Writing ICSPs to file", "path", filePath)
 	if err := utils.MarshalToFile(iscpsList, filePath); err != nil {
 		return fmt.Errorf("failed to write icsps to %s, err: %w", filePath, err)
-	}
-
-	return nil
-}
-
-func (r *UpgradeClusterConfigGather) fetchCABundle(ctx context.Context, manifestsDir, clusterConfigPath string) error {
-	r.Log.Info("Fetching user ca bundle")
-	caBundle := &corev1.ConfigMap{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: caBundleCMName,
-		Namespace: common.OpenshiftConfigNamespace}, caBundle)
-	if err != nil && errors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get ca bundle cm, err: %w", err)
-	}
-
-	typeMeta, err := r.typeMetaForObject(caBundle)
-	if err != nil {
-		return err
-	}
-	caBundle.TypeMeta = *typeMeta
-	caBundle.ObjectMeta = r.cleanObjectMetadata(caBundle)
-
-	if err := utils.MarshalToFile(caBundle, filepath.Join(manifestsDir, caBundleFileName)); err != nil {
-		return fmt.Errorf("failed to write user ca bundle to %s, err: %w",
-			filepath.Join(manifestsDir, caBundleFileName), err)
-	}
-
-	// we should copy ca-bundle from snoa as without doing it we will fail to pull images
-	// workaround for https://issues.redhat.com/browse/OCPBUGS-24035
-	caBundleFilePath := filepath.Join(hostPath, common.CABundleFilePath)
-	r.Log.Info("Copying", "file", caBundleFilePath)
-	if err := utils.CopyFileIfExists(caBundleFilePath, filepath.Join(clusterConfigPath, filepath.Base(caBundleFilePath))); err != nil {
-		return fmt.Errorf("failed to copy ca-bundle file %s to %s, err %w", caBundleFilePath, clusterConfigPath, err)
 	}
 
 	return nil

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -454,7 +454,7 @@ func TestClusterConfig(t *testing.T) {
 					Name: "2",
 				}, Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{{Source: "icspData2"}}}}},
-			caBundleCM: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: caBundleCMName,
+			caBundleCM: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: common.ClusterAdditionalTrustBundleName,
 				Namespace: common.OpenshiftConfigNamespace}, Data: map[string]string{"test": "data"}},
 			expectedErr: false,
 			validateFunc: func(t *testing.T, tempDir string, err error, ucc UpgradeClusterConfigGather) {
@@ -488,17 +488,6 @@ func TestClusterConfig(t *testing.T) {
 					assert.Contains(t, resultSourcesAsString, "icspData")
 					assert.Contains(t, resultSourcesAsString, "icspData2")
 				}
-
-				// validate caBundle
-				caBundle := &corev1.ConfigMap{}
-				if err := utils.ReadYamlOrJSONFile(filepath.Join(manifestsDir, caBundleFileName), caBundle); err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				assert.Equal(t, caBundleCMName, caBundle.Name)
-				assert.Equal(t, caBundle.Data, map[string]string{"test": "data"})
-
-				_, err = os.Stat(filepath.Join(clusterConfigPath, filepath.Base(common.CABundleFilePath)))
-				assert.Nil(t, err)
 			},
 		},
 	}
@@ -508,18 +497,6 @@ func TestClusterConfig(t *testing.T) {
 		t.Run(testCase.testCaseName, func(t *testing.T) {
 			hostPath = clusterConfigDir
 
-			if testCase.caBundleCM != nil {
-				dir := filepath.Join(clusterConfigDir, filepath.Dir(common.CABundleFilePath))
-				if err := os.MkdirAll(dir, 0o700); err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				newPath := filepath.Join(dir, filepath.Base(common.CABundleFilePath))
-				f, err := os.Create(newPath)
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				_ = f.Close()
-			}
 			if testCase.chronyConfig != "" {
 				dir := filepath.Join(clusterConfigDir, filepath.Dir(common.ChronyConfig))
 				if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -63,7 +63,7 @@ const (
 	EtcdContainerName                 = "recert_etcd"
 	LvmConfigDir                      = "lvm-configuration"
 	LvmDevicesPath                    = "/etc/lvm/devices/system.devices"
-	CABundleFilePath                  = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+	CABundleFilePath                  = "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"
 
 	LCAConfigDir                                    = "/var/lib/lca"
 	IBUAutoRollbackConfigFile                       = LCAConfigDir + "/autorollback_config.json"
@@ -111,6 +111,9 @@ const (
 
 	NMConnectionFolder = "/etc/NetworkManager/system-connections"
 	NetworkDir         = "network-configuration"
+
+	CaBundleDataKey                  = "ca-bundle.crt"
+	ClusterAdditionalTrustBundleName = "user-ca-bundle"
 )
 
 // Annotation names and values related to extra manifest

--- a/lca-cli/ops/ops.go
+++ b/lca-cli/ops/ops.go
@@ -251,6 +251,7 @@ func (o *ops) RunRecert(recertContainerImage, authFile, recertConfigFile string,
 		"-v", "/var/lib/kubelet:/kubelet",
 		"-v", "/var/tmp:/var/tmp",
 		"-v", "/etc/machine-config-daemon:/machine-config-daemon",
+		"-v", "/etc/pki:/pki",
 		"-e", fmt.Sprintf("RECERT_CONFIG=%s", recertConfigFile),
 	)
 	if authFile != "" {

--- a/lca-cli/seedclusterinfo/seedclusterinfo.go
+++ b/lca-cli/seedclusterinfo/seedclusterinfo.go
@@ -82,9 +82,25 @@ type SeedClusterInfo struct {
 	// from seeds that don't have one. Similarly, installing a cluster without
 	// FIPS from a seed with FIPS is also not supported.
 	HasFIPS bool `json:"has_fips"`
+
+	AdditionalTrustBundle *AdditionalTrustBundle `json:"additionalTrustBundle"`
 }
 
-func NewFromClusterInfo(clusterInfo *utils.ClusterInfo, seedImagePullSpec string, hasProxy, hasFIPS bool) *SeedClusterInfo {
+type AdditionalTrustBundle struct {
+	// Whether the "user-ca-bundle" configmap in the "openshift-config"
+	// namespace has a value or not
+	HasUserCaBundle bool `json:"hasUserCaBundle"`
+
+	// The Proxy CR trustedCA configmap name
+	ProxyConfigmapName string `json:"proxyConfigmapName"`
+}
+
+func NewFromClusterInfo(clusterInfo *utils.ClusterInfo,
+	seedImagePullSpec string,
+	hasProxy,
+	hasFIPS bool,
+	additionalTrustBundle *AdditionalTrustBundle,
+) *SeedClusterInfo {
 	return &SeedClusterInfo{
 		SeedClusterOCPVersion:    clusterInfo.OCPVersion,
 		BaseDomain:               clusterInfo.BaseDomain,
@@ -96,6 +112,7 @@ func NewFromClusterInfo(clusterInfo *utils.ClusterInfo, seedImagePullSpec string
 		RecertImagePullSpec:      seedImagePullSpec,
 		HasProxy:                 hasProxy,
 		HasFIPS:                  hasFIPS,
+		AdditionalTrustBundle:    additionalTrustBundle,
 	}
 }
 

--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	runtime "sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
@@ -193,6 +194,20 @@ func (s *SeedCreator) handleServices() error {
 	})
 }
 
+func GetSeedAdditionalTrustBundleState(ctx context.Context, client runtimeclient.Client) (*seedclusterinfo.AdditionalTrustBundle, error) {
+	hasUserCaBundle, proxyConfigmapName, err := utils.GetClusterAdditionalTrustBundleState(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster additional trust bundle state: %w", err)
+	}
+
+	result := seedclusterinfo.AdditionalTrustBundle{
+		HasUserCaBundle:    hasUserCaBundle,
+		ProxyConfigmapName: proxyConfigmapName,
+	}
+
+	return &result, nil
+}
+
 func (s *SeedCreator) gatherClusterInfo(ctx context.Context) error {
 	s.log.Info("Saving seed cluster configuration")
 	clusterInfo, err := utils.GetClusterInfo(ctx, s.client)
@@ -207,10 +222,21 @@ func (s *SeedCreator) gatherClusterInfo(ctx context.Context) error {
 
 	hasFIPS, err := utils.HasFIPS(ctx, s.client)
 	if err != nil {
-		return fmt.Errorf("failed to get proxy information: %w", err)
+		return fmt.Errorf("failed to get FIPS information: %w", err)
 	}
 
-	seedClusterInfo := seedclusterinfo.NewFromClusterInfo(clusterInfo, s.recertContainerImage, hasProxy, hasFIPS)
+	seedAdditionalTrustBundle, err := GetSeedAdditionalTrustBundleState(ctx, s.client)
+	if err != nil {
+		return fmt.Errorf("failed to get additional trust bundle information: %w", err)
+	}
+
+	seedClusterInfo := seedclusterinfo.NewFromClusterInfo(
+		clusterInfo,
+		s.recertContainerImage,
+		hasProxy,
+		hasFIPS,
+		seedAdditionalTrustBundle,
+	)
 
 	if err := os.MkdirAll(common.SeedDataDir, os.ModePerm); err != nil {
 		return fmt.Errorf("error creating SeedDataDir %s: %w", common.SeedDataDir, err)


### PR DESCRIPTION
# Background / Context

Recert recently added ([1], [2]) some options that allow changing the
cluster's trust bundle (it's recommended you read the PRs for more
background about this).

# Issue / Requirement / Reason for change

The lifecycle-agent doesn't make use of the new options added to recert

# Solution / Feature Overview

Change the lifecycle-agent to use the new options added to recert

# Implementation Details

Multiple new fields have been added.

- `AdditionalTrustBundle` in `SeedReconfiguration`. This represents the
  trust bundle to be used for seed-reconfiguration. This contains the
  user-ca-bundle contents, the proxy configmap name, and the proxy configmap
  contents.

- `AdditionalTrustBundle` in `SeedClusterInfo`. This represents the
  state of the trust bundle in the seed cluster. This is simply booleans
  indicating the presence or lack there-of of the user-ca-bundle and the
  proxy configmap name (only if it actually has contents, a configmap
  with no contents is considered invalid OCP configuration). This is
  useful for when we want to verify that the seed is compatible with
  our desired `SeedReconfiguration`.

- `RecertConfig` will now use the new `CryptoDirs` and `CryptoFiles` fields
  to specify the directories and files that should be considered part of
  the cluster's crypto material. Along with the `ClusterCustomizationDirs` and
  `ClusterCustomizationFiles` fields that specify the directories and files
  involved in cluster customization. Since these no longer overlap when
  it comes to customizing the trust bundle, we must use these new fields
  instead of the old common `StaticDirs` and `StaticFiles` fields.

[1] https://github.com/rh-ecosystem-edge/recert/pull/110
[2] https://github.com/rh-ecosystem-edge/recert/pull/140