### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lifecycle-agent

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -109,6 +109,10 @@ spec:
       default: docker
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - default: []
+      description: Additional labels to apply to the built container image
+      name: additional-labels
+      type: array
   results:
     - description: ''
       name: IMAGE_URL
@@ -254,12 +258,13 @@ spec:
         - name: LABELS
           value:
             - $(tasks.generate-labels.results.labels[*])
+            - $(params.additional-labels[*])
             - com.redhat.component=lifecycle-agent-operator-container
             - description=lifecycle-agent
             - distribution-scope=public
             - io.k8s.description=lifecycle-agent
-            - name=openshift4/lifecycle-agent-operator-bundle
             - release=4.20
+            - cpe="cpe:/a:redhat:openshift:4.20::el9"
             - url=https://github.com/openshift-kni/lifecycle-agent
             - vendor=Red Hat, Inc.
             - io.k8s.display-name=lifecycle-agent

--- a/.tekton/lifecycle-agent-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-4-20-pull-request.yaml
@@ -70,6 +70,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/lifecycle-agent-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/lifecycle-agent-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-4-20-push.yaml
@@ -68,6 +68,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/lifecycle-agent-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml
+++ b/.tekton/lifecycle-agent-operator-bundle-4-20-pull-request.yaml
@@ -66,6 +66,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/lifecycle-agent-rhel9-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml
+++ b/.tekton/lifecycle-agent-operator-bundle-4-20-push.yaml
@@ -64,6 +64,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/lifecycle-agent-rhel9-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Based on original changes from @rbean in our other operator repos

Assisted-by: Gemini
