### PR TITLE
[OCPBUGS-60642] [backport] release-4.19 adding must-gather-image annotation to the lifecycle-agent csv

### DIFF
--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -70,6 +70,7 @@ metadata:
         }
       }
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/must-gather-image: quay.io/openshift-kni/lifecycle-agent-operator:4.19.0
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.28.0

--- a/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
+++ b/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
@@ -31,6 +31,7 @@ metadata:
         }
       }
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/must-gather-image: $(PRECACHE_WORKLOAD_IMG)
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     provider: Red Hat

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,5 +1,13 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
+vars:
+  - name: PRECACHE_WORKLOAD_IMG
+    objref:
+      kind: Deployment
+      name: controller-manager
+      apiVersion: apps/v1
+    fieldref:
+      fieldpath: spec.template.spec.containers[0].env[0].value
 resources:
 - bases/lifecycle-agent.clusterserviceversion.yaml
 - ../default


### PR DESCRIPTION
# [OCPBUGS-60642] Add must-gather-image annotation to lifecycle-agent CSV

## Description

This PR adds the `operators.openshift.io/must-gather-image` annotation to the lifecycle-agent ClusterServiceVersion (CSV). This annotation specifies the container image that should be used when running `oc adm must-gather` for the lifecycle-agent operator.

## What Changed

### Files Modified:
1. **`config/manifests/kustomization.yaml`**
   - Added `vars` section to define `PRECACHE_WORKLOAD_IMG` variable
   - This variable references the controller-manager deployment's environment variable

2. **`config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml`**
   - Added `operators.openshift.io/must-gather-image: $(PRECACHE_WORKLOAD_IMG)` annotation
   - The variable will be substituted during bundle generation

3. **`bundle/manifests/lifecycle-agent.clusterserviceversion.yaml`**
   - Generated file now contains the populated annotation with the actual image reference
   - For 4.19: `quay.io/openshift-kni/lifecycle-agent-operator:4.19.0`

## Why This Change Is Needed

The `must-gather-image` annotation is required to:
- Enable proper must-gather support for the lifecycle-agent operator
- Allow cluster administrators to collect diagnostic information using the correct container image
- Follow OpenShift operator best practices for debugging and support

Without this annotation, the must-gather tool would not know which image to use when collecting lifecycle-agent diagnostic data.

## Implementation Details

The implementation uses Kustomize's `vars` feature to:
1. Reference the `PRECACHE_WORKLOAD_IMG` environment variable from the controller-manager deployment
2. Inject this value into the CSV's `must-gather-image` annotation during bundle generation
3. Ensure the annotation always matches the operator's actual image version

**Note:** While Kustomize's `vars` feature is deprecated in favor of `replacements`, this approach maintains consistency with the existing codebase patterns and will continue to function correctly.

## Testing

### Verify Bundle Generation
```bash
make bundle
```

### Verify Annotation
Check that the annotation is present in the generated CSV:
```bash
grep "must-gather-image" bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
```

Expected output:
```yaml
operators.openshift.io/must-gather-image: quay.io/openshift-kni/lifecycle-agent-operator:4.19.0
```

### Verify Bundle Check
Ensure all changes are committed and the bundle is in sync:
```bash
make bundle-check
```

Expected output: `git tree is clean`

## Related Issues

- Resolves: OCPBUGS-60642
- Related: [PR #2750](https://github.com/openshift-kni/lifecycle-agent/pull/2750) (main branch)

## Checklist

- [x] Changes follow the project's coding standards
- [x] Bundle has been regenerated with `make bundle`
- [x] Bundle validation passes
- [x] All modified files are included in the commit
- [x] Commit message follows the project's conventions
- [ ] CI checks pass
