### PR TITLE
OCPBUGS-55497 - Disable user monitoring on the Servicemonitor

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: lifecycle-agent-operator
     app.kubernetes.io/component: lifecycle-agent
     control-plane: controller-manager
+    openshift.io/user-monitoring: "false"
   name: controller-manager-metrics-monitor
   namespace: system
 spec:


### PR DESCRIPTION
Current configuration of the ServiceMonitor generates PrometheusOperatorRejectedResources alert on the cluster when UserWorkloadMonitoring is enabled. 

Addding the label openshift.io/user-monitoring: "false" prevents UWL to monitor the ServiceMonitor and th PrometheusOperatorRejectedResources alert is not triggered. 

Background: OCPBUGS-39126 
