### PR TITLE
Add support for ExtraPartitionSize to address issue #676

### DIFF
--- a/api/ibiconfig/ibiconfig.go
+++ b/api/ibiconfig/ibiconfig.go
@@ -104,12 +104,12 @@ type IBIPrepareConfig struct {
 	// +optional
 	ExtraPartitionStart string `json:"extraPartitionStart,omitempty"`
 
-	// ExtraPartitionEnd End of the /var/lib/containers partition. Free space at the end of the disk is free to be used by another partition
+	// ExtraPartitionSize Total size of /var/lib/containers partition. Free space at the end of the disk is free to be used by another partition
 	// It must be a positive number and can only be used when ExtraPartitionStart is defined:
 	// - Positive number: partition will start at position defined by ExtraPartitionStart and extend by the value here. Example: +120G
 	// Default is 0G (extend to the end of the disk)
 	// +optional
-	ExtraPartitionEnd string `json:"extraPartitionEnd,omitempty"`
+	ExtraPartitionSize string `json:"extraPartitionSize,omitempty"`
 
 	// ExtraPartitionLabel label of extra partition used for /var/lib/containers.
 	// Default is varlibcontainers
@@ -224,11 +224,11 @@ func (c *IBIPrepareConfig) Validate() error {
 	if c.InstallationDisk == "" {
 		return fmt.Errorf("installationDisk is required")
 	}
-	if (c.ExtraPartitionStart == "") && (c.ExtraPartitionEnd != "") {
-		return fmt.Errorf("can not define extraPartitionEnd without defining extraPartitionStart")
+	if (c.ExtraPartitionStart == "") && (c.ExtraPartitionSize != "") {
+		return fmt.Errorf("can not define extraPartitionSize without defining extraPartitionStart")
 	}
-	if (strings.Contains(c.ExtraPartitionStart, "-")) && (c.ExtraPartitionEnd != "") {
-		return fmt.Errorf("can not define extraPartitionEnd with negative extraPartitionStart defined")
+	if (strings.Contains(c.ExtraPartitionStart, "-")) && (c.ExtraPartitionSize != "") {
+		return fmt.Errorf("can not define extraPartitionSize with negative extraPartitionStart defined")
 	}
 
 	return nil
@@ -238,8 +238,8 @@ func (c *IBIPrepareConfig) SetDefaultValues() {
 	if c.ExtraPartitionStart == "" {
 		c.ExtraPartitionStart = "-40G"
 	}
-	if c.ExtraPartitionEnd == "" {
-		c.ExtraPartitionEnd = "0"
+	if c.ExtraPartitionSize == "" {
+		c.ExtraPartitionSize = "0"
 	}
 	if c.ExtraPartitionNumber == 0 {
 		c.ExtraPartitionNumber = 5

--- a/api/ibiconfig/ibiconfig.go
+++ b/api/ibiconfig/ibiconfig.go
@@ -104,6 +104,13 @@ type IBIPrepareConfig struct {
 	// +optional
 	ExtraPartitionStart string `json:"extraPartitionStart,omitempty"`
 
+	// ExtraPartitionEnd End of the /var/lib/containers partition. Free space at the end of the disk is free to be used by another partition
+	// It must be a positive number and can only be used when ExtraPartitionStart is defined:
+	// - Positive number: partition will start at position defined by ExtraPartitionStart and extend by the value here. Example: +120G
+	// Default is 0G (extend to the end of the disk)
+	// +optional
+	ExtraPartitionEnd string `json:"extraPartitionEnd,omitempty"`
+
 	// ExtraPartitionLabel label of extra partition used for /var/lib/containers.
 	// Default is varlibcontainers
 	// +optional
@@ -217,6 +224,12 @@ func (c *IBIPrepareConfig) Validate() error {
 	if c.InstallationDisk == "" {
 		return fmt.Errorf("installationDisk is required")
 	}
+	if (c.ExtraPartitionStart == "") && (c.ExtraPartitionEnd != "") {
+		return fmt.Errorf("can not define extraPartitionEnd without defining extraPartitionStart")
+	}
+	if (strings.Contains(c.ExtraPartitionStart, "-")) && (c.ExtraPartitionEnd != "") {
+		return fmt.Errorf("can not define extraPartitionEnd with negative extraPartitionStart defined")
+	}
 
 	return nil
 }
@@ -224,6 +237,9 @@ func (c *IBIPrepareConfig) Validate() error {
 func (c *IBIPrepareConfig) SetDefaultValues() {
 	if c.ExtraPartitionStart == "" {
 		c.ExtraPartitionStart = "-40G"
+	}
+	if c.ExtraPartitionEnd == "" {
+		c.ExtraPartitionEnd = "0"
 	}
 	if c.ExtraPartitionNumber == 0 {
 		c.ExtraPartitionNumber = 5

--- a/lca-cli/ibi-preparation/ibipreparation.go
+++ b/lca-cli/ibi-preparation/ibipreparation.go
@@ -164,7 +164,7 @@ func (i *IBIPrepare) diskPreparation() error {
 		}
 	} else {
 		if err := i.ops.CreateExtraPartition(i.config.InstallationDisk, i.config.ExtraPartitionLabel,
-			i.config.ExtraPartitionStart, i.config.ExtraPartitionEnd, i.config.ExtraPartitionNumber); err != nil {
+			i.config.ExtraPartitionStart, i.config.ExtraPartitionSize, i.config.ExtraPartitionNumber); err != nil {
 			return fmt.Errorf("failed to create extra partition: %w", err)
 		}
 	}

--- a/lca-cli/ibi-preparation/ibipreparation.go
+++ b/lca-cli/ibi-preparation/ibipreparation.go
@@ -164,7 +164,7 @@ func (i *IBIPrepare) diskPreparation() error {
 		}
 	} else {
 		if err := i.ops.CreateExtraPartition(i.config.InstallationDisk, i.config.ExtraPartitionLabel,
-			i.config.ExtraPartitionStart, i.config.ExtraPartitionNumber); err != nil {
+			i.config.ExtraPartitionStart, i.config.ExtraPartitionEnd, i.config.ExtraPartitionNumber); err != nil {
 			return fmt.Errorf("failed to create extra partition: %w", err)
 		}
 	}

--- a/lca-cli/ibi-preparation/ibipreparation_test.go
+++ b/lca-cli/ibi-preparation/ibipreparation_test.go
@@ -2,10 +2,11 @@ package ibi_preparation
 
 import (
 	"fmt"
-	"github.com/openshift-kni/lifecycle-agent/api/ibiconfig"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/openshift-kni/lifecycle-agent/api/ibiconfig"
 
 	preinstallUtils "github.com/rh-ecosystem-edge/preinstall-utils/pkg"
 	"github.com/sirupsen/logrus"
@@ -19,6 +20,7 @@ func TestDiskPreparation(t *testing.T) {
 	installationDisk := "/dev/sda"
 	extraPartitionLabel := "label"
 	extraPartitionStart := "-40"
+	extraPartitionEnd := "0"
 	extraPartitionNumber := uint(5)
 
 	testcases := []struct {
@@ -101,16 +103,16 @@ func TestDiskPreparation(t *testing.T) {
 			if !tc.UseContainersFolder {
 				if !tc.partitionError {
 					mockOps.EXPECT().CreateExtraPartition(installationDisk, extraPartitionLabel,
-						extraPartitionStart, extraPartitionNumber).Return(nil).Times(1)
+						extraPartitionStart, extraPartitionEnd, extraPartitionNumber).Return(nil).Times(1)
 				} else {
 					mockOps.EXPECT().CreateExtraPartition(installationDisk, extraPartitionLabel,
-						extraPartitionStart, extraPartitionNumber).Return(fmt.Errorf("dummy")).Times(1)
+						extraPartitionStart, extraPartitionEnd, extraPartitionNumber).Return(fmt.Errorf("dummy")).Times(1)
 				}
 
 				mockOps.EXPECT().SetupContainersFolderCommands().Return(nil).Times(0)
 			} else {
 				mockOps.EXPECT().CreateExtraPartition(gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any()).Return(nil).Times(0)
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
 				if !tc.setupFolderError {
 					mockOps.EXPECT().SetupContainersFolderCommands().Return(nil).Times(1)
 				} else {

--- a/lca-cli/ibi-preparation/ibipreparation_test.go
+++ b/lca-cli/ibi-preparation/ibipreparation_test.go
@@ -20,7 +20,7 @@ func TestDiskPreparation(t *testing.T) {
 	installationDisk := "/dev/sda"
 	extraPartitionLabel := "label"
 	extraPartitionStart := "-40"
-	extraPartitionEnd := "0"
+	extraPartitionSize := "0"
 	extraPartitionNumber := uint(5)
 
 	testcases := []struct {
@@ -103,10 +103,10 @@ func TestDiskPreparation(t *testing.T) {
 			if !tc.UseContainersFolder {
 				if !tc.partitionError {
 					mockOps.EXPECT().CreateExtraPartition(installationDisk, extraPartitionLabel,
-						extraPartitionStart, extraPartitionEnd, extraPartitionNumber).Return(nil).Times(1)
+						extraPartitionStart, extraPartitionSize, extraPartitionNumber).Return(nil).Times(1)
 				} else {
 					mockOps.EXPECT().CreateExtraPartition(installationDisk, extraPartitionLabel,
-						extraPartitionStart, extraPartitionEnd, extraPartitionNumber).Return(fmt.Errorf("dummy")).Times(1)
+						extraPartitionStart, extraPartitionSize, extraPartitionNumber).Return(fmt.Errorf("dummy")).Times(1)
 				}
 
 				mockOps.EXPECT().SetupContainersFolderCommands().Return(nil).Times(0)

--- a/lca-cli/ops/mock_ops.go
+++ b/lca-cli/ops/mock_ops.go
@@ -54,17 +54,17 @@ func (mr *MockOpsMockRecorder) Chroot(chrootPath any) *gomock.Call {
 }
 
 // CreateExtraPartition mocks base method.
-func (m *MockOps) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionEnd string, extraPartitionNumber uint) error {
+func (m *MockOps) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionSize string, extraPartitionNumber uint) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateExtraPartition", installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionEnd, extraPartitionNumber)
+	ret := m.ctrl.Call(m, "CreateExtraPartition", installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionSize, extraPartitionNumber)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateExtraPartition indicates an expected call of CreateExtraPartition.
-func (mr *MockOpsMockRecorder) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionEnd, extraPartitionNumber any) *gomock.Call {
+func (mr *MockOpsMockRecorder) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionSize, extraPartitionNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExtraPartition", reflect.TypeOf((*MockOps)(nil).CreateExtraPartition), installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionEnd, extraPartitionNumber)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExtraPartition", reflect.TypeOf((*MockOps)(nil).CreateExtraPartition), installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionSize, extraPartitionNumber)
 }
 
 // CreateIsoWithEmbeddedIgnition mocks base method.

--- a/lca-cli/ops/mock_ops.go
+++ b/lca-cli/ops/mock_ops.go
@@ -54,17 +54,17 @@ func (mr *MockOpsMockRecorder) Chroot(chrootPath any) *gomock.Call {
 }
 
 // CreateExtraPartition mocks base method.
-func (m *MockOps) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionNumber uint) error {
+func (m *MockOps) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionEnd string, extraPartitionNumber uint) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateExtraPartition", installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionNumber)
+	ret := m.ctrl.Call(m, "CreateExtraPartition", installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionEnd, extraPartitionNumber)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateExtraPartition indicates an expected call of CreateExtraPartition.
-func (mr *MockOpsMockRecorder) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionNumber any) *gomock.Call {
+func (mr *MockOpsMockRecorder) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionEnd, extraPartitionNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExtraPartition", reflect.TypeOf((*MockOps)(nil).CreateExtraPartition), installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionNumber)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExtraPartition", reflect.TypeOf((*MockOps)(nil).CreateExtraPartition), installationDisk, extraPartitionLabel, extraPartitionStart, extraPartitionEnd, extraPartitionNumber)
 }
 
 // CreateIsoWithEmbeddedIgnition mocks base method.

--- a/lca-cli/ops/ops.go
+++ b/lca-cli/ops/ops.go
@@ -50,7 +50,7 @@ type Ops interface {
 	Mount(deviceName, mountFolder string) error
 	Umount(deviceName string) error
 	Chroot(chrootPath string) (func() error, error)
-	CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionEnd string, extraPartitionNumber uint) error
+	CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionSize string, extraPartitionNumber uint) error
 	SetupContainersFolderCommands() error
 	GetHostname() (string, error)
 	CreateIsoWithEmbeddedIgnition(log logrus.FieldLogger, ignitionBytes []byte, baseIsoPath, outputIsoPath string) error
@@ -476,14 +476,14 @@ func (o *ops) RunListOfCommands(cmds []*CMD) error {
 	return nil
 }
 
-func (o *ops) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionEnd string, extraPartitionNumber uint) error {
+func (o *ops) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionSize string, extraPartitionNumber uint) error {
 	o.log.Info("Creating extra partition")
 	if _, err := o.RunBashInHostNamespace(
 		"echo", "write", "|", "sfdisk", installationDisk); err != nil {
 		return fmt.Errorf("failed to create extra partition: %w", err)
 	}
 	if _, err := o.RunInHostNamespace("sgdisk", "--new",
-		fmt.Sprintf("%d:%s:%s", extraPartitionNumber, extraPartitionStart, extraPartitionEnd),
+		fmt.Sprintf("%d:%s:%s", extraPartitionNumber, extraPartitionStart, extraPartitionSize),
 		"--change-name", fmt.Sprintf("%d:%s", extraPartitionNumber, extraPartitionLabel),
 		installationDisk); err != nil {
 		return fmt.Errorf("failed to create extra partition: %w", err)

--- a/lca-cli/ops/ops.go
+++ b/lca-cli/ops/ops.go
@@ -50,7 +50,7 @@ type Ops interface {
 	Mount(deviceName, mountFolder string) error
 	Umount(deviceName string) error
 	Chroot(chrootPath string) (func() error, error)
-	CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionNumber uint) error
+	CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionEnd string, extraPartitionNumber uint) error
 	SetupContainersFolderCommands() error
 	GetHostname() (string, error)
 	CreateIsoWithEmbeddedIgnition(log logrus.FieldLogger, ignitionBytes []byte, baseIsoPath, outputIsoPath string) error
@@ -476,14 +476,14 @@ func (o *ops) RunListOfCommands(cmds []*CMD) error {
 	return nil
 }
 
-func (o *ops) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionNumber uint) error {
+func (o *ops) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionEnd string, extraPartitionNumber uint) error {
 	o.log.Info("Creating extra partition")
 	if _, err := o.RunBashInHostNamespace(
 		"echo", "write", "|", "sfdisk", installationDisk); err != nil {
 		return fmt.Errorf("failed to create extra partition: %w", err)
 	}
 	if _, err := o.RunInHostNamespace("sgdisk", "--new",
-		fmt.Sprintf("%d:%s", extraPartitionNumber, extraPartitionStart),
+		fmt.Sprintf("%d:%s:%s", extraPartitionNumber, extraPartitionStart, extraPartitionEnd),
 		"--change-name", fmt.Sprintf("%d:%s", extraPartitionNumber, extraPartitionLabel),
 		installationDisk); err != nil {
 		return fmt.Errorf("failed to create extra partition: %w", err)


### PR DESCRIPTION

# Background / Context

This PR addresses the inability to reserve some space on the install device for other partitions.  By allowing for additional partitions on the install disk we can create partitions for use by other processes, such as the LVM Operator.

# Issue / Requirement / Reason for change

This PR addresses issue #676 

# Solution / Feature Overview

I have added one extra configuration option "ExtraPartitionSize" which allows you to define the size of the varlibcontainers partition that is created. It is a optional configuration. If you do not define this option, the lca-cli works exactly the same as it did prior to this code change. This means that all existing configuration files will work with no changes.

# Implementation Details

This change takes advantage of the existing "sgdisk" code and appends the required additional value of ExtraPartitionSize to the "new" command, allowing us to specify a total size. By defaulting "ExtraPartitionSize" to "0" the any previous config files that did not specify this value will work without any modification. 

# Other Information

Given that MCO can not be used to configure additional partitions the lca-cli utility should be updated to support the creation of additional partitions as part of the image application process. In theory this can be handled by adding a "post.sh" with the additional commands, but it would be easier if it was built into the utility itself. 

