### PR TITLE
CNF-19739: Add missing EUS repos to rpm lock configuration

### DIFF
--- a/.konflux/lock-runtime/rpms.in.yaml
+++ b/.konflux/lock-runtime/rpms.in.yaml
@@ -20,6 +20,20 @@ contentOrigin:
       metadata_expire: "86400"
       enabled_metadata: "1"
       varsFromContainerfile: Dockerfile
+    - repoid: rhel-9-for-$basearch-appstream-eus-rpms
+      name: Red Hat Enterprise Linux 9 for $basearch - AppStream EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/appstream/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-baseos-rpms
       name: Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
       baseurl: https://cdn.redhat.com/content/dist/rhel9/{version}/$basearch/baseos/os
@@ -34,9 +48,37 @@ contentOrigin:
       metadata_expire: "86400"
       enabled_metadata: "1"
       varsFromContainerfile: Dockerfile
+    - repoid: rhel-9-for-$basearch-baseos-eus-rpms
+      name: Red Hat Enterprise Linux 9 for $basearch - BaseOS EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/baseos/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
     - repoid: codeready-builder-for-rhel-9-$basearch-rpms
       name: Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
       baseurl: https://cdn.redhat.com/content/dist/rhel9/{version}/$basearch/codeready-builder/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
+    - repoid: codeready-builder-for-rhel-9-$basearch-eus-rpms
+      name: Red Hat CodeReady Linux Builder for RHEL 9 $basearch EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/codeready-builder/os
       enabled: "1"
       gpgcheck: "1"
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/.konflux/lock-runtime/rpms.lock.yaml
+++ b/.konflux/lock-runtime/rpms.lock.yaml
@@ -4,13 +4,6 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/r/rsync-3.2.3-19.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 405826
-    checksum: sha256:2836c96b161dff16224516e22a55e9ad2fbe1278e482caec1332cbc19812419e
-    name: rsync
-    evr: 3.2.3-19.el9
-    sourcerpm: rsync-3.2.3-19.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/t/tar-1.34-6.el9_4.1.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 900224
@@ -25,17 +18,17 @@ arches:
     name: util-linux-core
     evr: 2.37.4-18.el9
     sourcerpm: util-linux-2.37.4-18.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/r/rsync-3.2.3-19.el9_4.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 404393
+    checksum: sha256:86802e6f9fa68bcef00aabe04bcf601201292cf9bf79370992d11dbb853ddc1c
+    name: rsync
+    evr: 3.2.3-19.el9_4.1
+    sourcerpm: rsync-3.2.3-19.el9_4.1.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/r/rsync-3.2.3-19.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 411313
-    checksum: sha256:ee29f2138b7f732ba3e552281c4bdf56c71112a17c19dd941135aa56c22cb2c8
-    name: rsync
-    evr: 3.2.3-19.el9
-    sourcerpm: rsync-3.2.3-19.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/t/tar-1.34-6.el9_4.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 910343
@@ -50,5 +43,12 @@ arches:
     name: util-linux-core
     evr: 2.37.4-18.el9
     sourcerpm: util-linux-2.37.4-18.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/r/rsync-3.2.3-19.el9_4.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 409798
+    checksum: sha256:9202697f872c6bce4e3be7ed61eaa15fc48bf76673ce8f3a48fe94c414a5f783
+    name: rsync
+    evr: 3.2.3-19.el9_4.1
+    sourcerpm: rsync-3.2.3-19.el9_4.1.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
[CNF-19739](https://issues.redhat.com//browse/CNF-19739): Add missing EUS repos to rpm lock configuration
- This is required to receive updated packages for each 9.x release
- Re-run lock generation to update all packages