### PR TITLE
OCPEDGE-1089: fix: use rhel9 for the CI build root

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.21-openshift-4.16


### PR DESCRIPTION
Updating the base image for CI to be rhel9 so that the must gather works
