### PR TITLE
MGMT-17989: Support static network configuration in installation iso

### DIFF
--- a/api/ibiconfig/ibiconfig.go
+++ b/api/ibiconfig/ibiconfig.go
@@ -22,6 +22,7 @@ type IBIPrepareConfig struct {
 	AdditionalTrustBundlePath string             `json:"additionalTrustBundle,omitempty"`
 	Proxy                     seedreconfig.Proxy `json:"proxy,omitempty"`
 	MirrorRegistryPath        string             `json:"mirrorRegistry,omitempty"`
+	NMStateConfig             string             `json:"NMStateConfig,omitempty"`
 
 	// configuration for lca cli
 	SeedImage            string `json:"seedImage"`

--- a/ib-cli/cmd/createiso.go
+++ b/ib-cli/cmd/createiso.go
@@ -50,6 +50,7 @@ var (
 	noProxy               string
 	additionalTrustBundle string
 	mirrorRegistry        string
+	nmstateConfig         string
 )
 
 func addFlags(cmd *cobra.Command) {
@@ -74,6 +75,7 @@ func addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&noProxy, "no-proxy", "", "", "No proxy to be configured.")
 	cmd.Flags().StringVarP(&additionalTrustBundle, "additional-trust-bundle", "", "", "The path to the additional trust bundle.")
 	cmd.Flags().StringVarP(&mirrorRegistry, "mirror-registry", "", "", "The path to mirror registry config file.")
+	cmd.Flags().StringVarP(&nmstateConfig, "nmstate-config", "", "", "The path to nmstate config file.")
 
 	cmd.MarkFlagRequired("installation-disk")
 	cmd.MarkFlagRequired("extra-partition-start")
@@ -136,6 +138,7 @@ func createIso() error {
 			NoProxy:    noProxy,
 		},
 		MirrorRegistryPath: mirrorRegistry,
+		NMStateConfig:      nmstateConfig,
 	}
 
 	if err := ibiConfig.Validate(); err != nil {

--- a/ib-cli/installationiso/data/ibi-butane.template
+++ b/ib-cli/installationiso/data/ibi-butane.template
@@ -40,7 +40,13 @@ storage:
       user:
         name: root
       contents:
-        local: {{.AdditionalTrustBundlePath}}{{end}}
+        local: {{.AdditionalTrustBundlePath}}{{end}}{{if .NMStateConfigPath}}
+    - path: /var/tmp/network-config.yaml
+      mode: 0400
+      overwrite: true
+      contents:
+        local: {{.NMStateConfigPath}}{{end}}
+
 systemd:
   units:
     - name: install-rhcos-and-restore-seed.service
@@ -65,3 +71,20 @@ systemd:
         ExecStart=/usr/local/bin/install-rhcos-and-restore-seed.sh
         [Install]
         WantedBy=multi-user.target
+   {{if .NMStateConfigPath}}
+    - name: pre-network-manager-config.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Pre Network Manager Config
+        After=NetworkManager.service
+        Before=install-rhcos-and-restore-seed.service
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        TimeoutSec=60
+        ExecStart=bash -c "until /usr/bin/nmstatectl apply /var/tmp/network-config.yaml; do sleep 1; done"
+        [Install]
+        WantedBy=multi-user.target
+
+   {{end}}

--- a/ib-cli/installationiso/installationiso.go
+++ b/ib-cli/installationiso/installationiso.go
@@ -37,6 +37,7 @@ type IgnitionData struct {
 	NoProxy                   string
 	AdditionalTrustBundlePath string
 	MirrorRegistryPath        string
+	NMStateConfigPath         string
 }
 
 //go:embed data/*
@@ -224,6 +225,15 @@ func (r *InstallationIso) renderButaneConfig(ibiConfig *ibiconfig.IBIPrepareConf
 			return err
 		}
 		templateData.MirrorRegistryPath = mirrorRegistryInButane
+	}
+	if ibiConfig.NMStateConfig != "" {
+		nmstateConfigInButane := path.Join(butaneFiles, "nmstateConfig")
+		if err := r.copyFileToButaneDir(ibiConfig.NMStateConfig,
+			path.Join(r.workDir, nmstateConfigInButane)); err != nil {
+			return err
+		}
+		templateData.NMStateConfigPath = nmstateConfigInButane
+
 	}
 
 	template, err := folder.ReadFile(ibiButaneTemplateFilePath)


### PR DESCRIPTION
[MGMT-17989](https://issues.redhat.com//browse/MGMT-17989): Support static network configuration in installation iso
This change allows to provide nmstate configuration that will be applied on installation iso.
In case nmstate config was provided network configuration service will be added, this service run nmstatectl and applies provided config
