### PR TITLE
OCPBUGS-33535: export associated storage classes when exporting localvolumes

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -529,6 +529,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - velero.io
           resources:
           - backups

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -330,6 +330,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - velero.io
   resources:
   - backups


### PR DESCRIPTION
The storage classes that are being used in the localvolumes should be exported and restored along with localvolumes during post-pivot as well.