### PR TITLE
(release-4.19) Exclude telco5g-konflux subproject from linters

### DIFF
--- a/hack/bashate.sh
+++ b/hack/bashate.sh
@@ -30,8 +30,14 @@ source "${VENVDIR}/bin/activate" || fatal "Could not activate virtualenv"
 pip install bashate==2.1.0 || fatal "Installation of bashate failed"
 
 # Run bashate on all Bash script files, excluding specified directories
-find . -name '*.sh' -not -path './vendor/*' -not -path './*/vendor/*' -not -path './git/*' \
-    -not -path './bin/*' -not -path './testbin/*' -print0 \
+find . -name '*.sh' \
+    -not -path './*/vendor/*' \
+    -not -path './bin/*' \
+    -not -path './git/*' \
+    -not -path './testbin/*' \
+    -not -path './vendor/*' \
+    -not -path './telco5g-konflux/*' \
+    -print0 \
     | xargs -0 --no-run-if-empty bashate -v -e 'E*' -i E006
 
 # Check the exit status of bashate and exit with an appropriate status

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -17,5 +17,4 @@ EOF
     fi
 }
 
-markdownlint-cli2 '**/*.md' !'vendor/**/*.md'
-
+markdownlint-cli2 '**/*.md' !'vendor/**/*.md' !'./telco5g-konflux/**/*.md'

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -52,6 +52,12 @@ else
     fi
 fi
 
-find . -name '*.sh' -not -path './vendor/*' -not -path './*/vendor/*' -not -path './git/*' \
-    -not -path './bin/*' -not -path './testbin/*' -print0 \
+find . -name '*.sh' \
+    -not -path './*/vendor/*' \
+    -not -path './bin/*' \
+    -not -path './git/*' \
+    -not -path './testbin/*' \
+    -not -path './vendor/*' \
+    -not -path './telco5g-konflux/*' \
+    -print0 \
     | xargs -0 --no-run-if-empty ${shellcheck} -x

--- a/hack/yamllint.sh
+++ b/hack/yamllint.sh
@@ -22,6 +22,12 @@ source ${VENVDIR}/bin/activate || fatal "Could not activate virtualenv"
 
 pip install yamllint==1.35.1 || fatal "Installation of yamllint failed"
 
-find . -regextype egrep -regex '.*ya{0,1}ml$' -not -path './vendor/*' -not -path './git/*' \
-    -not -path './bin/*' -not -path './testbin/*' -print0 \
+find . -regextype egrep -regex '.*ya{0,1}ml$' \
+    -not -path './*/vendor/*' \
+    -not -path './bin/*' \
+    -not -path './git/*' \
+    -not -path './testbin/*' \
+    -not -path './vendor/*' \
+    -not -path './telco5g-konflux/*' \
+    -print0 \
     | xargs -0 --no-run-if-empty yamllint -c .yamllint.yaml


### PR DESCRIPTION
Exclude telco5g-konflux subproject from linters
- We do not want to lint the submodule since it may or may not have the same linters running
- This should fix the `ci-job` failure