### PR TITLE
OCPBUGS-32493: make all client calls retriable with middleware

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/client-go/util/retry"
+
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/samber/lo"
@@ -46,7 +48,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/controllers/seedgen_controller.go
+++ b/controllers/seedgen_controller.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/client-go/util/retry"
+
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	"github.com/openshift-kni/lifecycle-agent/internal/healthcheck"
@@ -43,7 +45,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"io"
 	"os"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/go-logr/logr"
+	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 	cp "github.com/otiai10/copy"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,8 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 )
 
 // TODO: Need a better way to change this but will require relatively big refactoring
@@ -129,12 +129,6 @@ func GetStaterootOptOpenshift(staterootPath string) string {
 	return filepath.Join(staterootPath, "var", OptOpenshift)
 }
 
-// FuncTimer check execution time
-func FuncTimer(start time.Time, name string, r logr.Logger) {
-	elapsed := time.Since(start)
-	r.Info(fmt.Sprintf("%s took %s", name, elapsed))
-}
-
 func IsConflictOrRetriable(err error) bool {
 	return apierrors.IsConflict(err) || apierrors.IsInternalError(err) || apierrors.IsServiceUnavailable(err) || net.IsConnectionRefused(err)
 }
@@ -216,7 +210,7 @@ func LogPodLogs(job *kbatch.Job, log logr.Logger, clientset *kubernetes.Clientse
 		}
 		if buf.Len() > 0 {
 			log.Info(fmt.Sprintf("------ start pod `%s` log  -----", pods.Items[0].Name), "job name", job.Name)
-			log.Info(buf.String())
+			log.Info(fmt.Sprintf("\n%s", buf.String()))
 			log.Info(fmt.Sprintf("------ end pod `%s` log  -----", pods.Items[0].Name), "job name", job.Name)
 		} else {
 			log.Info("No new pod logs available", "job name", job.Name, "pod name", pods.Items[0].Name)

--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -14,6 +14,9 @@ import (
 
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
+
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
 	clusterconfig_api "github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
 	"github.com/openshift-kni/lifecycle-agent/internal/backuprestore"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
@@ -144,7 +147,11 @@ func (p *PostPivot) PostPivotConfiguration(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create k8s client, err: %w", err)
 	}
-	dynamicClient, err := utils.CreateDynamicClient(p.kubeconfig, false, nil)
+
+	// init new logger for CreateDynamicClient (others are using logrus)
+	opts := zap.Options{Development: true}
+	l := zap.New(zap.UseFlagOptions(&opts))
+	dynamicClient, err := utils.CreateDynamicClient(p.kubeconfig, false, l.WithName("post-pivot-dynamic-client"))
 	if err != nil {
 		return fmt.Errorf("failed to create k8s dynamic client, err: %w", err)
 	}

--- a/utils/client_middleware.go
+++ b/utils/client_middleware.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+// RetryMiddleware pass this into your client config (with .Wrap()) to make it retriable
+func RetryMiddleware(logger logr.Logger) func(rt http.RoundTripper) http.RoundTripper {
+	logger.Info("Setting up retry middleware")
+	return func(rt http.RoundTripper) http.RoundTripper {
+		return &retryRoundTripper{
+			transport: rt,
+			backoff:   getBackoff(),
+			log:       logger.WithName("retry-middleware"),
+		}
+	}
+}
+
+// retryRoundTripper include anything here that's useful during middleware processing
+type retryRoundTripper struct {
+	transport http.RoundTripper
+	backoff   wait.Backoff
+	log       logr.Logger
+}
+
+// getBackoff configured for API outages where we require additional time to recover before being served.
+// this exponential with max wait time about ~3mins
+func getBackoff() wait.Backoff {
+	return wait.Backoff{
+		Steps:    45,
+		Duration: 10 * time.Millisecond,
+		Factor:   1.2,
+		Jitter:   0.1,
+	}
+}
+
+// isRetriable validates if an error is worth retrying
+func isRetriable(err error) bool {
+	return apierrors.IsInternalError(err) || apierrors.IsServiceUnavailable(err) || net.IsConnectionRefused(err)
+}
+
+// RoundTrip implements RoundTripper to do retries.
+// This helpful especially when running in SNO,
+// where API server maybe down and retries are needed to eventually be successful,
+// This allows all our client calls to have this "retry" feature without explicitly wrapping them
+func (r *retryRoundTripper) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	if errRetryOnError := retry.OnError(r.backoff, isRetriable, func() error {
+		resp, err = r.transport.RoundTrip(req)
+		if err != nil && isRetriable(err) {
+			r.log.Info("WARNING: retrying", "req.method", req.Method, "req.url", req.URL.String(), "error", err)
+		}
+		return err //nolint:wrapcheck
+	}); errRetryOnError != nil {
+		r.log.Info("WARNING: retrying failed", "error", errRetryOnError)
+	}
+
+	return resp, err //nolint:wrapcheck
+}


### PR DESCRIPTION
# Background / Context

This builds on https://github.com/openshift-kni/lifecycle-agent/pull/541.  We now have middleware that will do the retries, making all the client call implicitly retriable.

As long as clients are configured to include it during initialization...the middleware will intercept all calls and retry exponentially for max 3 mins if any of the error conditions are met.

/cc @donpenney 