### PR TITLE
OCPBUGS-32493: remove redundant retry wrappers

### DIFF
--- a/controllers/prep_handlers.go
+++ b/controllers/prep_handlers.go
@@ -464,13 +464,7 @@ func (r *ImageBasedUpgradeReconciler) handlePrep(ctx context.Context, ibu *ibuv1
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("Validating Ibu spec")
 			if err := r.validateIBUSpec(ctx, ibu); err != nil {
-				// there a few known network errors we are allowing for a requeue with IsConflictOrRetriable
-				// but more often than not,
-				// the error bubbling up from validateIBUSpec is from user and which should stop reconcile right away
-				if !common.IsConflictOrRetriable(err) {
-					return prepFailDoNotRequeue(r.Log, fmt.Sprintf("failed to validate Ibu spec: %s", err.Error()), ibu)
-				}
-				return requeueWithError(fmt.Errorf("failed to validate Ibu spec, requeuing due a known network issue: %w", err))
+				return prepFailDoNotRequeue(r.Log, fmt.Sprintf("failed to validate Ibu spec: %s", err.Error()), ibu)
 			}
 
 			r.Log.Info("Creating IBU workspace")

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -7,8 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openshift-kni/lifecycle-agent/internal/common"
-
 	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -474,11 +472,7 @@ func UpdateIBUStatus(ctx context.Context, c client.Client, ibu *ibuv1.ImageBased
 		}
 	}
 
-	err := common.RetryOnRetriable(common.RetryBackoffTwoMinutes, func() error {
-		return c.Status().Update(ctx, ibu) //nolint:wrapcheck
-	})
-
-	if err != nil {
+	if err := c.Status().Update(ctx, ibu); err != nil {
 		return fmt.Errorf("failed to update IBU status: %w", err)
 	}
 

--- a/internal/backuprestore/backup.go
+++ b/internal/backuprestore/backup.go
@@ -570,12 +570,10 @@ func (h *BRHandler) ensureBackupsDeleted(ctx context.Context, backups []velerov1
 	}
 
 	for _, backup := range backups {
-		err := common.RetryOnRetriable(common.RetryBackoffTwoMinutes, func() error {
-			return h.Get(ctx, types.NamespacedName{ //nolint:wrapcheck
-				Name:      backup.Name,
-				Namespace: backup.Namespace,
-			}, &velerov1.Backup{})
-		})
+		err := h.Get(ctx, types.NamespacedName{
+			Name:      backup.Name,
+			Namespace: backup.Namespace,
+		}, &velerov1.Backup{})
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				continue


### PR DESCRIPTION
# Background / Context

This builds on https://github.com/openshift-kni/lifecycle-agent/pull/548 to clean up the existing explicitly wrapped client calls since they are redundant 

/cc @jc-rh  @Missxiaoguo 