### PR TITLE
OCPBUGS-31570: Bump to latest preinstall utils for disk cleanup fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240501121109-c0e46154d36b
+	github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20241120105227-a01c7fe6b461
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240501121109-c0e46154d36b h1:QYPDs7dSQrPOudmlr/TWlZ1bO6ZFAqhQuQPBfKvCrkk=
-github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240501121109-c0e46154d36b/go.mod h1:kLsipUXPVdPRjK4pVmCKXBjxFYXtN9KjHsBm2QLBEfI=
+github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20241120105227-a01c7fe6b461 h1:zuwh5Si2zxHTq4Hn72aJOV3jl/lBU05OSVvW+k/ZgKA=
+github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20241120105227-a01c7fe6b461/go.mod h1:4u5fRNxjCfaquMdh5snHa/EpaBwjfgpamrA2plIL8vE=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
@@ -228,8 +228,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
-github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=

--- a/vendor/github.com/rh-ecosystem-edge/preinstall-utils/LICENSE
+++ b/vendor/github.com/rh-ecosystem-edge/preinstall-utils/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/rh-ecosystem-edge/preinstall-utils/pkg/disk_ops.go
+++ b/vendor/github.com/rh-ecosystem-edge/preinstall-utils/pkg/disk_ops.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
 
@@ -396,12 +396,46 @@ func (r *diskOps) RemoveDMDevice(dmDevice string) error {
 	return err
 }
 
+// sortDMDevicesForDeletion orders devices in a manner that ensures they can be deleted
+// When using thin provisioning we have to contend with _tdata and _tmeta dmsetup records
+// These cannot be deleted until the main dmsetup record is deleted
+func (r *diskOps) sortDMDevicesForDeletion(dmDevices []string) []string {
+	rootDevices := []string{}
+	dependentDevices := []string{}
+	for _, dmDevice := range dmDevices {
+		if strings.HasSuffix(dmDevice, "_tdata") || strings.HasSuffix(dmDevice, "_tmeta") {
+			dependentDevices = append(dependentDevices, dmDevice)
+			continue
+		}
+		rootDevices = append(rootDevices, dmDevice)
+	}
+	return append(rootDevices, dependentDevices...)
+}
+
+// getBaseDMDevicesForThinProvisioning derives missing DM Devices;
+// When checking the disk dependencies for thin provisioning.
+// The base device will not report a dependency on a specific disk
+// So we need to derive the base device from the already matchd _data of the thin provisioning.
+func (r *diskOps) getBaseDMDevicesForThinProvisioning(dmDevices []string) []string {
+	baseDevices := []string{}
+	for _, dmDevice := range dmDevices {
+		if strings.HasSuffix(dmDevice, "_tdata") {
+			baseDevice := strings.Replace(dmDevice, "_tdata", "", 1)
+			if !lo.Contains(baseDevices, baseDevice) {
+				baseDevices = append(baseDevices, baseDevice)
+			}
+		}
+	}
+	return baseDevices
+}
+
 func (r *diskOps) RemoveAllDMDevicesOnDisk(diskName string) error {
 	var ret error
 	dmDevices, err := r.getDMDevices(diskName)
 	if err != nil {
 		return err
 	}
+	dmDevices = r.sortDMDevicesForDeletion(append(dmDevices, r.getBaseDMDevicesForThinProvisioning(dmDevices)...))
 	for _, dmDevice := range dmDevices {
 		r.log.Infof("Removing DM device %s", dmDevice)
 		err = r.RemoveDMDevice(dmDevice)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -445,7 +445,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20240501121109-c0e46154d36b
+# github.com/rh-ecosystem-edge/preinstall-utils v0.0.0-20241120105227-a01c7fe6b461
 ## explicit; go 1.20
 github.com/rh-ecosystem-edge/preinstall-utils/pkg
 # github.com/robfig/cron v1.2.0


### PR DESCRIPTION
The purpose of this PR is to pick up a change to disk cleanup made in rh-ecosystem-edge/preinstall-utils@cf01558

This change is to ensure that in the case of thin provisioning we clean up all necessary disks in the correct order.

This has been tested in assisted-test infra with a 5 node cluster and an artificially created thin provisioning, the cluster installs correctly where it would not have done so before this change.


# Background / Context

It was discovered that disk cleanup does not clean disks in every scenario.

When thin provisioned disk mappings are present, the existing installer is not able to clean them up. this is because the `_tdata` and `_tmeta` mappings are the only mappings that will be returned when filtering by associated disk.

The changed library code ensures that we search for a base DM and then order the DMs correctly so that deletion will be performed in the correct order.

# Issue / Requirement / Reason for change

Certain customers were running into the scenario above when they have thin volume provisioning.

# Solution / Feature Overview

For more context, please see the commit here


# Implementation Details

We derive a name for the base DM using the function `getBaseDMDevicesForThinProvisioning` and we ensure proper delete order is adhered to using `sortDMDevicesForDeletion`

# Other Information

This has been tested as part of an assisted-service deployment using assisted-test-infra to create a 5 node cluster. Some thin volumes were created and linked to the installation disk. 

These were cleaned correctly when they would not have been cleaned before.

<!---

# Checklist

This is a personal checklist that should be applicable to most PRs. It's good
to go over it in order to make sure you haven't missed anything. If you feel
like some of these points are not relevant to your PR, feel free to keep them
unchecked and if you want also explain why you think they're inapplicable.

- [x] I performed a rough self-review of my changes
- [x] I explained non-trivial motivation for my code using code-comments
- [x] I made sure my code passes linting, tests, and builds correctly
- [x] I have ran the code and made sure it works as intended, and doesn't introduce any obvious regressions
- [x] I have not committed any irrelevant changes (if you did, please point them out and why, ideally separate them into a different PR)
- [x] I added tests (or decided that tests aren't really necessary)
Tests present in the updated library and also test have been performed on assisted-test-infra to ensure that this is working correctly.
