### PR TITLE
Enable multi-arch building for lifecycle-agent

### DIFF
--- a/.konflux/lock-runtime/redhat.repo
+++ b/.konflux/lock-runtime/redhat.repo
@@ -9,3474 +9,156 @@
 # a "yum repolist" to refresh available repos
 #
 
-[satellite-client-6-for-rhel-9-x86_64-eus-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sat-client/6/debug
+[rhel-9-for-$basearch-appstream-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/appstream/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-highavailability-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/highavailability/debug
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/sap/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-appstream-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/appstream/os
+[gitops-1.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-resilientstorage-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/resilientstorage/source/SRPMS
+[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sap-solutions/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-sap-netweaver-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sap/source/SRPMS
+[openstack-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
 enabled = 0
 gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-x86_64-source-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-deployment-tools/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jdg/8.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-x86_64-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-x86_64-rpms]
-name = Kernel Module Management 2 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/kmm/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-x86_64-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-x86_64-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-rt-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-far/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jon-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Operations Network Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack-dev-preview/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-x86_64-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-x86_64-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/sat-capsule/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-x86_64-rhui-source-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/x86_64/jbeap/8.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-mdr/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-textonly-1-for-middleware-rhui-rpms]
-name = Single Sign-On Text-Only Advisories from RHUI
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-x86_64-rhui-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/x86_64/jbeap/8.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-x86_64-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-snr/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-rpms]
-name = Red Hat Container Development Kit 3.6 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-eus-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-aus-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Advanced Mission Critical Update Support (Source RPMS)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-cinderlib/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-debug-rpms]
-name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-eus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-x86_64-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-x86_64-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-x86_64-rpms]
-name = Red Hat Certification for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-rt-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Application Interconnect for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhai/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-x86_64-eus-debug-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 x86_64 - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jpp-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Portal Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-x86_64-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-rt-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-debug-rpms]
-name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-eus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-x86_64-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-eus-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Extended Update Support (RPMS)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhsi-textonly-1-for-middleware-rpms]
-name = Red Hat Service Interconnect Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/x86_64/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack-dev-preview/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/satellite/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-interconnect-textonly-1-for-middleware-rpms]
-name = Red Hat AMQ Interconnect Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-eus-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-aus-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Advanced Mission Critical Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-x86_64-source-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/amq/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-x86_64-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-x86_64-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-x86_64-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 (Debug RPMS)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-x86_64-rpms]
-name = JBoss Web Server 5 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jws/5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-x86_64-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jbeap/7.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-x86_64-source-rpms]
-name = Fast Datapath for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-x86_64-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1.8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-tools/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-x86_64-rpms]
-name = Kernel Module Management 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/kmm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-x86_64-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhacm/2.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-x86_64-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-stf/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-x86_64-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/network-observability/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-x86_64-debug-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-e4s-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Update Services SAP Solutions (Debug RPMS)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-for-rhel-9-textonly-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhacm-textonly/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-tools/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-x86_64-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Service Interconnect for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-x86_64-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhdh/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-utils/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-far/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-x86_64-debug-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/network-observability/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-x86_64-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-x86_64-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rodoo/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-e4s-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-utils/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-far/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-x86_64-rpms]
-name = Red Hat Service Interconnect for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 x86_64 - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-cinderlib/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Certification for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Quay 3 (for RHEL 9 x86_64) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/quay/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-x86_64-rpms]
-name = JBoss Web Server 6 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jws/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-x86_64-source-rpms]
-name = Kernel Module Management 2 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/kmm/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Web Server Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-x86_64-debug-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-x86_64-source-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/satellite/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-x86_64-debug-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-mdr/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-x86_64-debug-rpms]
-name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jws/5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-x86_64-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-x86_64-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Insights Proxy for RHEL9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/insights-proxy/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-x86_64-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-x86_64-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-source-rpms]
-name = Red Hat Container Development Kit 3.3 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-deployment-tools/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-deployment-tools/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-cinderlib/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-x86_64-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-aus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Advanced Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-nmo/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.10-rpms]
-name = Red Hat Container Development Kit 3.10 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-nfv-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time for NFV (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/nfv/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.17-rpms]
-name = Red Hat Container Development Kit 3.17 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-podified/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[pipelines-1.18-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 x86_64) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/pipelines/1.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-x86_64-debug-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rodoo/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-x86_64-source-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) (x86_64 Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-x86_64-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) (x86_64 RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.13-rpms]
-name = Red Hat Container Development Kit 3.13 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-capsule/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhv-tools/4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-x86_64-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-podified/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-x86_64-source-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jbeap/7.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 (RPMS)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-eus-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-x86_64-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-x86_64-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-x86_64-rhui-debug-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/x86_64/jbeap/8.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-x86_64-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-x86_64-source-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jdg/8.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openliberty-textonly-1-for-middleware-rpms]
-name = Open Liberty Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-x86_64-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/amq/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-source-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-coreservices-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Core Services Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-x86_64-rpms]
-name = Red Hat Discovery 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/discovery/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Discovery 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/discovery/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 x86_64 - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-aus-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Advanced Mission Critical Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-nmo/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-x86_64-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-x86_64-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-x86_64-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-stf/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhdh/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-rt-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-eus-rhui-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/satellite/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-debug-rpms]
-name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhbop-textonly-1-for-middleware-rpms]
-name = Red Hat Build of OptaPlanner Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[soa-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss SOA Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-edpm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-snr/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-x86_64-source-rpms]
-name = Kernel Module Management 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/kmm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-tools/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-4.14-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.14/source/SRPMS
+[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack-dev-preview/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cnv-4.15-for-rhel-9-x86_64-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.15/os
+[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/baseos/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[insights-proxy-1-tech-preview-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/insights-proxy-tech-preview/1/source/SRPMS
+[lvms-4.19-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[satellite-client-6-for-rhel-9-x86_64-e4s-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sat-client/6/debug
+[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[lvms-4.15-for-rhel-9-x86_64-source-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.15/source/SRPMS
+[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[openstack-17.1-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-tools/17.1/source/SRPMS
+[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -3489,848 +171,22 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhceph-8-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/8/os
+[rhocp-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-eus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhodf/4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-x86_64-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-x86_64-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.14-rpms]
-name = Red Hat Container Development Kit 3.14 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-utils/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-x86_64-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-tools/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-x86_64-rpms]
-name = Red Hat Application Interconnect for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhai/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-utils/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-x86_64-debug-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-x86_64-source-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 x86_64) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jbeap/8.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-x86_64-debug-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jbeap/7.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-eus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-debug-rpms]
-name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-x86_64-debug-rpms]
-name = Kernel Module Management 2 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/kmm/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-x86_64-rpms]
-name = Single Sign-On 7.6 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rh-sso/7.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-source-rpms]
-name = Red Hat Container Development Kit 2.3 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-capsule/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-eus-rhui-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-nfv-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time for NFV - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/nfv/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss AMQ Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-podified/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-eus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-x86_64-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-edpm/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-eus-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Extended Update Support (Debug RPMS)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-rhui-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-nfv-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time for NFV (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/nfv/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/sat-capsule/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-x86_64-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.11/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-x86_64-source-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-x86_64-source-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) (x86_64 Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-aus-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Advanced Mission Critical Update Support (Debug RPMS)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso/18.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhodf/4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1.8/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-rpms]
-name = Red Hat Container Development Kit 2.3 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -4343,36 +199,764 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[satellite-maintenance-6.17-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-maintenance/6.17/os
+[gitops-1.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[pipelines-1.18-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 x86_64) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/pipelines/1.18/source/SRPMS
+[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-rpms]
+name = Red Hat Container Development Kit 2.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.10-rpms]
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -4385,1240 +969,8 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-x86_64-debug-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) (x86_64 Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ossm/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-aus-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Advanced Mission Critical Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Certification for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhacm/2.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.9-rpms]
-name = Red Hat Container Development Kit 3.9 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-stf/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-x86_64-source-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rodoo/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-x86_64-eus-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 x86_64 - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-x86_64-rpms]
-name = Red Hat Insights Proxy for RHEL9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/insights-proxy/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Application Interconnect for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhai/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-x86_64-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.10/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 (Source RPMS)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-rpms]
-name = Red Hat Container Development Kit 3.5 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-nhc/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-x86_64-source-rpms]
-name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jws/5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-nmo/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-podified/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-x86_64-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack-deployment-tools/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-maintenance/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.15-rpms]
-name = Red Hat Container Development Kit 3.15 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/codeready-builder/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[osso-1-for-rhel-9-x86_64-debug-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/osso/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-x86_64-source-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/network-observability/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-x86_64-eus-source-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 x86_64 - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/satellite/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-debug-rpms]
-name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhodf/4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-textonly-1-for-middleware-rpms]
-name = Single Sign-On Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-maintenance/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-maintenance/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-x86_64-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.10/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-x86_64-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso/18.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-x86_64-debug-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 x86_64) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jbeap/8.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-x86_64-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-rt-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/rt/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-x86_64-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-x86_64-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) (x86_64 RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhacm/2.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack-deployment-tools/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-x86_64-source-rpms]
-name = Single Sign-On 7.6 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rh-sso/7.6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-x86_64-textonly-source-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 x86_64) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhpm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-e4s-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Update Services SAP Solutions (RPMS)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-x86_64-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-x86_64-source-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-utils/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-x86_64-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ossm/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-source-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -5631,2696 +983,456 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-sap-solutions-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sap-solutions/source/SRPMS
+[amq-clients-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-sap-solutions-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/sap-solutions/debug
+[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rh-sso-7.6-for-rhel-9-x86_64-debug-rpms]
-name = Single Sign-On 7.6 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rh-sso/7.6/debug
+[osso-1-for-rhel-9-$basearch-debug-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[insights-proxy-1-tech-preview-for-rhel-9-x86_64-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/insights-proxy-tech-preview/1/os
+[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-baseos-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.7-rpms]
-name = Red Hat Container Development Kit 3.7 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-textonly-1-for-middleware-rpms]
-name = OpenJDK Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/x86_64/os
+[rh-sso-textonly-1-for-middleware-rpms]
+name = Single Sign-On Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file://
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-highavailability-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/highavailability/debug
+[gitops-1.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-4.14-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.14/os
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/codeready-builder/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-ironic-4.12-for-rhel-9-x86_64-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.12/os
+[jb-eap-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
 enabled = 0
 gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-x86_64-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-x86_64-textonly-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 x86_64) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhpm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-deployment-tools/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-x86_64-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/satellite/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-x86_64-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhacm/2.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-x86_64-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/7/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-x86_64-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-source-rpms]
-name = Red Hat Container Development Kit 3.5 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-eus-rhui-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-capsule/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[rhpm-1-for-rhel-9-x86_64-textonly-debug-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 x86_64) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhpm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-x86_64-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-x86_64-debug-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-nfv-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time for NFV (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/nfv/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ossm/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-nfv-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time for NFV - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/nfv/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Discovery 1 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/discovery/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-x86_64-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-edpm/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-x86_64-rpms]
-name = Fast Datapath for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/amq/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Insights Proxy for RHEL9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/insights-proxy/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Quay 3 (for RHEL 9 x86_64) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/quay/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-x86_64-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-tools/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-x86_64-source-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/osso/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-x86_64-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-edpm/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 x86_64 - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-x86_64-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.8-rpms]
-name = Red Hat Container Development Kit 3.8 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-podified/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-debug-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhosds-textonly-3-for-middleware-rpms]
-name = Red Hat OpenShift Dev Spaces 3 Container Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/x86_64/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-tools/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-source-rpms]
-name = Red Hat Container Development Kit 3.4 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-x86_64-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-solutions-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgkey = file://
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[openstack-17.1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17.1/debug
+[rhel-9-for-$basearch-sap-solutions-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/sap-solutions/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cnv-4.17-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.17/debug
+[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhwa-nhc-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-nhc/1/debug
+[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[dirsrv-12.4-for-rhel-9-x86_64-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.4/os
+[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-sap-netweaver-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/sap/source/SRPMS
+[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-sap-netweaver-eus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sap/os
+[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cert-manager-1.11-for-rhel-9-x86_64-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.11/debug
+[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-appstream-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/appstream/os
+[rhel-9-for-$basearch-baseos-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/baseos/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-sap-solutions-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP Solutions - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sap-solutions/debug
+[rhelai-3.0-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cnv-4.16-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.16/debug
+[rhel-atomic-7-cdk-2.3-source-rpms]
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[jws-6-for-rhel-9-x86_64-debug-rpms]
-name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jws/6/debug
+[rh-sso-7.6-for-rhel-9-$basearch-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[codeready-builder-for-rhel-9-x86_64-eus-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/codeready-builder/os
+[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-4.13-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.13/source/SRPMS
+[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sap/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[ocp-tools-4.15-for-rhel-9-x86_64-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) (x86_64 RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.15/os
+[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/resilientstorage/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[jb-datagrid-8.4-for-rhel-9-x86_64-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jdg/8.4/os
+[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[openstack-beta-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack/os
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[jdv-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Data Virtualization Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-x86_64-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-cuda/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-maintenance/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/satellite/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-x86_64-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-x86_64-debug-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-utils/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-edpm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-mdr/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack-deployment-tools/os
+[openstack-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-ironic-4.17-for-rhel-9-x86_64-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.17/debug
+[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhceph-5-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/5/debug
+[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/sat-client/6/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[ansible-automation-platform-2.5-for-rhel-9-x86_64-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.5/os
+[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[service-interconnect-1-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Service Interconnect for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1/debug
+[cnv-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhoso-tools-18-beta-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-tools/18/source/SRPMS
+[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
 enabled = 0
 gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-x86_64-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/osso/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhose-textonly-1-for-middleware-rpms]
-name = Red Hat Middleware Container Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/x86_64/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-debug-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-x86_64-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-e4s-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhv-tools/4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-x86_64-debug-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) (x86_64 Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhdh/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-x86_64-source-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) (x86_64 Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-x86_64-debug-rpms]
-name = Fast Datapath for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-eus-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Extended Update Support (Source RPMS)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso/18.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-x86_64-aus-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Advanced Mission Critical Update Support (RPMS)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-x86_64-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-rt-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/rt/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-x86_64-debug-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) (x86_64 Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ocp-tools/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
-name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-x86_64-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 x86_64) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jbeap/8.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-eus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-x86_64-source-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/lvms/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhsi/1.8/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-resilientstorage-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-tools/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhacm/2.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-sap-netweaver-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - SAP NetWeaver (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fsw-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Fuse Service Works Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-x86_64-rpms]
-name = Red Hat Quay 3 (for RHEL 9 x86_64) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/quay/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quarkus-textonly-1-for-middleware-rpms]
-name = Red Hat build of Quarkus Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/x86_64/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhv-tools/4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/8/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/7/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 x86_64 - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/sat-capsule/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-x86_64-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/1.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-x86_64-source-rpms]
-name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/jws/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-baseos-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-tools/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/gitops/1.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-x86_64-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.10/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 x86_64 - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai-gaudi/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-x86_64-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cnv/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-x86_64-eus-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 x86_64 - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-rhui-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-tools/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-x86_64-source-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-appstream-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - AppStream (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-nhc/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-podified/1.0/debug
-enabled = 0
-gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[satellite-6-client-2-for-rhel-9-x86_64-e4s-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 x86_64 - Update Services SAP Solutions (Source RPMS)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/sat-client-2/6/source/SRPMS
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhceph-8-tools-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/8/debug
+[rhel-9-for-$basearch-appstream-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/appstream/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -8333,358 +1445,246 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cert-manager-1.12-for-rhel-9-x86_64-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/cert-manager/1.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhacm/2.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-x86_64-rhui-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 x86_64 (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-automation-platform/2.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-deployment-tools/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Data Grid Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-x86_64-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp-ironic/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/x86_64/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[nbde-tang-server-1-for-rhel-9-x86_64-textonly-rpms]
-name = nbde tang server 1 (for RHEL 9 x86_64) (Text-Only Advisories)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/nbde-tang-server-textonly/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 x86_64) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/pipelines/1.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/openstack-deployment-tools/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/insights-proxy-tech-preview/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-highavailability-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhwa-snr/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-x86_64-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/sat-maintenance/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-x86_64-supplementary-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Supplementary - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/x86_64/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/dirsrv/12.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/openstack/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-x86_64-debug-rpms]
-name = Kernel Module Management 1 for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/kmm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/x86_64/rhoso-edpm/1/debug
+[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-nfv-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Real Time for NFV - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/nfv/debug
+[rhceph-6-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhceph-7-tools-for-rhel-9-x86_64-source-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 x86_64 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhceph-tools/7/source/SRPMS
+[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/appstream/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -8697,92 +1697,3284 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhoso-tools-18-for-rhel-9-x86_64-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 x86_64 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhoso-tools/18/debug
+[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/supplementary/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-highavailability-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/x86_64/highavailability/os
+[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sat-client/6/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[ansible-developer-1.2-for-rhel-9-x86_64-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.2/os
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-resilientstorage-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/x86_64/resilientstorage/debug
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-x86_64-baseos-aus-rpms]
-name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Advanced Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/x86_64/baseos/os
+[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/resilientstorage/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-4.17-for-rhel-9-x86_64-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.17/os
+[quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat build of Quarkus Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sap/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss AMQ Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-debug-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-debug-rpms]
+name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
+name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-source-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.17-rpms]
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-debug-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhose-textonly-1-for-middleware-rpms]
+name = Red Hat Middleware Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhsi-textonly-1-for-middleware-rpms]
+name = Red Hat Service Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhem-0.7-for-rhel-9-$basearch-rpms]
+name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.15-rpms]
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 5 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[service-interconnect-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-rpms]
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-source-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/codeready-builder/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosds-textonly-3-for-middleware-rpms]
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Grid Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-textonly-1-for-middleware-rpms]
+name = OpenJDK Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhbop-textonly-1-for-middleware-rpms]
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-for-rhel-9-textonly-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -8795,22 +4987,4250 @@ gpgcheck = 1
 gpgkey = file://
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[ansible-developer-1.1-for-rhel-9-x86_64-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 x86_64 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/ansible-developer/1.1/os
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/resilientstorage/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/3026705028630828910-key.pem
-sslclientcert = /etc/pki/entitlement/3026705028630828910.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jpp-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Portal Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[soa-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss SOA Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-rpms]
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhem-0.7-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-rpms]
+name = Fast Datapath for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+name = Single Sign-On Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+name = Red Hat AMQ Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.13-rpms]
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.8-rpms]
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhem-0.7-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openliberty-textonly-1-for-middleware-rpms]
+name = Open Liberty Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jon-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Operations Network Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-debug-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Server Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fsw-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-source-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-source-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/9.4/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 6 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.7-rpms]
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/9.4/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/9.4/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.14-rpms]
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/9.4/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/9.4/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.9-rpms]
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jdv-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/3670834170235349048-key.pem
+sslclientcert = /etc/pki/entitlement/3670834170235349048.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0

--- a/.konflux/lock-runtime/rpms.in.yaml
+++ b/.konflux/lock-runtime/rpms.in.yaml
@@ -10,6 +10,7 @@ packages:
 
 arches:
   - x86_64
+  - aarch64
 
 context:
     containerfile:

--- a/.konflux/lock-runtime/rpms.lock.yaml
+++ b/.konflux/lock-runtime/rpms.lock.yaml
@@ -2,6 +2,31 @@
 lockfileVersion: 1
 lockfileVendor: redhat
 arches:
+- arch: aarch64
+  packages:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/r/rsync-3.2.3-19.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 405826
+    checksum: sha256:2836c96b161dff16224516e22a55e9ad2fbe1278e482caec1332cbc19812419e
+    name: rsync
+    evr: 3.2.3-19.el9
+    sourcerpm: rsync-3.2.3-19.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/t/tar-1.34-6.el9_4.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 900224
+    checksum: sha256:f2b65a333b9de17af1f71e27c7540fa23d85cbe98774a246eb70547d028027da
+    name: tar
+    evr: 2:1.34-6.el9_4.1
+    sourcerpm: tar-1.34-6.el9_4.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-18.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 477963
+    checksum: sha256:16dfccafa090ff446a374e81e11224e396f44b9c20eba9144cfb48d46a71f3e1
+    name: util-linux-core
+    evr: 2.37.4-18.el9
+    sourcerpm: util-linux-2.37.4-18.el9.src.rpm
+  source: []
+  module_metadata: []
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/r/rsync-3.2.3-19.el9.x86_64.rpm

--- a/.tekton/lifecycle-agent-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-4-20-pull-request.yaml
@@ -50,6 +50,7 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
     - name: dockerfile
       value: Dockerfile
     - name: build-args-file

--- a/.tekton/lifecycle-agent-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-4-20-push.yaml
@@ -48,6 +48,7 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
     - name: dockerfile
       value: Dockerfile
     - name: build-args-file

--- a/.tekton/lifecycle-agent-fbc-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-fbc-4-20-pull-request.yaml
@@ -36,6 +36,7 @@ spec:
     value: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-fbc-4-20:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
+    # FBCs are explicitly not allowed to be multi arch, so we only build x86_64
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/lifecycle-agent-fbc-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-fbc-4-20-push.yaml
@@ -33,6 +33,7 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-fbc-4-20:{{revision}}
+    # FBCs are explicitly not allowed to be multi arch, so we only build x86_64
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml
@@ -39,6 +39,7 @@ spec:
       value: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
+    # Bundles are explicitly not allowed to be multi arch, so we only build x86_64
     - name: build-platforms
       value:
         - linux/x86_64

--- a/.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml
@@ -37,6 +37,7 @@ spec:
       value: '{{revision}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20:{{revision}}
+    # Bundles are explicitly not allowed to be multi arch, so we only build x86_64
     - name: build-platforms
       value:
         - linux/x86_64

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ debug: manifests generate fmt vet ## Run a controller from your host that accept
 	PRECACHE_WORKLOAD_IMG=${IMG} dlv debug --headless --listen 127.0.0.1:2345 --api-version 2 --accept-multiclient ./main.go
 
 docker-build: ## Build container image with the manager.
-	${ENGINE} build --arch ${GOARCH} --build-arg GOARCH=${GOARCH} -t ${IMG} -f Dockerfile .
+	${ENGINE} build --platform=linux/${GOARCH} -t ${IMG} -f Dockerfile .
 
 docker-push: docker-build ## Push container image with the manager.
 	${ENGINE} push ${IMG}


### PR DESCRIPTION
- Include arm64 as a build target in Konflux
- Update rpm lock configuration to include both architectures packages
- Update Dockerfile/Makefile to fix cross compiling to work both in and outside of Konflux