### PR TITLE
OCPBUGS-59548: Fix min_kube_version for LCA bundle

### DIFF
--- a/.konflux/overlay/overlay.bash
+++ b/.konflux/overlay/overlay.bash
@@ -281,7 +281,7 @@ overlay_release()
     local replaces="lifecycle-agent.v4.18.0"
     # min_kube_version should match ocp
     # https://access.redhat.com/solutions/4870701
-    export min_kube_version="1.31"
+    export min_kube_version="1.31.0"
 
     yq e -i ".metadata.annotations[\"containerImage\"] = \"${IMAGE_TO_TARGET[$MANAGER_KEY]}\"" $ARG_CSV_FILE
     yq e -i ".spec.displayName = \"$display_name\"" $ARG_CSV_FILE


### PR DESCRIPTION
- The min_kube_version needs to be set using three field semantic versioning, e.g. x.y.z
