### PR TITLE
OCPBUGS-32493: fix wrong error check

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -290,7 +290,7 @@ func InitIBU(ctx context.Context, c client.Client, log *logr.Logger) error {
 
 	log.Info("Saved IBU CR found, restoring ...")
 	if err := c.Delete(ctx, ibu); err != nil {
-		if !k8serrors.IsAlreadyExists(err) {
+		if !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete IBU during restore: %w", err)
 		}
 	}


### PR DESCRIPTION
# Background / Context

Accidentally included the wrong error check during wrapped called cleanup.  (`client.IgnoreNotFound` should have been replaced with `k8serrors.IsNotFound` instead it was set to `k8serrors.IsAlreadyExists`)  