### PR TITLE
Fix image pins

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:5881ad12e8b6ae8abc5b4743e9e8e688236430eaa90bf101b8b7160ad16d8f12
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:c2a766e3a5d7c78003cc44c62525a2c25b35cfc0c20019e10a3ae46a374d05c7

--- a/.konflux/overlay/pin_images.in.yaml
+++ b/.konflux/overlay/pin_images.in.yaml
@@ -2,10 +2,10 @@
 # Manager
 - key: manager
   source: quay.io/openshift-kni/lifecycle-agent-operator:4.20.0
-  target: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-4-20@sha256:90725be7eb4d7462f8c3ac3cac63167b3348c64a7fb7adb2fbfff0874d714371
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-4-20@sha256:8b42d348593544124433ecf019592dc42b73ec308b3a5e94be24caafab4c8df8
 #
 # Recert
 - key: recert_image
   source: quay.io/edge-infrastructure/recert:v0
-  target: quay.io/redhat-user-workloads/telco-5g-tenant/recert-4-20@sha256:1c9b498c07c875dcff95f815cef430ff4a6c08af123651bff5dc7f7f8c3ee515
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/recert-4-20@sha256:dbefcd6623d768b9518485cca25af075b6dd4ff561a6f781811230472716e1f7
 #


### PR DESCRIPTION
- Due to an outage, the FBC failed to publish but the images were pushed to staging
- Reset image pins to the ones on staging to fix FBC
