### PR TITLE
Sort on-cel-expression file paths && add telco5g-konflux to it

### DIFF
--- a/.tekton/lifecycle-agent-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-4-20-pull-request.yaml
@@ -13,23 +13,25 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/lifecycle-agent-4-20-pull-request.yaml'.pathChanged() ||
         'api/***'.pathChanged() ||
         'config/***'.pathChanged() ||
         'controllers/***'.pathChanged() ||
-        'lca-cli'.pathChanged() ||
+        'Dockerfile'.pathChanged() ||
+        'go.mod'.pathChanged() ||
+        'go.sum'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'internal/***'.pathChanged() ||
+        'lca-cli'.pathChanged() ||
         'main/***'.pathChanged() ||
         'must-gather/***'.pathChanged() ||
         'pkg/***'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
         'utils/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
-        'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged() ||
-        '.tekton/lifecycle-agent-4-20-pull-request.yaml'.pathChanged() ||
-        'Dockerfile'.pathChanged()
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/lifecycle-agent-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-4-20-push.yaml
@@ -13,23 +13,25 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/lifecycle-agent-4-20-push.yaml'.pathChanged() ||
         'api/***'.pathChanged() ||
         'config/***'.pathChanged() ||
         'controllers/***'.pathChanged() ||
-        'lca-cli'.pathChanged() ||
+        'Dockerfile'.pathChanged() ||
+        'go.mod'.pathChanged() ||
+        'go.sum'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'internal/***'.pathChanged() ||
+        'lca-cli'.pathChanged() ||
         'main/***'.pathChanged() ||
         'must-gather/***'.pathChanged() ||
         'pkg/***'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
         'utils/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
-        'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged() ||
-        '.tekton/lifecycle-agent-4-20-push.yaml'.pathChanged() ||
-        'Dockerfile'.pathChanged()
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/lifecycle-agent-fbc-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-fbc-4-20-pull-request.yaml
@@ -13,12 +13,14 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
+        '.konflux/catalog/***'.pathChanged() ||
+        '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/Dockerfile.catalog'.pathChanged() ||
         '.tekton/fbc-pipeline.yaml'.pathChanged() ||
         '.tekton/images-mirror-set.yaml'.pathChanged() ||
         '.tekton/lifecycle-agent-fbc-4-20-pull-request.yaml'.pathChanged() ||
-        '.konflux/catalog/***'.pathChanged() ||
-        '.konflux/container_build_args.conf'.pathChanged() ||
-        '.konflux/Dockerfile.catalog'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/lifecycle-agent-fbc-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-fbc-4-20-push.yaml
@@ -12,12 +12,14 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
+        '.konflux/catalog/***'.pathChanged() ||
+        '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/Dockerfile.catalog'.pathChanged() ||
         '.tekton/fbc-pipeline.yaml'.pathChanged() ||
         '.tekton/images-mirror-set.yaml'.pathChanged() ||
         '.tekton/lifecycle-agent-fbc-4-20-push.yaml'.pathChanged() ||
-        '.konflux/catalog/***'.pathChanged() ||
-        '.konflux/container_build_args.conf'.pathChanged() ||
-        '.konflux/Dockerfile.catalog'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml
@@ -13,15 +13,17 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/Dockerfile.bundle'.pathChanged() ||
+        '.konflux/overlay/***'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml'.pathChanged() ||
         'bundle/***'.pathChanged() ||
         'config/***'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'manifests/***'.pathChanged() ||
-        '.konflux/overlay/***'.pathChanged() ||
-        '.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml'.pathChanged() ||
-        '.konflux/Dockerfile.bundle'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml
@@ -13,15 +13,17 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/Dockerfile.bundle'.pathChanged() ||
+        '.konflux/overlay/***'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml'.pathChanged() ||
         'bundle/***'.pathChanged() ||
         'config/***'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'manifests/***'.pathChanged() ||
-        '.konflux/overlay/***'.pathChanged() ||
-        '.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml'.pathChanged() ||
-        '.konflux/Dockerfile.bundle'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged()
       )
   creationTimestamp: null
   labels:


### PR DESCRIPTION
- Sorting them will make it easier to keep the paths sane going forward
- Since the library scripts are used by the tekton builds, changes there should trigger the builds

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/