### PR TITLE
OCPBUGS-34010: In case proxy status was set there is no reason to update proxy in post pivot phase (IBU flow)

### DIFF
--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -242,9 +242,11 @@ func (p *PostPivot) setProxyAndProxyStatus(seedReconfig *clusterconfig_api.SeedR
 		return fmt.Errorf("seedReconfig and seedClusterInfo proxy configuration mismatch")
 	}
 
-	if seedReconfig.Proxy == nil {
+	// In case of no proxy, we don't need to set it
+	// In case of status was set it means that we already have all relevant info as in IBU case
+	// and we should not change anything
+	if seedReconfig.Proxy == nil || seedReconfig.StatusProxy != nil {
 		return nil
-
 	}
 
 	set := sets.NewString(


### PR DESCRIPTION
OCPBUGS-34010: In case proxy status was set there is no reason to update proxy in post pivot phase (IBU flow)


# Background / Context
In IBU flow we take proxy and proxy status from upgraded cluster and there is no need to update those values in post-pivot
<!---
Not all reviewers know everything there is to know about the project, use this
section to give a bit of background knowledge about the part of the project
you're changing. Things like links to previous relevant commits, existing
system behavior, how things currently work. Don't describe your changes or what
issue you're solving, just things that are already established. Even if these
seem obvious and the reviewer likely already knows them, it still helps
establish the context of the change.
-->

# Issue / Requirement / Reason for change
failure in proxy installation
