### PR TITLE
CNF-19873: Bump versions used by lifecycle-agent build

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.20
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/.konflux/Dockerfile.catalog
+++ b/.konflux/Dockerfile.catalog
@@ -1,5 +1,5 @@
 # The opm image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
+ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 # CNF-18555: When there is a Konflux build available for this then we need to update from the brew image
 ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24
 

--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -8,13 +8,13 @@ BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_go
 #
 
 # The openshift cli image is used to fetch the oc binary
-# When 4.20 is released, we need to update from the v4.18 tag
-OPENSHIFT_CLI_IMAGE=registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:3444e5c4f1858158fed73899c3aa2810f387d78ca0f58468a9c5296bb42765ca
+# When 4.21 is released, we need to update from the v4.20 tag
+OPENSHIFT_CLI_IMAGE=registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:c69995f11a43e6173a2d05d5912f391488655cce7f0507cde51325fcd1e36911
 #
 
 # The opm image is used to serve the FBC
 # There is a metadata processing bug preventing us from pinning this particular image for now
-# OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20@sha256:10c6d4fb1eca7285f61656002265e9e9bdc915b6b7d53a828b175dab54237d0c
+# OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21@sha256:e3f4a76ebf5d6587b7738b548ee5c2d79a946162a63f415df1f27f04e6d255dc
 #
 
 # The runtime image is used to run the binaries


### PR DESCRIPTION
- Now that 4.20.0 is released, we have a few things that need to be updated

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/
