### PR TITLE
CNF-12712: Add badges and code-coverage targets

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,50 @@
+# (mandatory)
+# Path to coverprofile file (output of `go test -coverprofile` command).
+#
+# For cases where there are many coverage profiles, such as when running
+# unit tests and integration tests separately, you can combine all those
+# profiles into one. In this case, the profile should have a comma-separated list
+# of profile files, e.g., 'cover_unit.out,cover_integration.out'.
+profile: cover.out
+
+# (optional; but recommended to set)
+# When specified reported file paths will not contain local prefix in the output
+local-prefix: "github.com/openshift-kni/lifecycle-agent"
+
+# Holds coverage thresholds percentages, values should be in range [0-100]
+threshold:
+  # (optional; default 0)
+  # The minimum coverage that each file should have
+  file: 0
+
+  # (optional; default 0)
+  # The minimum coverage that each package should have
+  package: 0
+
+  # (optional; default 0)
+  # The minimum total coverage project should have
+  total: 30
+
+# Holds regexp rules which will override thresholds for matched files or packages
+# using their paths.
+#
+# First rule from this list that matches file or package is going to apply
+# new threshold to it. If project has multiple rules that match same path,
+# override rules should be listed in order from specific to more general rules.
+override:
+  # Increase coverage threshold to 100% for `foo` package
+  # (default is 80, as configured above in this example)
+  - threshold: 100
+    path: ^pkg/lib/foo$
+
+# Holds regexp rules which will exclude matched files or packages
+# from coverage statistics
+exclude:
+  # Exclude files or packages matching their paths
+  paths:
+    - \.pb\.go$    # excludes all protobuf generated files
+    - ^pkg/bar     # exclude package `pkg/bar`
+
+# NOTES:
+# - symbol `/` in all path regexps will be replaced by current OS file path separator
+#   to properly work on Windows

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ VERSION ?= 4.17.0
 # You can use podman or docker as a container engine. Notice that there are some options that might be only valid for one of them.
 ENGINE ?= docker
 
+# Path to go binary in local
+GOBIN ?= $$(go env GOPATH)/bin
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -124,6 +127,15 @@ else
 	@echo "Running scorecard"
 	$(OPERATOR_SDK) scorecard bundle
 endif
+
+.PHONY: install-go-test-coverage
+install-go-test-coverage:
+	go install github.com/vladopajic/go-test-coverage/v2@latest
+
+.PHONY: check-coverage
+check-coverage: install-go-test-coverage
+	go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
+	${GOBIN}/go-test-coverage --config=./.testcoverage.yml
 
 .PHONY: ci-job
 ci-job: common-deps-update generate fmt vet golangci-lint unittest shellcheck bashate bundle-check

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Lifecycle Agent Operator
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/openshift-kni/lifecycle-agent)](https://goreportcard.com/report/github.com/openshift-kni/lifecycle-agent)
+[![Go Reference](https://pkg.go.dev/badge/github.com/openshift-kni/lifecycle-agent.svg)](https://pkg.go.dev/github.com/openshift-kni/lifecycle-agent)
+[![License Apache](https://img.shields.io/github/license/openshift-kni/lifecycle-agent)](https://opensource.org/licenses/Apache-2.0)
+
 ## What it is
 
 The Lifecycle Agent Operator provides local (on cluster) lifecycle management services for Single

--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -872,7 +872,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 				if _, err := os.Stat(filepath.Join(ibuTempDirOrig, utils.IBUFilePath)); !errors.Is(err, os.ErrNotExist) {
 					dat, _ := os.ReadFile(filepath.Join(ibuTempDirOrig, utils.IBUFilePath))
 					savedIbu := ibuv1.ImageBasedUpgrade{}
-					err = yaml.Unmarshal(dat, &savedIbu)
+					_ = yaml.Unmarshal(dat, &savedIbu)
 					assert.Equalf(t, len(savedIbu.Status.Conditions), 2, "")
 					assert.Equalf(t, savedIbu.Status.Conditions[0].Message, utils.UpgradeFailed, "")
 					assert.Equalf(t, savedIbu.Status.Conditions[1].Message, "Uncontrolled rollback", "")

--- a/internal/backuprestore/restore_test.go
+++ b/internal/backuprestore/restore_test.go
@@ -366,7 +366,7 @@ func TestEnsureOadpConfigurations(t *testing.T) {
 	}
 
 	errorChan := make(chan error)
-	// Verify DPA is reconciled and storage backends are availiable
+	// Verify DPA is reconciled and storage backends are available
 	go func() {
 		// Override the default host path
 		hostPath = fromDir

--- a/internal/extramanifest/extramanifest_test.go
+++ b/internal/extramanifest/extramanifest_test.go
@@ -237,7 +237,7 @@ func TestValidateExtraManifestConfigmaps(t *testing.T) {
 			expectedErr: fmt.Errorf("failed to decode yaml in the configMap"),
 		},
 		{
-			name: "extra manifest containts MachineConfig",
+			name: "extra manifest contains MachineConfig",
 			configmaps: []ibuv1.ConfigMapRef{
 				{Name: "extra-manifest-cm-mc", Namespace: "default"},
 			},

--- a/internal/extramanifest/policy_test.go
+++ b/internal/extramanifest/policy_test.go
@@ -56,10 +56,10 @@ func TestGetParentPolicyNameAndNamespace(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(res), 2)
 
-	res, err = getParentPolicyNameAndNamespace("upgrade")
+	_, err = getParentPolicyNameAndNamespace("upgrade")
 	assert.Error(t, err)
 
-	res, err = getParentPolicyNameAndNamespace("default.upgrade.cluster")
+	res, _ = getParentPolicyNameAndNamespace("default.upgrade.cluster")
 	assert.Equal(t, res[0], "default")
 	assert.Equal(t, res[1], "upgrade.cluster")
 }

--- a/pkg/dependencymagnet/doc.go
+++ b/pkg/dependencymagnet/doc.go
@@ -7,5 +7,5 @@
 package dependencymagnet
 
 import (
-	_ "k8s.io/code-generator"                       // used for generating clientset code
+	_ "k8s.io/code-generator" // used for generating clientset code
 )


### PR DESCRIPTION
This PR proposes the following:

- Updates README.md with some badges. 
- Fixes some misspell, ineffassign and gofmt recommendations provided by the goreportcard.
- Adds code-coverage target to Makefile and a config file, these could be used (e.g., in the ci-job or in local by devs) at any moment.

/cc @donpenney 