### PR TITLE
[release-4.16] OCPEDGE-1089: chore: use rhel9 for the CI build root

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.21-openshift-4.16


### PR DESCRIPTION
Cherry-pick https://github.com/openshift-kni/lifecycle-agent/pull/590 to release-4.16
