### PR TITLE
[release-4.19] CNF-19873: Fix oc image used in 4.19

### DIFF
--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -7,8 +7,7 @@ BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_go
 #
 
 # The openshift cli image is used to fetch the oc binary
-# When 4.19 is released, we need to update from the v4.18 tag
-OPENSHIFT_CLI_IMAGE=registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:3444e5c4f1858158fed73899c3aa2810f387d78ca0f58468a9c5296bb42765ca
+OPENSHIFT_CLI_IMAGE=registry.redhat.io/openshift4/ose-cli-rhel9:v4.19@sha256:5d5bd5c125a3713986e2d3c37b65c442fbea9f47f80c01e07b35a51092274cfc
 #
 
 # The opm image is used to serve the FBC


### PR DESCRIPTION
- We should have done this awhile ago, better late than never

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/
