### PR TITLE
[release-4.20] CNF-19873: Bump oc image used in 4.20

### DIFF
--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -8,8 +8,7 @@ BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_go
 #
 
 # The openshift cli image is used to fetch the oc binary
-# When 4.20 is released, we need to update from the v4.18 tag
-OPENSHIFT_CLI_IMAGE=registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:3444e5c4f1858158fed73899c3aa2810f387d78ca0f58468a9c5296bb42765ca
+OPENSHIFT_CLI_IMAGE=registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:c69995f11a43e6173a2d05d5912f391488655cce7f0507cde51325fcd1e36911
 #
 
 # The opm image is used to serve the FBC


### PR DESCRIPTION
- Now that the release is completed, we should use the correct oc image

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/
