### PR TITLE
OCPBUGS-34520: add additional checks to validate if oadp is installed

### DIFF
--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	"github.com/openshift-kni/lifecycle-agent/utils"
 
@@ -439,7 +441,7 @@ func (h *BRHandler) CleanupBackups(ctx context.Context) error {
 		clusterIDLabel: clusterID,
 	}); err != nil {
 		var groupDiscoveryErr *discovery.ErrGroupDiscoveryFailed
-		if errors.As(err, &groupDiscoveryErr) {
+		if errors.As(err, &groupDiscoveryErr) || meta.IsNoMatchError(err) {
 			h.Log.Info("Backup CR is not installed, nothing to cleanup")
 			return nil
 		}
@@ -601,7 +603,7 @@ func (h *BRHandler) CleanupDeleteBackupRequests(ctx context.Context) error {
 		clusterIDLabel: clusterID,
 	}); err != nil {
 		var groupDiscoveryErr *discovery.ErrGroupDiscoveryFailed
-		if errors.As(err, &groupDiscoveryErr) {
+		if errors.As(err, &groupDiscoveryErr) || meta.IsNoMatchError(err) {
 			h.Log.Info("DeleteBackupRequest CR is not installed, nothing to cleanup")
 			return nil
 		}

--- a/internal/backuprestore/mocks/mock_backuprestore.go
+++ b/internal/backuprestore/mocks/mock_backuprestore.go
@@ -156,6 +156,20 @@ func (mr *MockBackuperRestorerMockRecorder) GetSortedBackupsFromConfigmap(ctx, c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSortedBackupsFromConfigmap", reflect.TypeOf((*MockBackuperRestorer)(nil).GetSortedBackupsFromConfigmap), ctx, content)
 }
 
+// IsOadpInstalled mocks base method.
+func (m *MockBackuperRestorer) IsOadpInstalled(ctx context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOadpInstalled", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOadpInstalled indicates an expected call of IsOadpInstalled.
+func (mr *MockBackuperRestorerMockRecorder) IsOadpInstalled(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOadpInstalled", reflect.TypeOf((*MockBackuperRestorer)(nil).IsOadpInstalled), ctx)
+}
+
 // LoadRestoresFromOadpRestorePath mocks base method.
 func (m *MockBackuperRestorer) LoadRestoresFromOadpRestorePath() ([][]*v10.Restore, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Background / Context

LCA may incorrectly try to delete OADP resources if configured with proxy even though no OADP is not present/installed 

e.g error
```
2024-05-23T21:04:01Z	ERROR	controllers.ImageBasedUpgrade.Idle	failed to cleanup backups	{"error": "failed to list Backup: failed to get API group resources: unable to retrieve the complete list of server APIs: velero.io/v1: the server could not find the requested resource"}
```

# Solution / Feature Overview

- before a cleanup LCA makes sure OADP is installed by checking for presence of OADP's CRDs
- improved checks when listing OADP resources
