### PR TITLE
Operator image should build when lock-runtime is changed

### DIFF
--- a/.tekton/lifecycle-agent-4-21-pull-request.yaml
+++ b/.tekton/lifecycle-agent-4-21-pull-request.yaml
@@ -14,6 +14,7 @@ metadata:
       target_branch == "main" &&
       (
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/lock-runtime/***'.pathChanged() ||
         '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.tekton/lifecycle-agent-4-21-pull-request.yaml'.pathChanged() ||
         'api/***'.pathChanged() ||

--- a/.tekton/lifecycle-agent-4-21-push.yaml
+++ b/.tekton/lifecycle-agent-4-21-push.yaml
@@ -14,6 +14,7 @@ metadata:
       target_branch == "main" &&
       (
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/lock-runtime/***'.pathChanged() ||
         '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.tekton/lifecycle-agent-4-21-push.yaml'.pathChanged() ||
         'api/***'.pathChanged() ||


### PR DESCRIPTION
- Changes to rpm inputs or outputs should absolutely trigger a build
