### PR TITLE
chore: Override compute resources for a task that was OOMKilled yesterday

### DIFF
--- a/.tekton/lifecycle-agent-4-14-pull-request.yaml
+++ b/.tekton/lifecycle-agent-4-14-pull-request.yaml
@@ -76,6 +76,15 @@ spec:
     name: build-pipeline
   taskRunTemplate:
     serviceAccountName: build-pipeline-lifecycle-agent-4-14
+  taskRunSpecs:
+    - pipelineTaskName: validate-fbc
+      stepSpecs:
+        - name: extract-and-validate
+          computeResources:
+            requests:
+              memory: 10Gi
+            limits:
+              memory: 10Gi
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/lifecycle-agent-4-14-push.yaml
+++ b/.tekton/lifecycle-agent-4-14-push.yaml
@@ -74,6 +74,15 @@ spec:
     name: build-pipeline
   taskRunTemplate:
     serviceAccountName: build-pipeline-lifecycle-agent-4-14
+  taskRunSpecs:
+    - pipelineTaskName: validate-fbc
+      stepSpecs:
+        - name: extract-and-validate
+          computeResources:
+            requests:
+              memory: 10Gi
+            limits:
+              memory: 10Gi
   workspaces:
     - name: git-auth
       secret:


### PR DESCRIPTION
Created by following https://konflux-ci.dev/docs/building/overriding-compute-resources/

This is in regards to discussion in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1762327151283939?thread_ts=1761229009.276159&cid=C04PZ7H0VA8