### PR TITLE
Skip sast-coverity tekton task

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -54,6 +54,10 @@ spec:
       name: skip-preflight
       type: string
     - default: "false"
+      description: Skip the sast coverity check
+      name: skip-sast-coverity
+      type: string
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -490,6 +494,10 @@ spec:
           operator: in
           values:
             - "false"
+        - input: $(params.skip-sast-coverity)
+          operator: in
+          values:
+            - "false"
         - input: $(tasks.coverity-availability-check.results.STATUS)
           operator: in
           values:
@@ -508,6 +516,10 @@ spec:
         resolver: bundles
       when:
         - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+        - input: $(params.skip-sast-coverity)
           operator: in
           values:
             - "false"

--- a/.tekton/lifecycle-agent-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-4-20-pull-request.yaml
@@ -62,6 +62,8 @@ spec:
       value: '[{"type": "rpm", "path": ".konflux/lock-runtime"}, {"type": "gomod", "path": "."}]'
     - name: build-source-image
       value: "true"
+    - name: skip-sast-coverity
+      value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/lifecycle-agent-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-4-20-push.yaml
@@ -60,6 +60,8 @@ spec:
       value: '[{"type": "rpm", "path": ".konflux/lock-runtime"}, {"type": "gomod", "path": "."}]'
     - name: build-source-image
       value: "true"
+    - name: skip-sast-coverity
+      value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml
@@ -58,6 +58,8 @@ spec:
       value: "false"
     - name: image-append-platform
       value: "false"
+    - name: skip-sast-coverity
+      value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml
@@ -56,6 +56,8 @@ spec:
       value: "false"
     - name: image-append-platform
       value: "false"
+    - name: skip-sast-coverity
+      value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}


### PR DESCRIPTION
- The sast-coverity task often times out and is optional
- Until the task has been improved by the Konflux team we will skip it
