### PR TITLE
OCPBUGS-33536: [IBI] install-rhcos-and-restore-seed.service fails the first time it starts

### DIFF
--- a/ib-cli/installationiso/data/ibi-butane.template
+++ b/ib-cli/installationiso/data/ibi-butane.template
@@ -35,6 +35,8 @@ systemd:
       enabled: true
       contents: |
         [Unit]
+        Wants=network-online.target
+        After=network-online.target
         Description=SNO Image Based Installation
         [Service]
         Environment=SEED_IMAGE={{.SeedImage}}

--- a/ib-cli/installationiso/data/install-rhcos-and-restore-seed.sh
+++ b/ib-cli/installationiso/data/install-rhcos-and-restore-seed.sh
@@ -6,8 +6,10 @@ seed_image=${1:-$SEED_IMAGE}
 authfile=${AUTH_FILE:-"/var/tmp/backup-secret.json"}
 ibi_config=${IBI_CONFIGURATION_FILE:-"/var/tmp/ibi-configuration.json"}
 
-# Copy the lca-cli binary to the host
-podman create --authfile "${authfile}" --name lca-cli "${seed_image}" lca-cli
+# Copy the lca-cli binary to the host, pulling it seed image can sometimes fail
+until podman create --authfile "${authfile}" --name lca-cli "${seed_image}" lca-cli ; do
+    sleep 10
+done
 podman cp lca-cli:lca-cli /usr/local/bin/lca-cli
 podman rm lca-cli
 


### PR DESCRIPTION
OCPBUGS-33536: [IBI] install-rhcos-and-restore-seed.service fails the first time it starts
We are taking lca-cli from seed image and sometimes it can fail. Adding dependency for this service on network-online and adding retry to image pull part