### PR TITLE
MGMT-19151: Fix ingress crt not signed by target ingress CA key

### DIFF
--- a/api/seedreconfig/seedreconfig.go
+++ b/api/seedreconfig/seedreconfig.go
@@ -173,7 +173,15 @@ type ClientAuthCrypto struct {
 }
 
 type IngresssCrypto struct {
-	IngressCA PEM `json:"ingress_ca,omitempty"`
+	IngressCAPrivateKey PEM `json:"ingress_ca,omitempty"`
+
+	// IngressCertificateCN is the common name of the ingress CA used to sign the
+	// ingress certificate. The ingress CA is contained in the cluster's CA bundle,
+	// which is in turn contained in the kubeconfig CA. We need to reconfigure it
+	// during an IBU, in order for the ingress certificate to be regenerated and
+	// trusted with the target cluster's CA bundle.
+	// Its format is `ingress-operator@<unix-timestamp>`.
+	IngressCertificateCN string `json:"ingress_certificate_cn,omitempty"`
 }
 
 // Proxy defines the proxy settings for the cluster.

--- a/lca-cli/seedclusterinfo/seedclusterinfo.go
+++ b/lca-cli/seedclusterinfo/seedclusterinfo.go
@@ -87,6 +87,13 @@ type SeedClusterInfo struct {
 
 	// The target for the /var/lib/containers mountpoint, if setup.
 	ContainerStorageMountpointTarget string `json:"container_storage_mountpoint_target,omitempty"`
+
+	// IngressCertificateCN is the Subject.CN of the ingress router-ca signer
+	// certificate, which is of the form `ingress-operator@<unix-timestampt>`.
+	// Without this recert will not be able to sign the ingress certificate with
+	// the correct ingress private key, because it looks for strict equality in
+	// the certificate's Subject.CN.
+	IngressCertificateCN string `json:"ingress_certificate_cn,omitempty"`
 }
 
 type AdditionalTrustBundle struct {
@@ -104,6 +111,7 @@ func NewFromClusterInfo(clusterInfo *utils.ClusterInfo,
 	hasFIPS bool,
 	additionalTrustBundle *AdditionalTrustBundle,
 	containerStorageMountpointTarget string,
+	ingressCertificateCN string,
 ) *SeedClusterInfo {
 	return &SeedClusterInfo{
 		SeedClusterOCPVersion:    clusterInfo.OCPVersion,
@@ -119,6 +127,8 @@ func NewFromClusterInfo(clusterInfo *utils.ClusterInfo,
 		AdditionalTrustBundle:    additionalTrustBundle,
 
 		ContainerStorageMountpointTarget: containerStorageMountpointTarget,
+
+		IngressCertificateCN: ingressCertificateCN,
 	}
 }
 

--- a/lca-cli/seedcreator/seedcreator.go
+++ b/lca-cli/seedcreator/seedcreator.go
@@ -242,6 +242,7 @@ func (s *SeedCreator) gatherClusterInfo(ctx context.Context) error {
 		hasFIPS,
 		seedAdditionalTrustBundle,
 		containerStorageMountpointTarget,
+		clusterInfo.IngressCertificateCN,
 	)
 
 	if err := os.MkdirAll(common.SeedDataDir, os.ModePerm); err != nil {


### PR DESCRIPTION
# Background / Context

The ingress certificate's Subject.CN that LCA provides to recert, i.e. `ingress-operator.key`, along with the ingress CA private key of the target cluster, in order for HTTP clients to keep trusting the ingress certificate is incorrect, i.e. it is not contained in the ingress CA certificate. Recert regenerates the ingress CA certificate and its private key, instead of using the provided ingress private key of the target cluster. The latter leads in HTTP clients requesting an API resource via ingress using the cluster's CA certificates in their TLS transport to fail because they can't verify the ingress certificate.

# Issue / Requirement / Reason for change

After an IBU we should have the ingress CA certificates properly regenerated and signed by the provided target cluster's ingress private key, using the correct CN in the recert config. That way we will leave the target cluster's ingress healthy instead of broken.

# Solution / Feature Overview

Instead of using the Subject.CN `ingress-operator.key`, we should use the [correct](https://github.com/openshift/cluster-ingress-operator/blob/release-4.17/pkg/operator/controller/certificate/ca.go#L63) one, which is formatted as `ingress-operator@<unix-timestamp>` and is contained in the `secrets/openshift-ingress-operator/router-ca` `tls.crt`. 

We should also replace the seed cluster's ingress CA Subject.CN with the target cluster's ingress CA Subject.CN, as it contains a unix timestamp.

# Implementation Details

# Other Information

You can verify this issue via the following steps:

1. Run an IBU

2. Download the cluster's CA bundle:
    ```sh
    oc config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ca.crt
    ```

3. Download the ingress certificate:
    ```sh
    openssl s_client -connect oauth.apps.<cluster-name>.<base-domain>:443 -showcerts </dev/null </dev/null 2>/dev/null | awk '/BEGIN CERTIFICAT/,/END CERTIFICATE/ {print}' > ingress.crt
    ```

4. Try to verify the ingress certificate with the cluster's CA bundle: 
    ```sh
    openssl verify -CAfile ca.crt ingress.crt
    ```
