### PR TITLE
MGMT-17828: LCA should allow reconfiguration if hostname wasn't provided

### DIFF
--- a/lca-cli/ops/mock_ops.go
+++ b/lca-cli/ops/mock_ops.go
@@ -94,6 +94,21 @@ func (mr *MockOpsMockRecorder) ForceExpireSeedCrypto(recertContainerImage, authF
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceExpireSeedCrypto", reflect.TypeOf((*MockOps)(nil).ForceExpireSeedCrypto), recertContainerImage, authFile, hasKubeAdminPassword)
 }
 
+// GetHostname mocks base method.
+func (m *MockOps) GetHostname() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHostname")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHostname indicates an expected call of GetHostname.
+func (mr *MockOpsMockRecorder) GetHostname() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockOps)(nil).GetHostname))
+}
+
 // ImageExists mocks base method.
 func (m *MockOps) ImageExists(img string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/lca-cli/ops/ops.go
+++ b/lca-cli/ops/ops.go
@@ -52,6 +52,7 @@ type Ops interface {
 	Chroot(chrootPath string) (func() error, error)
 	CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionNumber uint) error
 	SetupContainersFolderCommands() error
+	GetHostname() (string, error)
 }
 
 type CMD struct {
@@ -523,4 +524,12 @@ func (o *ops) growRootPartitionCommands(installationDisk string) []*CMD {
 		NewCMD("xfs_growfs", "/dev/disk/by-partlabel/root"))
 
 	return cmds
+}
+
+func (o *ops) GetHostname() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("failed to get hostname: %w", err)
+	}
+	return hostname, nil
 }


### PR DESCRIPTION
1. We should block localhost as hostname
2. In case hostname was not provided as part of seed reconfiguration we should use current node hostname
3. Hostname should be set with hostnamectl command rather than with /etc/hostname file in order to be changed immediately
