### PR TITLE
OCPBUGS-33786 - Fix SELinux issues in IBI when running outside of a container

### DIFF
--- a/ib-cli/installationiso/data/ibi-butane.template
+++ b/ib-cli/installationiso/data/ibi-butane.template
@@ -43,6 +43,7 @@ systemd:
         Environment=IBI_CONFIGURATION_FILE={{.IBIConfigurationPath}}
         Type=oneshot
         RemainAfterExit=yes
+        ExecStartPre=/usr/bin/chcon -t install_exec_t /usr/local/bin/install-rhcos-and-restore-seed.sh
         ExecStart=/usr/local/bin/install-rhcos-and-restore-seed.sh
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
# Background / Context

https://github.com/openshift-kni/lifecycle-agent/commit/e20c260d00eb2c9b03a6b174151615b884c5c85f broke the ability to set unexisting selinux contexts to files introduced by https://github.com/openshift-kni/lifecycle-agent/commit/f26ae70d96640cf7b974b5d5ad23ee2db967d228

# Solution / Feature Overview

Just change the script to `install_exec_t` context before running it

/cc @tsorya 
/cc @donpenney 