### PR TITLE
OCPBUGS-33275: extramanifest configmaps validation update

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -227,6 +227,7 @@ spec:
           resources:
           - namespaces
           verbs:
+          - create
           - delete
           - get
           - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,7 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
   - delete
   - get
   - list

--- a/controllers/idle_handlers.go
+++ b/controllers/idle_handlers.go
@@ -163,7 +163,7 @@ func (r *ImageBasedUpgradeReconciler) cleanup(ctx context.Context, ibu *ibuv1.Im
 	}
 
 	r.Log.Info("Removing annotation with warning")
-	if err := extramanifest.RemoveAnnotationWarnUnknownCRD(r.Client, ibu, r.Log); err != nil {
+	if err := extramanifest.RemoveAnnotationEMWarningValidation(r.Client, r.Log, ibu); err != nil {
 		handleError(err, "failed to remove extra manifest warning annotation from IBU")
 	}
 

--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -1099,7 +1099,7 @@ func TestImageBasedUpgradeReconciler_postPivot(t *testing.T) {
 				mockExtramanifest.EXPECT().ApplyExtraManifests(gomock.Any(), common.PathOutsideChroot(extramanifest.PolicyManifestPath)).Return(tt.applyPolicyManifestsReturn()).Times(1)
 			}
 			if tt.applyExtraManifestsReturn != nil {
-				mockExtramanifest.EXPECT().ApplyExtraManifests(gomock.Any(), common.PathOutsideChroot(extramanifest.ExtraManifestPath)).Return(tt.applyExtraManifestsReturn()).Times(1)
+				mockExtramanifest.EXPECT().ApplyExtraManifests(gomock.Any(), common.PathOutsideChroot(extramanifest.CmManifestPath)).Return(tt.applyExtraManifestsReturn()).Times(1)
 			}
 			if tt.ensureOadpConfigurationReturn != nil {
 				mockBackuprestore.EXPECT().EnsureOadpConfiguration(gomock.Any()).Return(tt.ensureOadpConfigurationReturn()).Times(1)

--- a/docs/image-based-upgrade.md
+++ b/docs/image-based-upgrade.md
@@ -293,15 +293,17 @@ The "Prep" stage will:
 1. Perform various validation steps on IBU CR. This includes (but not limited to) the following:
    - If the oadpContent is populated, validate that the specified configmap has been applied and is valid
    - If the extraManifests is populated, validate that the specified configmap has been applied and is valid
-     - If a required CRD is missing from the current cluster, a warning message will be included in the IBU CR with annotation along with useful info as value.
+     - Validation errors from Dry-run such as Invalid and webhook BadRequest types are treated as warnings. This also includes cases where CRDs are missing from the current stateroot and dependent namespace does not exist on the current stateroot but is also not found in the configmaps.
+    LCA doesn't block the upgrade due to validation warnings. Instead, it updates the Prep status condition with a warning message and annotates IBU with the annotation `extra-manifest.lca.openshift.io/validation-warning`, providing detailed information about the failures
 
        ```yaml
        metadata:
         annotations:
-          lca.openshift.io/warn-extramanifest-cm-unknown-crd: '...'
+          extra-manifest.lca.openshift.io/validation-warning: '...'
        ```
 
        > 📝 Warnings are not enforced, and it is up to the user to decide if it's safe to proceed with  `Upgrade` stage.
+     - Other validation errors, such as random chars, missing resource Kind, resource ApiVersion, resource name or the presence of disallowed resource types (such as MachineConfig and operator manifests), will cause the Prep stage to fail and block the upgrade
    - Validate the version of the LCA in the seed image is compatible with the version on the running SNO
 2. Setup new stateroot
    - Pull the seed image

--- a/internal/extramanifest/mocks/mock_extramanifest.go
+++ b/internal/extramanifest/mocks/mock_extramanifest.go
@@ -100,15 +100,16 @@ func (mr *MockEManifestHandlerMockRecorder) ValidateAndExtractManifestFromPolici
 }
 
 // ValidateExtraManifestConfigmaps mocks base method.
-func (m *MockEManifestHandler) ValidateExtraManifestConfigmaps(ctx context.Context, extraManifestCMs []v1.ConfigMapRef, ibu *v1.ImageBasedUpgrade) error {
+func (m *MockEManifestHandler) ValidateExtraManifestConfigmaps(ctx context.Context, extraManifestCMs []v1.ConfigMapRef) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateExtraManifestConfigmaps", ctx, extraManifestCMs, ibu)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ValidateExtraManifestConfigmaps", ctx, extraManifestCMs)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ValidateExtraManifestConfigmaps indicates an expected call of ValidateExtraManifestConfigmaps.
-func (mr *MockEManifestHandlerMockRecorder) ValidateExtraManifestConfigmaps(ctx, extraManifestCMs, ibu any) *gomock.Call {
+func (mr *MockEManifestHandlerMockRecorder) ValidateExtraManifestConfigmaps(ctx, extraManifestCMs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateExtraManifestConfigmaps", reflect.TypeOf((*MockEManifestHandler)(nil).ValidateExtraManifestConfigmaps), ctx, extraManifestCMs, ibu)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateExtraManifestConfigmaps", reflect.TypeOf((*MockEManifestHandler)(nil).ValidateExtraManifestConfigmaps), ctx, extraManifestCMs)
 }


### PR DESCRIPTION
# Background / Context
LCA performs Kubernetes Dry-run to validate the manifests included in the extraManifests configmaps. Any invalid/webhook badRequest type of error returned from dry-run fails the Prep stage and blocks the upgrade.

# Issue / Requirement / Reason for change
Kubernetes Dry-run sends requests to API server, where the server processes the request as if it were real, but without acutally making any modifications to the actual resources. As all API requests are single-resource requests, dryrun doesn't work for resources that depends on eariler resources that are not persisted in the cluster. For example, in a multi-object manifest that includes namespace A and resource A created within the namespace A. Running a dry-run on resource returns the namespace not found error.

The extra manifests are configurations intented to be applied to the new cluster version. Runing dry-run on the old version aims to thoroughly check for possible manifest error before upgrading. However, in cases where extramanifests configmaps contain the dependent resources, the Dry-run failure results in failed Prep, but the failure may be not the case for the new cluster version.

# Solution / Feature Overview
Not only in the case of dependent resources, but there may also be other dry-run errors that occur only on the old cluster version.  The dry-run validation should be a soft validation. The errors such as invalid or webhook badRequest type of error from dry-run are considered warnings. This also includes cases where CRDs are missing from the old version and dependent namespace does not exist on the old version but is also not found in the configmaps. The warnings do not block upgrade. Instead, the Prep status condition could be updated with a warning message and the failure details can be provided in an IBU annotation. The other type of errors such as random chars, missing resource Kind, resource ApiVersion, resource name or the presence of disallowed resource types, are treated as critical errors which will fail the Prep.

<!---
Use this section to give a general overview of the solution you're proposing.
Explain how it helps to solve the issue you described above. No need to go into
code specifics.
-->

# Implementation Details

<!---
If your change is complicated, use this section to describe the implementation
details of your PR. This is mostly good for huge PRs where it's easy to get
lost in a lot of diff, or when the changes are complicated. Not everything
needs to be described, just the main points.
-->

# Other Information
- If user uses the ZTP/TALM to run IBU with extra manifests configmaps, the prep stage policy should include `message` check with "Prep stage completed successfully" which would prevent CGU to complete if there's validation warning

- Log error in the upgrade handler for the error that causes the upgrade to fail.


/cc @donpenney @pixelsoccupied @leo8a 