### PR TITLE
MGMT-19505: IBU fails during lca-prep-stateroot-setup: failed to complete stateroot setup

### DIFF
--- a/internal/prep/prep.go
+++ b/internal/prep/prep.go
@@ -152,7 +152,7 @@ func SetupStateroot(log logr.Logger, ops ops.Ops, ostreeClient ostreeclient.ICli
 
 	}
 
-	mountpoint, err := ops.RunInHostNamespace("podman", "image", "mount", seedImage)
+	mountpoint, err := ops.MountImage(seedImage)
 	if err != nil {
 		return fmt.Errorf("failed to mount seed image: %w", err)
 	}

--- a/lca-cli/ops/mock_ops.go
+++ b/lca-cli/ops/mock_ops.go
@@ -198,6 +198,21 @@ func (mr *MockOpsMockRecorder) Mount(deviceName, mountFolder any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mount", reflect.TypeOf((*MockOps)(nil).Mount), deviceName, mountFolder)
 }
 
+// MountImage mocks base method.
+func (m *MockOps) MountImage(img string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MountImage", img)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MountImage indicates an expected call of MountImage.
+func (mr *MockOpsMockRecorder) MountImage(img any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MountImage", reflect.TypeOf((*MockOps)(nil).MountImage), img)
+}
+
 // RecertFullFlow mocks base method.
 func (m *MockOps) RecertFullFlow(recertContainerImage, authFile, configFile string, preRecertOperations, postRecertOperations func() error, additionalPodmanParams ...string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
[MGMT-19505](https://issues.redhat.com//browse/MGMT-19505): IBU fails during lca-prep-stateroot-setup: failed to complete stateroot setup

In new version of crio was added a cleanup that if crio doesn't find image mount point it removes container.
    When running with chroot and moint image , mount point is not created in the host namespace
    and in this case crio removes the image at some point causing preparation logic to fail.
    This change fixes the issue by using nsenter command for podman image mount.