### PR TITLE
OCPBUGS-34089: Add container storage mountpoint checks

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -75,6 +75,9 @@ type ImageBasedUpgradeReconciler struct {
 	RebootClient    reboot.RebootIntf
 	Mux             *sync.Mutex
 	Clientset       *kubernetes.Clientset
+
+	// Cluster data retrieved once, during init
+	ContainerStorageMountpointTarget string
 }
 
 func doNotRequeue() ctrl.Result {

--- a/controllers/seedgen_controller.go
+++ b/controllers/seedgen_controller.go
@@ -69,6 +69,9 @@ type SeedGeneratorReconciler struct {
 	Recorder        record.EventRecorder
 	Executor        ops.Execute
 	Mux             *sync.Mutex
+
+	// Cluster data retrieved once, during init
+	ContainerStorageMountpointTarget string
 }
 
 var (
@@ -550,6 +553,11 @@ func (r *SeedGeneratorReconciler) validateSystem(ctx context.Context) (msg strin
 	// Check that the "ostree admin set-default" feature is available
 	if !ostreeclient.NewClient(r.Executor, false).IsOstreeAdminSetDefaultFeatureEnabled() {
 		msg = "Rejected: Installed release does not support \"ostree admin set-default\" feature"
+		return
+	}
+
+	if r.ContainerStorageMountpointTarget == "" {
+		msg = "Rejected: Cluster must be configured with shared container storage"
 		return
 	}
 

--- a/lca-cli/ops/mock_ops.go
+++ b/lca-cli/ops/mock_ops.go
@@ -109,6 +109,21 @@ func (mr *MockOpsMockRecorder) ForceExpireSeedCrypto(recertContainerImage, authF
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceExpireSeedCrypto", reflect.TypeOf((*MockOps)(nil).ForceExpireSeedCrypto), recertContainerImage, authFile, hasKubeAdminPassword)
 }
 
+// GetContainerStorageTarget mocks base method.
+func (m *MockOps) GetContainerStorageTarget() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainerStorageTarget")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetContainerStorageTarget indicates an expected call of GetContainerStorageTarget.
+func (mr *MockOpsMockRecorder) GetContainerStorageTarget() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerStorageTarget", reflect.TypeOf((*MockOps)(nil).GetContainerStorageTarget))
+}
+
 // GetHostname mocks base method.
 func (m *MockOps) GetHostname() (string, error) {
 	m.ctrl.T.Helper()

--- a/lca-cli/seedclusterinfo/seedclusterinfo.go
+++ b/lca-cli/seedclusterinfo/seedclusterinfo.go
@@ -84,6 +84,9 @@ type SeedClusterInfo struct {
 	HasFIPS bool `json:"has_fips"`
 
 	AdditionalTrustBundle *AdditionalTrustBundle `json:"additionalTrustBundle"`
+
+	// The target for the /var/lib/containers mountpoint, if setup.
+	ContainerStorageMountpointTarget string `json:"container_storage_mountpoint_target,omitempty"`
 }
 
 type AdditionalTrustBundle struct {
@@ -100,6 +103,7 @@ func NewFromClusterInfo(clusterInfo *utils.ClusterInfo,
 	hasProxy,
 	hasFIPS bool,
 	additionalTrustBundle *AdditionalTrustBundle,
+	containerStorageMountpointTarget string,
 ) *SeedClusterInfo {
 	return &SeedClusterInfo{
 		SeedClusterOCPVersion:    clusterInfo.OCPVersion,
@@ -113,6 +117,8 @@ func NewFromClusterInfo(clusterInfo *utils.ClusterInfo,
 		HasProxy:                 hasProxy,
 		HasFIPS:                  hasFIPS,
 		AdditionalTrustBundle:    additionalTrustBundle,
+
+		ContainerStorageMountpointTarget: containerStorageMountpointTarget,
 	}
 }
 

--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -230,12 +230,18 @@ func (s *SeedCreator) gatherClusterInfo(ctx context.Context) error {
 		return fmt.Errorf("failed to get additional trust bundle information: %w", err)
 	}
 
+	containerStorageMountpointTarget, err := s.ops.GetContainerStorageTarget()
+	if err != nil {
+		return fmt.Errorf("failed to get container storage mountpoint target: %w", err)
+	}
+
 	seedClusterInfo := seedclusterinfo.NewFromClusterInfo(
 		clusterInfo,
 		s.recertContainerImage,
 		hasProxy,
 		hasFIPS,
 		seedAdditionalTrustBundle,
+		containerStorageMountpointTarget,
 	)
 
 	if err := os.MkdirAll(common.SeedDataDir, os.ModePerm); err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -202,6 +202,12 @@ func main() {
 	extraManifest := &extramanifest.EMHandler{
 		Client: mgr.GetClient(), DynamicClient: dynamicClient, Log: log.WithName("ExtraManifest")}
 
+	containerStorageMountpointTarget, err := op.GetContainerStorageTarget()
+	if err != nil {
+		setupLog.Error(err, "unable to get container storage mountpoint target")
+		os.Exit(1)
+	}
+
 	// a simple in-cluster client-go based client, useful for getting pod logs
 	// as runtime-controller client currently doesn't support pod sub resources
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/452#issuecomment-792266582
@@ -247,6 +253,9 @@ func main() {
 		},
 		Mux:       mux,
 		Clientset: clientset,
+
+		// Cluster data retrieved once during init
+		ContainerStorageMountpointTarget: containerStorageMountpointTarget,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageBasedUpgrade")
 		os.Exit(1)
@@ -261,6 +270,9 @@ func main() {
 		Scheme:          mgr.GetScheme(),
 		Executor:        executor,
 		Mux:             mux,
+
+		// Cluster data retrieved once during init
+		ContainerStorageMountpointTarget: containerStorageMountpointTarget,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SeedGenerator")
 		os.Exit(1)


### PR DESCRIPTION
This update adds checks to IBU and seedgen to ensure:
- container storage is setup shared, ie. is a mountpoint
- the mountpoint target for the seed image is the same as the mountpoint target on the running cluster

# Background / Context

IBU requires container storage setup such that it is shared between stateroots. The configuration of the shared storage is up to the user, but the mountpoint target (eg. `/dev/disk/by-partlabel/varlibcontainers`) must be the same on both seed and target SNO.

# Issue / Requirement / Reason for change

If the seed image is generated on an SNO with a different container storage mountpoint target, the upgraded SNO may fail to boot, as the mountpoint target would not exist.

# Solution / Feature Overview

In order to prevent such a configuration mismatch, LCA has been updated to include checks for the container storage setup.
- If container storage is not setup shared, ie. a mountpoint:
  - A seedgen request will be rejected
  - IBU Prep stage will fail
- If the container storage config in the seed image does not align with the running cluster, the IBU Prep stage will fail

# Implementation Details

LCA parses the var-lib-containers.mount service unit to determine the mountpoint target, as defined by the `What` config variable. This path is added to the seed config information, which is included in the seed image label. This label is checked during IBU Prep to ensure that it matches the configuration on the running cluster.