### PR TITLE
MGMT-21789: Implement new IP Configuration flow in lca-cli tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /cache
 /bundle-*
 testbin/*
+/build
 
 # Test binary, build with `go test -c`
 *.test

--- a/controllers/rollback_handlers.go
+++ b/controllers/rollback_handlers.go
@@ -174,7 +174,7 @@ func (r *ImageBasedUpgradeReconciler) finishRollback(ibu *ibuv1.ImageBasedUpgrad
 
 //nolint:unparam
 func (r *ImageBasedUpgradeReconciler) handleRollback(ctx context.Context, ibu *ibuv1.ImageBasedUpgrade) (ctrl.Result, error) {
-	origStaterootBooted, err := r.RebootClient.IsOrigStaterootBooted(ibu)
+	origStaterootBooted, err := r.RebootClient.IsOrigStaterootBooted(ibu.Spec.SeedImageRef.Version)
 	if err != nil {
 		utils.SetRollbackStatusFailed(ibu, err.Error())
 		return doNotRequeue(), nil

--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -76,7 +76,7 @@ var (
 func (r *ImageBasedUpgradeReconciler) handleUpgrade(ctx context.Context, ibu *ibuv1.ImageBasedUpgrade) (ctrl.Result, error) {
 	r.Log.Info("Starting handleUpgrade")
 
-	origStaterootBooted, err := r.RebootClient.IsOrigStaterootBooted(ibu)
+	origStaterootBooted, err := r.RebootClient.IsOrigStaterootBooted(ibu.Spec.SeedImageRef.Version)
 
 	if err != nil {
 		utils.SetUpgradeStatusFailed(ibu, err.Error())

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -47,14 +47,17 @@ const (
 	OvnIcEtcFolder = "/var/lib/ovn-ic/etc"
 	OvnNodeCerts   = OvnIcEtcFolder + "/ovnkube-node-certs"
 
-	MultusCerts  = "/etc/cni/multus/certs"
-	ChronyConfig = "/etc/chrony.conf"
+	MultusCerts   = "/etc/cni/multus/certs"
+	ChronyConfig  = "/etc/chrony.conf"
+	OvsConfDb     = "/etc/openvswitch/conf.db"
+	OvsConfDbLock = "/etc/openvswitch/.conf.db.~lock~"
 
 	SSHServerKeysDirectory = "/etc/ssh"
 
 	MCDCurrentConfig = "/etc/machine-config-daemon/currentconfig"
 
 	InstallationConfigurationFilesDir = "/usr/local/installation_configuration_files"
+	IPConfigurationFilesDir           = "/usr/local/ip_configuration_files"
 	OptOpenshift                      = "/opt/openshift"
 	SeedDataDir                       = "/var/seed_data"
 	KubeconfigCryptoDir               = "kubeconfig-crypto"
@@ -69,11 +72,24 @@ const (
 	LvmDevicesPath                    = "/etc/lvm/devices/system.devices"
 	CABundleFilePath                  = "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"
 
-	LCAConfigDir                                    = "/var/lib/lca"
+	LCAConfigDir                      = "/var/lib/lca"
+	LCAWorkspaceDir                   = LCAConfigDir + "/workspace"
+	IPConfigRunFlagsFile              = LCAWorkspaceDir + "/ip-config-run.json"
+	IPConfigRunPullSecretFile         = LCAWorkspaceDir + "/recert-pull-secret.json"
+	IPConfigRunStatusFile             = LCAWorkspaceDir + "/ip-config-run-status.json"
+	IPConfigPrepareStatusFile         = LCAWorkspaceDir + "/ip-config-prepare-status.json"
+	IPConfigRollbackStatusFile        = LCAWorkspaceDir + "/ip-config-rollback-status.json"
+	IPConfigMonitorRollbackMarkerFile = LCAWorkspaceDir + "/ip-config-monitor-rollback-status.done"
+	IPCAutoRollbackConfigFile         = LCAWorkspaceDir + "/ip-config-autorollback-config.json"
+
 	IBUAutoRollbackConfigFile                       = LCAConfigDir + "/autorollback_config.json"
-	IBUAutoRollbackInitMonitorTimeoutDefaultSeconds = 1800
+	IBUAutoRollbackInitMonitorTimeoutDefaultSeconds = 1800 // 30 minutes
 	IBUInitMonitorService                           = "lca-init-monitor.service"
 	IBUInitMonitorServiceFile                       = "/etc/systemd/system/" + IBUInitMonitorService
+	IPCAutoRollbackInitMonitorTimeoutDefaultSeconds = 1800 // 30 minutes
+	IPCInitMonitorService                           = "lca-init-monitor.service"
+	// InitMonitorModeFile configures which mode the init-monitor should operate in ("ibu" or "ipconfig")
+	InitMonitorModeFile = LCAWorkspaceDir + "/initmonitor_mode"
 	// AutoRollbackOnFailurePostRebootConfigAnnotation configure automatic rollback when the reconfiguration of the cluster fails upon the first reboot.
 	// Only acceptable value is AutoRollbackDisableValue. Any other value is treated as "Enabled".
 	AutoRollbackOnFailurePostRebootConfigAnnotation = "auto-rollback-on-failure.lca.openshift.io/post-reboot-config"
@@ -83,6 +99,9 @@ const (
 	// AutoRollbackOnFailureInitMonitorAnnotation configure automatic rollback LCA Init Monitor watchdog, which triggers auto-rollback if timeout occurs before upgrade completion
 	// Only acceptable value is AutoRollbackDisableValue. Any other value is treated as "Enabled".
 	AutoRollbackOnFailureInitMonitorAnnotation = "auto-rollback-on-failure.lca.openshift.io/init-monitor"
+	// AutoRollbackOnFailureIPConfigRunAnnotation configure automatic rollback when the IP config run fails.
+	// Only acceptable value is AutoRollbackDisableValue. Any other value is treated as "Enabled".
+	AutoRollbackOnFailureIPConfigRunAnnotation = "auto-rollback-on-failure.lca.openshift.io/ip-config-run"
 	// AutoRollbackDisableValue value that decides if rollback is disabled
 	AutoRollbackDisableValue = "Disabled"
 	// ContainerStorageUsageThresholdPercentAnnotation overrides default /var/lib/containers disk usage threshold for image cleanup
@@ -131,6 +150,34 @@ const (
 	IBIWorkspace = "var/tmp"
 
 	ContainerStoragePath = "/var/lib/containers"
+
+	DnsmasqOverrides = "/etc/default/sno_dnsmasq_configuration_overrides"
+
+	IPConfigName = "ipconfig"
+
+	// DNS family names
+	IPv4FamilyName = "ipv4"
+	IPv6FamilyName = "ipv6"
+)
+
+// DNSMasq-related constants
+const (
+	// MachineConfig name that carries dnsmasq configuration
+	DnsmasqMachineConfigName = "50-master-dnsmasq-configuration"
+	// Path where the single-node filter configuration is placed
+	DnsmasqFilterTargetPath = "/etc/dnsmasq.d/single-node-filter.conf"
+	// Filter directives based on IP family
+	DnsmasqFilterIPv4 = "filter-AAAA\n"
+	DnsmasqFilterIPv6 = "filter-A\n"
+	// Data URL template used for embedding file contents in ignition (URL-encoded body)
+	DataURLBase64Template = "data:text/plain;charset=utf-8,%s"
+	// Ignition version used when creating/updating configs
+	IgnitionVersion32 = "3.2.0"
+	// Environment key written to dnsmasq override file for the IP override
+	DnsmasqOverrideEnvKeyIP = "SNO_DNSMASQ_IP_OVERRIDE"
+	// Common file permission modes
+	FileMode0644 = 420 // 0644
+	FileMode0600 = 384 // 0600
 )
 
 // Annotation names and values related to extra manifest

--- a/internal/common/ipc.go
+++ b/internal/common/ipc.go
@@ -1,0 +1,195 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WriteIPConfigStatus writes the given status struct to the provided file path.
+func WriteIPConfigStatus(filePath string, st IPConfigStatus) error {
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	data, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("failed to marshal IPConfigStatus for %s: %w", filePath, err)
+	}
+
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write IPConfigStatus file %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// FinalizeIPConfigStatus sets final phase, message and finishedAt in the given file.
+// If a previous status exists, StartedAt is preserved.
+func FinalizeIPConfigStatus(filePath string, phase IPConfigStatusType, msg string) error {
+	st := IPConfigStatus{Phase: phase, Message: msg, FinishedAt: time.Now().UTC().Format(time.RFC3339)}
+	if data, err := os.ReadFile(filePath); err == nil && len(data) > 0 {
+		var prev IPConfigStatus
+		if jsonErr := json.Unmarshal(data, &prev); jsonErr == nil {
+			st.StartedAt = prev.StartedAt
+		}
+	}
+	return WriteIPConfigStatus(filePath, st)
+}
+
+type IPConfigRunConfig struct {
+	IPv4Address        string `json:"ipv4-address,omitempty"`
+	IPv4MachineNetwork string `json:"ipv4-machine-network,omitempty"`
+	IPv6Address        string `json:"ipv6-address,omitempty"`
+	IPv6MachineNetwork string `json:"ipv6-machine-network,omitempty"`
+	IPv4Gateway        string `json:"ipv4-gateway,omitempty"`
+	IPv6Gateway        string `json:"ipv6-gateway,omitempty"`
+	IPv4DNSServer      string `json:"ipv4-dns,omitempty"`
+	IPv6DNSServer      string `json:"ipv6-dns,omitempty"`
+	VLANID             int    `json:"vlan-id,omitempty"`
+	HTTPProxy          string `json:"http-proxy,omitempty"`
+	HTTPSProxy         string `json:"https-proxy,omitempty"`
+	NoProxy            string `json:"no-proxy,omitempty"`
+	StatusHTTPProxy    string `json:"status-http-proxy,omitempty"`
+	StatusHTTPSProxy   string `json:"status-https-proxy,omitempty"`
+	StatusNoProxy      string `json:"status-no-proxy,omitempty"`
+	PullSecretRefName  string `json:"pull-secret-ref-name,omitempty"`
+	RecertImage        string `json:"recert-image,omitempty"`
+	DNSIPFamily        string `json:"dns-ip-family,omitempty"`
+}
+
+// IPConfigStatusPhase enumerates phases of the ip-config lifecycle.
+// Values are persisted to a JSON file; keep names stable.
+type IPConfigStatusType string
+
+const (
+	IPConfigStatusUnknown   IPConfigStatusType = "unknown"
+	IPConfigStatusRunning   IPConfigStatusType = "running"
+	IPConfigStatusSucceeded IPConfigStatusType = "succeeded"
+	IPConfigStatusFailed    IPConfigStatusType = "failed"
+)
+
+// IPConfigStatus describes current state of lca-cli ip-config run.
+type IPConfigStatus struct {
+	// Phase: running/succeeded/failed
+	Phase IPConfigStatusType `json:"phase"`
+	// Message: short human-readable summary
+	Message string `json:"message,omitempty"`
+	// StartedAt/FinishedAt are RFC3339 timestamps for observability
+	StartedAt  string `json:"startedAt,omitempty"`
+	FinishedAt string `json:"finishedAt,omitempty"`
+}
+
+// SetDNSMasqFilterInMachineConfig updates the dnsmasq MachineConfig to filter DNS answers
+// according to the desired IP family ("ipv4" or "ipv6").
+func SetDNSMasqFilterInMachineConfig(
+	ctx context.Context,
+	k8sClient runtimeclient.Client,
+	family string,
+) error {
+	var filterLine string
+	switch family {
+	case IPv4FamilyName:
+		filterLine = DnsmasqFilterIPv4
+	case IPv6FamilyName:
+		filterLine = DnsmasqFilterIPv6
+	default:
+		return fmt.Errorf("unsupported DNS IP family: %s", family)
+	}
+
+	encoded := url.PathEscape(filterLine)
+	source := fmt.Sprintf(DataURLBase64Template, encoded)
+
+	existingMC := &machineconfigv1.MachineConfig{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: DnsmasqMachineConfigName}, existingMC); err != nil {
+		return fmt.Errorf("failed to get existing machine config %s: %w", DnsmasqMachineConfigName, err)
+	}
+
+	var cfg igntypes.Config
+	if len(existingMC.Spec.Config.Raw) > 0 {
+		if err := json.Unmarshal(existingMC.Spec.Config.Raw, &cfg); err != nil {
+			return fmt.Errorf("failed to parse ignition config in %s: %w", DnsmasqMachineConfigName, err)
+		}
+	}
+	if cfg.Ignition.Version == "" {
+		cfg.Ignition.Version = IgnitionVersion32
+	}
+
+	trueVal := true
+	modeVal := FileMode0644
+	newFile := igntypes.File{
+		Node: igntypes.Node{
+			Path:      DnsmasqFilterTargetPath,
+			Overwrite: &trueVal,
+		},
+		FileEmbedded1: igntypes.FileEmbedded1{
+			Mode: &modeVal,
+			Contents: igntypes.Resource{
+				Source: &source,
+			},
+		},
+	}
+
+	updated := false
+	for idx, f := range cfg.Storage.Files {
+		if f.Path == DnsmasqFilterTargetPath {
+			if f.Contents.Source != nil && *f.Contents.Source == source {
+				// Already configured as desired
+				existingMC.Spec.Config = runtime.RawExtension{Raw: existingMC.Spec.Config.Raw}
+				return nil
+			}
+			cfg.Storage.Files[idx] = newFile
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		cfg.Storage.Files = append(cfg.Storage.Files, newFile)
+	}
+
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated ignition for %s: %w", DnsmasqMachineConfigName, err)
+	}
+	existingMC.Spec.Config = runtime.RawExtension{Raw: raw}
+
+	if err := k8sClient.Update(ctx, existingMC); err != nil {
+		return fmt.Errorf("failed to update machine config %s: %w", DnsmasqMachineConfigName, err)
+	}
+
+	return nil
+}
+
+// DetectClusterIPFamilies inspects cluster info to determine whether the
+// cluster is configured with IPv4, IPv6, or both (dual-stack).
+func DetectClusterIPFamilies(ips []string) (bool, bool) {
+	var nodeIPv4, nodeIPv6 string
+	for _, ip := range ips {
+		if strings.Contains(ip, ":") {
+			if nodeIPv6 == "" {
+				nodeIPv6 = ip
+			}
+		} else {
+			if nodeIPv4 == "" {
+				nodeIPv4 = ip
+			}
+		}
+	}
+
+	clusterHasIPv4 := nodeIPv4 != ""
+	clusterHasIPv6 := nodeIPv6 != ""
+
+	return clusterHasIPv4, clusterHasIPv6
+}

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 
 	"io"
 	"os"
@@ -125,8 +126,8 @@ func GetStaterootCertsDir(ibu *ibuv1.ImageBasedUpgrade) string {
 	return PathOutsideChroot(filepath.Join(GetStaterootOptOpenshift(GetStaterootPath(GetDesiredStaterootName(ibu))), KubeconfigCryptoDir))
 }
 
-func GetStaterootName(seedImageVersion string) string {
-	return fmt.Sprintf("rhcos_%s", strings.ReplaceAll(seedImageVersion, "-", "_"))
+func GetStaterootName(identifier string) string {
+	return fmt.Sprintf("rhcos_%s", strings.ReplaceAll(identifier, "-", "_"))
 }
 
 func RemoveDuplicates[T comparable](list []T) []T {
@@ -208,4 +209,41 @@ func GenerateDeleteOptions() *client.DeleteOptions {
 		PropagationPolicy: &propagationPolicy,
 	}
 	return &delOpt
+}
+
+func SanitizeForOsname(s string) string {
+	s = strings.Trim(s, "[]")
+	s = strings.Split(s, "/")[0]
+	re := regexp.MustCompile(`[^A-Za-z0-9]+`)
+	return re.ReplaceAllString(s, "-")
+}
+
+// IPConfigStaterootParams represents the parameters used to build a new stateroot name for IP configuration
+// Each of the spec values the user can change such that unique stateroot name is generated are represented here.
+type IPConfigStaterootParams struct {
+	IPv4Address string
+	IPv6Address string
+	VLANID      string
+	DNSIPFamily string
+}
+
+func BuildNewStaterootNameForIPConfig(params IPConfigStaterootParams) string {
+	parts := []string{"rhcos"}
+	if params.IPv4Address != "" {
+		parts = append(parts, SanitizeForOsname(params.IPv4Address))
+	}
+
+	if params.IPv6Address != "" {
+		parts = append(parts, SanitizeForOsname(params.IPv6Address))
+	}
+
+	if params.VLANID != "" {
+		parts = append(parts, "vlan-"+SanitizeForOsname(params.VLANID))
+	}
+
+	if params.DNSIPFamily != "" {
+		parts = append(parts, "dns-"+SanitizeForOsname(params.DNSIPFamily))
+	}
+
+	return strings.Join(parts, "_")
 }

--- a/internal/prep/prep_test.go
+++ b/internal/prep/prep_test.go
@@ -2,8 +2,6 @@ package prep
 
 import (
 	"fmt"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,70 +43,6 @@ func TestGetDeploymentFromDeploymentID(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-		})
-	}
-}
-
-func TestGetKernelArgumentsFromMCOFile(t *testing.T) {
-	testcases := []struct {
-		name   string
-		data   string
-		expect []string
-	}{
-		{
-			name: "multiple args",
-			data: `{"spec":{"kernelArguments":[    "tsc=nowatchdog",
-			"nosoftlockup",                                                                                                                     
-            "cgroup_no_v1=\"all\"",
-			"nmi_watchdog=0",                                                                                                                   
-			"mce=off",                                                                                                                          
-			"rcutree.kthread_prio=11",
-			"default_hugepagesz=1G",                                        
-			"hugepagesz=1G",
-			"hugepages=32",
-			"rcupdate.rcu_normal_after_boot=0",                                                                                                 
-			"efi=runtime",                                                                                                                      
-			"vfio_pci.enable_sriov=1",                                                                                                          
-			"vfio_pci.disable_idle_d3=1",                                                                                                       
-			"module_blacklist=irdma",                                                                                                           
-			"intel_pstate=disable"         ]}}`,
-			expect: []string{
-				"--karg-append", "\"tsc=nowatchdog\"",
-				"--karg-append", "\"nosoftlockup\"",
-				"--karg-append", "\"cgroup_no_v1=\\\"all\\\"\"",
-				"--karg-append", "\"nmi_watchdog=0\"",
-				"--karg-append", "\"mce=off\"",
-				"--karg-append", "\"rcutree.kthread_prio=11\"",
-				"--karg-append", "\"default_hugepagesz=1G\"",
-				"--karg-append", "\"hugepagesz=1G\"",
-				"--karg-append", "\"hugepages=32\"",
-				"--karg-append", "\"rcupdate.rcu_normal_after_boot=0\"",
-				"--karg-append", "\"efi=runtime\"",
-				"--karg-append", "\"vfio_pci.enable_sriov=1\"",
-				"--karg-append", "\"vfio_pci.disable_idle_d3=1\"",
-				"--karg-append", "\"module_blacklist=irdma\"",
-				"--karg-append", "\"intel_pstate=disable\"",
-			},
-		},
-	}
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			// create fixture
-			f, err := os.CreateTemp("", "tmp")
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer os.Remove(f.Name())
-			if _, err := f.Write([]byte(tc.data)); err != nil {
-				log.Fatal(err)
-			}
-			if err := f.Close(); err != nil {
-				log.Fatal(err)
-			}
-
-			res, err := buildKernelArgumentsFromMCOFile(f.Name())
-			assert.Equal(t, tc.expect, res)
-			assert.NoError(t, err)
 		})
 	}
 }

--- a/internal/reboot/mock_reboot.go
+++ b/internal/reboot/mock_reboot.go
@@ -11,7 +11,6 @@ package reboot
 import (
 	reflect "reflect"
 
-	v1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -79,33 +78,47 @@ func (mr *MockRebootIntfMockRecorder) InitiateRollback(msg any) *gomock.Call {
 }
 
 // IsOrigStaterootBooted mocks base method.
-func (m *MockRebootIntf) IsOrigStaterootBooted(ibu *v1.ImageBasedUpgrade) (bool, error) {
+func (m *MockRebootIntf) IsOrigStaterootBooted(identifier string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsOrigStaterootBooted", ibu)
+	ret := m.ctrl.Call(m, "IsOrigStaterootBooted", identifier)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsOrigStaterootBooted indicates an expected call of IsOrigStaterootBooted.
-func (mr *MockRebootIntfMockRecorder) IsOrigStaterootBooted(ibu any) *gomock.Call {
+func (mr *MockRebootIntfMockRecorder) IsOrigStaterootBooted(identifier any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOrigStaterootBooted", reflect.TypeOf((*MockRebootIntf)(nil).IsOrigStaterootBooted), ibu)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOrigStaterootBooted", reflect.TypeOf((*MockRebootIntf)(nil).IsOrigStaterootBooted), identifier)
 }
 
-// ReadIBUAutoRollbackConfigFile mocks base method.
-func (m *MockRebootIntf) ReadIBUAutoRollbackConfigFile() (*IBUAutoRollbackConfig, error) {
+// ReadAutoRollbackConfigFile mocks base method.
+func (m *MockRebootIntf) ReadAutoRollbackConfigFile() (*AutoRollbackConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadIBUAutoRollbackConfigFile")
-	ret0, _ := ret[0].(*IBUAutoRollbackConfig)
+	ret := m.ctrl.Call(m, "ReadAutoRollbackConfigFile")
+	ret0, _ := ret[0].(*AutoRollbackConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadIBUAutoRollbackConfigFile indicates an expected call of ReadIBUAutoRollbackConfigFile.
-func (mr *MockRebootIntfMockRecorder) ReadIBUAutoRollbackConfigFile() *gomock.Call {
+// ReadAutoRollbackConfigFile indicates an expected call of ReadAutoRollbackConfigFile.
+func (mr *MockRebootIntfMockRecorder) ReadAutoRollbackConfigFile() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadIBUAutoRollbackConfigFile", reflect.TypeOf((*MockRebootIntf)(nil).ReadIBUAutoRollbackConfigFile))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAutoRollbackConfigFile", reflect.TypeOf((*MockRebootIntf)(nil).ReadAutoRollbackConfigFile))
+}
+
+// Reboot mocks base method.
+func (m *MockRebootIntf) Reboot(rationale string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reboot", rationale)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Reboot indicates an expected call of Reboot.
+func (mr *MockRebootIntfMockRecorder) Reboot(rationale any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reboot", reflect.TypeOf((*MockRebootIntf)(nil).Reboot), rationale)
 }
 
 // RebootToNewStateRoot mocks base method.

--- a/internal/reboot/reboot_test.go
+++ b/internal/reboot/reboot_test.go
@@ -58,9 +58,9 @@ func TestIsOrigStaterootBooted(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rebootClient := NewRebootClient(&tt.args.log, tt.args.executor, tt.args.r, tt.args.ostreeClient, tt.args.ops)
+			rebootClient := NewIBURebootClient(&tt.args.log, tt.args.executor, tt.args.r, tt.args.ostreeClient, tt.args.ops)
 			mockRpmostreeclient.EXPECT().GetCurrentStaterootName().Return(tt.currentStateRoot, nil).Times(1)
-			got, err := rebootClient.IsOrigStaterootBooted(tt.args.ibu)
+			got, err := rebootClient.IsOrigStaterootBooted(tt.args.ibu.Spec.SeedImageRef.Version)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IsOrigStaterootBooted() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/lca-cli/README.md
+++ b/lca-cli/README.md
@@ -62,12 +62,16 @@ Usage:
   lca-cli [command]
 
 Available Commands:
-  completion  Generate the autocompletion script for the specified shell
-  create      Create OCI image and push it to a container registry.
-  help        Help about any command
-  ibi         prepare ibi
-  post-pivot  post pivot configuration
-  restore     Restore seed cluster configurations
+  completion          Generate the autocompletion script for the specified shell
+  create              Create OCI image and push it to a container registry.
+  help                Help about any command
+  ibi                 prepare ibi
+  ibuPrecacheWorkload Start precache during IBU
+  ibuStaterootSetup   Setup a new stateroot during IBU
+  init-monitor        LCA Init Monitor
+  ip-config           IP configuration commands
+  post-pivot          post pivot configuration
+  restore             Restore seed cluster configurations
 
 Flags:
   -h, --help       help for lca-cli

--- a/lca-cli/cmd/ipconfig/common.go
+++ b/lca-cli/cmd/ipconfig/common.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfigcmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	sysrootPath = "/sysroot"
+)
+
+// buildOpsAndK8sClient creates the host executor, ops interface, and Kubernetes client
+// using the provided scheme. This logic is shared between the ip-config prepare and run flows.
+func buildOpsAndK8sClient(
+	scheme *runtime.Scheme,
+) (ops.Ops, ops.Execute, runtimeClient.Client, error) {
+	var hostCommandsExecutor ops.Execute
+	if _, err := os.Stat(common.Host); err == nil {
+		hostCommandsExecutor = ops.NewChrootExecutor(pkgLog, true, common.Host)
+	} else {
+		hostCommandsExecutor = ops.NewRegularExecutor(pkgLog, true)
+	}
+	opsInterface := ops.NewOps(pkgLog, hostCommandsExecutor)
+
+	k8sConfig, err := clientcmd.BuildConfigFromFlags("", common.PathOutsideChroot(common.KubeconfigFile))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create k8s config: %w", err)
+	}
+
+	client, err := runtimeClient.New(k8sConfig, runtimeClient.Options{Scheme: scheme})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create runtime client: %w", err)
+	}
+
+	return opsInterface, hostCommandsExecutor, client, nil
+}

--- a/lca-cli/cmd/ipconfig/prepare.go
+++ b/lca-cli/cmd/ipconfig/prepare.go
@@ -1,0 +1,334 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfigcmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/go-logr/logr"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	intOstree "github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
+	"github.com/openshift-kni/lifecycle-agent/internal/reboot"
+	lcacli "github.com/openshift-kni/lifecycle-agent/lca-cli"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ipconfig"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
+	rpmOstree "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ipPrepareScheme = runtime.NewScheme()
+
+	newStaterootName   string
+	installInitMonitor bool
+)
+
+const (
+	newStaterootNameFlag   = "new-stateroot-name"
+	installInitMonitorFlag = "install-init-monitor"
+	prepareCmd             = "prepare"
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(ipPrepareScheme))
+	utilruntime.Must(mcfgv1.AddToScheme(ipPrepareScheme))
+
+	ipConfigPrepareCmd.Flags().StringVar(&newStaterootName, newStaterootNameFlag, "", "New stateroot name")
+	ipConfigPrepareCmd.MarkFlagRequired(newStaterootNameFlag)
+	ipConfigPrepareCmd.Flags().BoolVar(
+		&installInitMonitor,
+		installInitMonitorFlag,
+		false,
+		"Install init monitor service in the new stateroot",
+	)
+}
+
+var ipConfigPrepareCmd = &cobra.Command{
+	Use:   prepareCmd,
+	Short: "Prepare a new stateroot for IP configuration change and reboot to it",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runIPConfigPrepare(); err != nil {
+			pkgLog.Fatalf("Error executing ip-config prepare: %v", err)
+		}
+	},
+}
+
+// runIPConfigPrepare orchestrates the ip-config "prepare" flow:
+// - sets up executors and logs flags
+// - gathers OSTree state for old/new stateroots
+// - writes progress status, runs preparation, optionally installs an init monitor
+// - finalizes status and reboots into the new stateroot
+func runIPConfigPrepare() error {
+	opsInterface, hostCommandsExecutor, client, err := buildOpsAndK8sClient(ipPrepareScheme)
+	if err != nil {
+		return err
+	}
+
+	logPrepareFlags()
+
+	rpmClient := rpmOstree.NewClient("lca-cli-ip-config-prepare", hostCommandsExecutor)
+	ostreeClient := intOstree.NewClient(hostCommandsExecutor, false)
+	rbClient := reboot.NewIPCRebootClient(
+		&logr.Logger{},
+		hostCommandsExecutor,
+		rpmClient,
+		ostreeClient,
+		opsInterface,
+	)
+
+	ostreeData, err := getOstreeData(newStaterootName, rpmClient, ostreeClient, pkgLog)
+	if err != nil {
+		return fmt.Errorf("failed to get ostree data: %w", err)
+	}
+
+	preparer := ipconfig.NewPrepareHandler(
+		pkgLog, opsInterface, ostreeData, ostreeClient, rpmClient, rbClient, client,
+	)
+	if err := common.WriteIPConfigStatus(common.IPConfigPrepareStatusFile, common.IPConfigStatus{
+		Phase:     common.IPConfigStatusRunning,
+		Message:   "ip-config prepare started",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		return fmt.Errorf("failed to write initial prepare status: %w", err)
+	}
+
+	ctx := context.Background()
+	if err := preparer.Run(ctx); err != nil {
+		internalErr := common.FinalizeIPConfigStatus(
+			common.IPConfigPrepareStatusFile,
+			common.IPConfigStatusFailed,
+			fmt.Sprintf("ip-config prepare failed: %v", err),
+		)
+		if internalErr != nil {
+			return fmt.Errorf("failed to finalize IP config prepare status: %w", internalErr)
+		}
+		return fmt.Errorf("failed to prepare ip config: %w", err)
+	}
+
+	if installInitMonitor {
+		err := installMonitorInitializationServiceInNewStateroot(
+			ostreeClient, opsInterface, ostreeData.NewStateroot.Name, pkgLog,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to install monitor initialization service: %w", err)
+		}
+
+		if err := cleanupMonitorInitializationServiceInOldStateroot(opsInterface, ostreeData); err != nil {
+			return fmt.Errorf("failed to cleanup monitor initialization service in old stateroot: %w", err)
+		}
+	}
+
+	staterootPath := common.GetStaterootPath(ostreeData.NewStateroot.Name)
+	statusFilePath := filepath.Join(staterootPath, common.IPConfigPrepareStatusFile)
+	if err := common.FinalizeIPConfigStatus(
+		statusFilePath,
+		common.IPConfigStatusSucceeded,
+		"ip-config prepare completed successfully",
+	); err != nil {
+		return fmt.Errorf("failed to mark prepare as successful: %w", err)
+	}
+
+	if err := common.FinalizeIPConfigStatus(
+		common.IPConfigPrepareStatusFile,
+		common.IPConfigStatusSucceeded,
+		"ip-config prepare completed successfully",
+	); err != nil {
+		return fmt.Errorf("failed to mark prepare as successful: %w", err)
+	}
+
+	if err := rbClient.RebootToNewStateRoot("ip-config prepare"); err != nil {
+		return fmt.Errorf("failed to reboot to new stateroot: %w", err)
+	}
+
+	return nil
+}
+
+// logPrepareFlags prints the flags used by the ip-config prepare command.
+func logPrepareFlags() {
+	pkgLog.Infof("ip-config prepare flags:")
+	pkgLog.Infof("  %s=%q", newStaterootNameFlag, newStaterootName)
+	pkgLog.Infof("  %s=%t", installInitMonitorFlag, installInitMonitor)
+}
+
+// installMonitorInitializationServiceInNewStateroot installs and enables the IPC init monitor service
+// within the new stateroot deployment.
+func installMonitorInitializationServiceInNewStateroot(
+	ostree intOstree.IClient,
+	ops ops.Ops,
+	newStaterootName string,
+	logger *logrus.Logger,
+) error {
+	deploymentDir, err := ostree.GetDeploymentDir(newStaterootName)
+	if err != nil {
+		return fmt.Errorf("failed to get deployment dir for %s: %w", newStaterootName, err)
+	}
+
+	destinationFilePath := filepath.Join(deploymentDir, "etc/systemd/system", common.IPCInitMonitorService)
+	logger.Infof("Creating service %s", common.IPCInitMonitorService)
+
+	if err := os.MkdirAll(path.Dir(destinationFilePath), 0o755); err != nil {
+		return fmt.Errorf("failed to create destination directory for %s: %w", common.IPCInitMonitorService, err)
+	}
+	if err := os.WriteFile(destinationFilePath, []byte(lcacli.LcaInitMonitorServiceFile), common.FileMode0600); err != nil {
+		return fmt.Errorf("failed to write init monitor service file: %w", err)
+	}
+
+	logger.Infof("Enabling service %s", common.IPCInitMonitorService)
+	if _, err := ops.SystemctlAction(
+		"enable",
+		"--root",
+		deploymentDir,
+		common.IPCInitMonitorService,
+	); err != nil {
+		return fmt.Errorf("failed enabling service %s: %w", common.IPCInitMonitorService, err)
+	}
+
+	staterootPath := common.GetStaterootPath(newStaterootName)
+	initMonitorModeFile := filepath.Join(staterootPath, common.InitMonitorModeFile)
+	if err := os.WriteFile(initMonitorModeFile, []byte("ipconfig"), common.FileMode0600); err != nil {
+		return fmt.Errorf("failed to write init monitor mode file: %w", err)
+	}
+
+	return nil
+}
+
+func cleanupMonitorInitializationServiceInOldStateroot(
+	ops ops.Ops, ostreeData *ipconfig.OstreeData,
+) error {
+	if _, err := ops.SystemctlAction("is-enabled", common.IPCInitMonitorService); err == nil {
+		if _, err := ops.SystemctlAction("disable", common.IPCInitMonitorService); err != nil {
+			return fmt.Errorf("failed to disable init monitor in old stateroot: %w", err)
+		}
+	}
+	if _, err := ops.SystemctlAction("is-active", common.IPCInitMonitorService); err == nil {
+		if _, err := ops.SystemctlAction("stop", common.IPCInitMonitorService); err != nil {
+			return fmt.Errorf("failed to stop init monitor in old stateroot: %w", err)
+		}
+	}
+
+	if err := os.Remove(
+		filepath.Join(
+			ostreeData.OldStateroot.DeploymentDir,
+			"etc/systemd/system",
+			common.IPCInitMonitorService,
+		),
+	); err != nil &&
+		!os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove init monitor service file in old stateroot: %w", err)
+	}
+
+	if _, err := ops.SystemctlAction("daemon-reload"); err != nil {
+		return fmt.Errorf("failed to reload systemctl daemon: %w", err)
+	}
+
+	return nil
+}
+
+// getOstreeData returns information about the current (old) and target (new)
+// stateroots, including names, paths, deployment names, and deployment dirs.
+func getOstreeData(
+	newStaterootName string,
+	rpmOstree rpmOstree.IClient,
+	ostree intOstree.IClient,
+	logger *logrus.Logger,
+) (*ipconfig.OstreeData, error) {
+	common.OstreeDeployPathPrefix = sysrootPath
+	ostreeData := &ipconfig.OstreeData{}
+
+	currentStaterootData, err := getCurrentStaterootData(rpmOstree, ostree)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current stateroot data: %w", err)
+	}
+	ostreeData.OldStateroot = currentStaterootData
+
+	newStaterootData, err := getNewStaterootData(newStaterootName, ostree, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get new stateroot data: %w", err)
+	}
+	ostreeData.NewStateroot = newStaterootData
+
+	return ostreeData, nil
+}
+
+// getCurrentStaterootData queries the system for the current stateroot details.
+func getCurrentStaterootData(rpmOstree rpmOstree.IClient, ostree intOstree.IClient) (*ipconfig.StaterootData, error) {
+	staterootData := &ipconfig.StaterootData{}
+
+	currentStaterootName, err := rpmOstree.GetCurrentStaterootName()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current stateroot name: %w", err)
+	}
+	staterootData.Name = currentStaterootName
+
+	staterootData.Path = common.GetStaterootPath(currentStaterootName)
+
+	oldDeploymentName, err := ostree.GetDeployment(currentStaterootName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployment for %s: %w", currentStaterootName, err)
+	}
+	staterootData.DeploymentName = oldDeploymentName
+
+	oldDeploymentDir, err := ostree.GetDeploymentDir(currentStaterootName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployment dir for %s: %w", currentStaterootName, err)
+	}
+	staterootData.DeploymentDir = oldDeploymentDir
+
+	return staterootData, nil
+}
+
+// getNewStaterootData resolves the metadata for the target new stateroot.
+func getNewStaterootData(
+	newStaterootName string,
+	ostree intOstree.IClient,
+	logger *logrus.Logger,
+) (*ipconfig.StaterootData, error) {
+	staterootData := &ipconfig.StaterootData{
+		Name: newStaterootName,
+		Path: common.GetStaterootPath(newStaterootName),
+	}
+
+	newDeploymentName, err := ostree.GetDeployment(newStaterootName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployment name for %s: %w", newStaterootName, err)
+	}
+	if newDeploymentName != "" {
+		staterootData.DeploymentName = newDeploymentName
+		logger.Infof("Found deployment for new stateroot before creation %s: %s", newStaterootName, newDeploymentName)
+	} else {
+		return staterootData, nil
+	}
+
+	newDeploymentDir, err := ostree.GetDeploymentDir(newStaterootName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployment dir for %s: %w", newStaterootName, err)
+	}
+	staterootData.DeploymentDir = newDeploymentDir
+
+	return staterootData, nil
+}

--- a/lca-cli/cmd/ipconfig/rollback.go
+++ b/lca-cli/cmd/ipconfig/rollback.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfigcmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	intOstree "github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
+	"github.com/openshift-kni/lifecycle-agent/internal/reboot"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ipconfig"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
+	rpmOstree "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rollbackStateroot string
+)
+
+const (
+	rollbackCmd   = "rollback"
+	staterootFlag = "stateroot"
+)
+
+func init() {
+	// subcommand is added by NewIPConfigCmd after globals are initialized
+	ipConfigRollbackCmd.Flags().StringVar(
+		&rollbackStateroot,
+		staterootFlag,
+		"",
+		"Target stateroot to roll back to",
+	)
+	ipConfigRollbackCmd.MarkFlagRequired(staterootFlag)
+}
+
+var ipConfigRollbackCmd = &cobra.Command{
+	Use:   rollbackCmd,
+	Short: "Rollback to the state before the IP configuration change",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runIPConfigRollback(); err != nil {
+			pkgLog.Fatalf("Error executing ip-config rollback: %v", err)
+		}
+	},
+}
+
+func runIPConfigRollback() error {
+	var hostCommandsExecutor ops.Execute
+	if _, err := os.Stat(common.Host); err == nil {
+		hostCommandsExecutor = ops.NewChrootExecutor(pkgLog, true, common.Host)
+	} else {
+		hostCommandsExecutor = ops.NewRegularExecutor(pkgLog, true)
+	}
+	opsInterface := ops.NewOps(pkgLog, hostCommandsExecutor)
+	rpmClient := rpmOstree.NewClient("lca-cli-ip-config-rollback", hostCommandsExecutor)
+	ostreeClient := intOstree.NewClient(hostCommandsExecutor, false)
+
+	rb := reboot.NewIPCRebootClient(&logr.Logger{}, hostCommandsExecutor, rpmClient, ostreeClient, opsInterface)
+
+	if err := common.WriteIPConfigStatus(common.IPConfigRollbackStatusFile, common.IPConfigStatus{
+		Phase:     common.IPConfigStatusRunning,
+		Message:   "ip-config rollback started",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		return fmt.Errorf("failed to write initial rollback status: %w", err)
+	}
+
+	exec := ipconfig.NewRollbackHandler(pkgLog, opsInterface, ostreeClient, rpmClient)
+	if err := exec.Run(rollbackStateroot); err != nil {
+		internalErr := common.FinalizeIPConfigStatus(
+			common.IPConfigRollbackStatusFile,
+			common.IPConfigStatusFailed,
+			fmt.Sprintf("ip-config rollback failed: %v", err),
+		)
+		if internalErr != nil {
+			return fmt.Errorf("failed to finalize IP config rollback status: %w", internalErr)
+		}
+		return fmt.Errorf("ip-config rollback handler failed: %w", err)
+	}
+
+	common.OstreeDeployPathPrefix = sysrootPath
+	staterootPath := common.GetStaterootPath(rollbackStateroot)
+	statusFilePath := filepath.Join(staterootPath, common.IPConfigRollbackStatusFile)
+
+	if err := opsInterface.RemountSysroot(); err != nil {
+		return fmt.Errorf("failed to remount /sysroot rw: %w", err)
+	}
+
+	if err := common.FinalizeIPConfigStatus(
+		statusFilePath,
+		common.IPConfigStatusSucceeded,
+		"ip-config rollback completed successfully",
+	); err != nil {
+		return fmt.Errorf("failed to mark rollback as successful: %w", err)
+	}
+
+	if err := rb.RebootToNewStateRoot("ip-config rollback"); err != nil {
+		return fmt.Errorf("failed to reboot: %w", err)
+	}
+
+	return nil
+}

--- a/lca-cli/cmd/ipconfig/root.go
+++ b/lca-cli/cmd/ipconfig/root.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfigcmd
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pkgLog *logrus.Logger
+)
+
+// NewIPConfigCmd builds the ip-config parent command and its subcommands
+func NewIPConfigCmd(log *logrus.Logger) *cobra.Command {
+	pkgLog = log
+
+	ipConfigCmd := &cobra.Command{
+		Use:   "ip-config",
+		Short: "IP configuration commands",
+	}
+
+	// Subcommands are registered in their init() functions when package is imported,
+	// but here we ensure they are attached after globals are set
+	ipConfigCmd.AddCommand(ipConfigRunCmd)
+	ipConfigCmd.AddCommand(ipConfigPrepareCmd)
+	ipConfigCmd.AddCommand(ipConfigRollbackCmd)
+
+	return ipConfigCmd
+}

--- a/lca-cli/cmd/ipconfig/run.go
+++ b/lca-cli/cmd/ipconfig/run.go
@@ -1,0 +1,507 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfigcmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	intOstree "github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
+	"github.com/openshift-kni/lifecycle-agent/internal/reboot"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ipconfig"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
+	rpmOstree "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
+	lcautils "github.com/openshift-kni/lifecycle-agent/utils"
+	ocp_config_v1 "github.com/openshift/api/config/v1"
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+)
+
+var (
+	ipConfigScheme = runtime.NewScheme()
+
+	ipv4Address        string
+	ipv4MachineNetwork string
+	ipv6Address        string
+	ipv6MachineNetwork string
+	ipv4Gateway        string
+	ipv6Gateway        string
+	ipv4DNS            string
+	ipv6DNS            string
+	vlanID             int
+	pullSecretRefName  string
+	recertImage        string
+	dnsIPFamily        string
+)
+
+const (
+	ipv4AddressFlag        = "ipv4-address"
+	ipv4MachineNetworkFlag = "ipv4-machine-network"
+	ipv6AddressFlag        = "ipv6-address"
+	ipv6MachineNetworkFlag = "ipv6-machine-network"
+	ipv4GatewayFlag        = "ipv4-gateway"
+	ipv6GatewayFlag        = "ipv6-gateway"
+	ipv4DNSFlag            = "ipv4-dns"
+	ipv6DNSFlag            = "ipv6-dns"
+	vlanIDFlag             = "vlan-id"
+	recertImageFlag        = "recert-image"
+	pullSecretRefNameFlag  = "pull-secret-ref-name" //nolint:gosec // flag name, not credentials
+	dnsIPFamilyFlag        = "dns-ip-family"
+	runCmd                 = "run"
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(ipConfigScheme))
+	utilruntime.Must(machineconfigv1.AddToScheme(ipConfigScheme))
+	utilruntime.Must(ocp_config_v1.AddToScheme(ipConfigScheme))
+
+	ipConfigRunCmd.Flags().StringVar(&ipv4Address, ipv4AddressFlag, "", "Target IPv4 address")
+	ipConfigRunCmd.Flags().StringVar(&ipv4MachineNetwork, ipv4MachineNetworkFlag, "", "Target IPv4 machine network CIDR")
+	ipConfigRunCmd.Flags().StringVar(&ipv6Address, ipv6AddressFlag, "", "Target IPv6 address")
+	ipConfigRunCmd.Flags().StringVar(&ipv6MachineNetwork, ipv6MachineNetworkFlag, "", "Target IPv6 machine network CIDR")
+	ipConfigRunCmd.Flags().StringVar(&ipv4Gateway, ipv4GatewayFlag, "", "IPv4 default gateway")
+	ipConfigRunCmd.Flags().StringVar(&ipv6Gateway, ipv6GatewayFlag, "", "IPv6 default gateway")
+	ipConfigRunCmd.Flags().StringVar(&ipv4DNS, ipv4DNSFlag, "", "IPv4 DNS server")
+	ipConfigRunCmd.Flags().StringVar(&ipv6DNS, ipv6DNSFlag, "", "IPv6 DNS server")
+	ipConfigRunCmd.Flags().IntVar(&vlanID, vlanIDFlag, 0, "Optional VLAN ID to use on the br-ex uplink")
+	ipConfigRunCmd.Flags().StringVar(&recertImage, recertImageFlag, "", "The full image name for the recert container tool")
+	ipConfigRunCmd.Flags().StringVar(&pullSecretRefName, pullSecretRefNameFlag, "", "The name of the pull secret to use for the recert container tool")
+	ipConfigRunCmd.Flags().StringVar(&dnsIPFamily, dnsIPFamilyFlag, "", "IP family for DNS resolution (ipv4|ipv6)")
+}
+
+var ipConfigRunCmd = &cobra.Command{
+	Use:   runCmd,
+	Short: "Execute IP configuration change and reboot to the new configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runIPConfigRun(); err != nil {
+			pkgLog.Fatalf("Error executing ip-config run: %v", err)
+		}
+	},
+}
+
+// runIPConfigRun coordinates the ip-config "run" flow:
+// - writes initial status, loads flags/config, validates inputs
+// - infers the primary IP family and builds handler dependencies
+// - applies network changes, finalizes status, and reboots
+func runIPConfigRun() (retErr error) {
+	// This part is not rollback protected because we need the reboot client to be available
+	// for auto-rollback. We can consider solutions for it if needed
+	opsInterface, hostCommandsExecutor, client, err := buildOpsAndK8sClient(ipConfigScheme)
+	if err != nil {
+		return err
+	}
+
+	rpmClient := rpmOstree.NewClient("lca-cli-ip-config-run", hostCommandsExecutor)
+	ostreeClient := intOstree.NewClient(hostCommandsExecutor, false)
+	rbClient := reboot.NewIPCRebootClient(&logr.Logger{}, hostCommandsExecutor, rpmClient, ostreeClient, opsInterface)
+
+	defer func() {
+		if retErr == nil {
+			if err := common.FinalizeIPConfigStatus(
+				common.IPConfigRunStatusFile,
+				common.IPConfigStatusSucceeded,
+				"ip-config run completed successfully",
+			); err != nil {
+				retErr = fmt.Errorf("failed to mark IP config run as successful: %w", err)
+				return
+			}
+
+			if err := rbClient.Reboot("ip-config run"); err != nil {
+				retErr = fmt.Errorf("failed to reboot: %w", err)
+				return
+			}
+		}
+
+		common.OstreeDeployPathPrefix = sysrootPath
+		if err := opsInterface.RemountSysroot(); err != nil {
+			retErr = fmt.Errorf("failed to remount sysroot: %w", err)
+			return
+		}
+
+		oldStateroot, err := rpmClient.GetUnbootedStaterootName()
+		if err != nil {
+			retErr = fmt.Errorf("failed to get unbooted stateroot: %w", err)
+			return
+		}
+
+		// We need to write the old stateroot status file to the old stateroot because
+		// the controller need to pick it up and set the condition properly.
+		statusFilePath := filepath.Join(
+			common.GetStaterootPath(oldStateroot),
+			common.IPConfigRunStatusFile,
+		)
+
+		if err := common.FinalizeIPConfigStatus(
+			statusFilePath,
+			common.IPConfigStatusFailed,
+			fmt.Sprintf("rolled back automatically due to ip-config run failure: %v", retErr),
+		); err != nil {
+			retErr = fmt.Errorf("failed to finalize old stateroot IP config run status: %w", err)
+			return
+		}
+
+		if err := common.FinalizeIPConfigStatus(
+			common.IPConfigRunStatusFile,
+			common.IPConfigStatusFailed,
+			fmt.Sprintf("ip-config run failed: %v", retErr),
+		); err != nil {
+			retErr = fmt.Errorf("failed to finalize current stateroot IP config run status: %w", err)
+			return
+		}
+
+		rbClient.AutoRollbackIfEnabled(
+			reboot.IPConfigRunComponent,
+			fmt.Sprintf("automatic rollback: ip-config run failed: %v", retErr),
+		)
+	}()
+
+	// Start of rollback protected part
+
+	err = common.WriteIPConfigStatus(common.IPConfigRunStatusFile,
+		common.IPConfigStatus{
+			Phase:     common.IPConfigStatusRunning,
+			Message:   "ip-config run started",
+			StartedAt: time.Now().UTC().Format(time.RFC3339),
+		})
+	if err != nil {
+		return fmt.Errorf("failed to write initial status: %w", err)
+	}
+
+	if data, err := os.ReadFile(common.IPConfigRunFlagsFile); err == nil && len(data) > 0 {
+		var cfg common.IPConfigRunConfig
+		if jsonErr := json.Unmarshal(data, &cfg); jsonErr == nil {
+			ipv4Address = cfg.IPv4Address
+			ipv4MachineNetwork = cfg.IPv4MachineNetwork
+			ipv6Address = cfg.IPv6Address
+			ipv6MachineNetwork = cfg.IPv6MachineNetwork
+			ipv4Gateway = cfg.IPv4Gateway
+			ipv6Gateway = cfg.IPv6Gateway
+			ipv4DNS = cfg.IPv4DNSServer
+			ipv6DNS = cfg.IPv6DNSServer
+			vlanID = cfg.VLANID
+			pullSecretRefName = cfg.PullSecretRefName
+			recertImage = cfg.RecertImage
+			dnsIPFamily = cfg.DNSIPFamily
+		} else {
+			pkgLog.Warnf("failed to unmarshal ip-config run config: %v", jsonErr)
+		}
+	} else {
+		pkgLog.Info("using command line flags")
+	}
+
+	logRunFlags()
+
+	// test error
+	ctx := context.Background()
+
+	if err := validateRunFlags(ctx, client); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	if err := gatherMissingNetworkData(
+		ctx,
+		client,
+		opsInterface,
+	); err != nil {
+		return err
+	}
+
+	effectivePrimary, err := ipconfig.InferPrimaryStack()
+	if err != nil {
+		return fmt.Errorf("failed to infer primary IP stack: %w", err)
+	}
+
+	ipConfigs := ipconfig.BuildIPConfigs(
+		ipv4Address, ipv4MachineNetwork, ipv4Gateway, ipv4DNS,
+		ipv6Address, ipv6MachineNetwork, ipv6Gateway, ipv6DNS,
+		lo.FromPtr(effectivePrimary),
+	)
+
+	if recertImage == "" {
+		recertImage = common.DefaultRecertImage
+	}
+
+	ipConfigHandler := ipconfig.NewIPConfig(
+		pkgLog,
+		opsInterface,
+		hostCommandsExecutor,
+		client,
+		recertImage,
+		ipConfigs,
+		pullSecretRefName,
+		vlanID,
+		dnsIPFamily,
+	)
+
+	if err := ipConfigHandler.Run(ctx); err != nil {
+		return fmt.Errorf("ip-config run failed: %w", err)
+	}
+
+	return nil
+}
+
+// completeMissingIPFamilyFromClusterAndHost fills in missing IP family configuration
+// (address, machine network, gateway, DNS) by inspecting the current SNO host and
+// cluster state. It is used when the user only specifies one IP family on a
+// dual-stack cluster so that recert and nmstate still see a complete configuration.
+func gatherMissingNetworkData(
+	ctx context.Context,
+	client runtimeClient.Client,
+	hostOps ops.Ops,
+) error {
+	ipv4Provided := ipv4Address != "" && ipv4MachineNetwork != "" && ipv4Gateway != "" && ipv4DNS != ""
+	ipv6Provided := ipv6Address != "" && ipv6MachineNetwork != "" && ipv6Gateway != "" && ipv6DNS != ""
+
+	if ipv4Provided && ipv6Provided {
+		return nil
+	}
+
+	// dual-stack clusters only
+
+	nmOutput, err := hostOps.RunInHostNamespace("nmstatectl", "show", "--json", "-q")
+	if err != nil {
+		return fmt.Errorf("failed to run nmstatectl show --json: %w", err)
+	}
+
+	nmState, err := lcautils.ParseNmstate(nmOutput)
+	if err != nil {
+		return fmt.Errorf("failed to parse nmstate output: %w", err)
+	}
+
+	dnsV4, dnsV6 := lcautils.ExtractDNS(nmState)
+	if dnsV4 == "" || dnsV6 == "" {
+		pkgLog.Infof("No DNS servers found in nmstate output")
+	}
+
+	gw4, gw6 := lcautils.FindDefaultGateways(
+		nmState,
+		ipconfig.BridgeExternalName,
+		ipconfig.DefaultRouteV4,
+		ipconfig.DefaultRouteV6,
+	)
+	if gw4 == "" || gw6 == "" {
+		pkgLog.Infof("No default gateways found in nmstate output")
+	}
+
+	ips, err := lcautils.GetNodeInternalIPs(ctx, client)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster info: %w", err)
+	}
+
+	var nodeIPv4, nodeIPv6 string
+	for _, ip := range ips {
+		if strings.Contains(ip, ":") {
+			if nodeIPv6 == "" {
+				nodeIPv6 = ip
+			}
+		} else {
+			if nodeIPv4 == "" {
+				nodeIPv4 = ip
+			}
+		}
+	}
+
+	clusterHasIPv4, clusterHasIPv6 := common.DetectClusterIPFamilies(ips)
+	machineNetworks, err := lcautils.GetMachineNetworks(ctx, client)
+	if err != nil {
+		return fmt.Errorf("failed to get machine networks: %w", err)
+	}
+
+	// Auto-complete IPv4 if user omitted it but cluster is IPv4-capable.
+	if !ipv4Provided && clusterHasIPv4 {
+		cidr := lcautils.FindMatchingCIDR(nodeIPv4, machineNetworks)
+		if cidr == "" {
+			return fmt.Errorf("failed to find machine network CIDR for node IPv4 %s", nodeIPv4)
+		}
+
+		pkgLog.Infof("Auto-completing IPv4 configuration from cluster/host state: ip=%s, cidr=%s", nodeIPv4, cidr)
+		ipv4Address = nodeIPv4
+		ipv4MachineNetwork = cidr
+		ipv4Gateway = gw4
+		ipv4DNS = dnsV4
+	}
+
+	// Auto-complete IPv6 if user omitted it but cluster is IPv6-capable.
+	if !ipv6Provided && clusterHasIPv6 {
+		cidr := lcautils.FindMatchingCIDR(nodeIPv6, machineNetworks)
+		if cidr == "" {
+			return fmt.Errorf("failed to find machine network CIDR for node IPv6 %s", nodeIPv6)
+		}
+
+		pkgLog.Infof("Auto-completing IPv6 configuration from cluster/host state: ip=%s, cidr=%s", nodeIPv6, cidr)
+		ipv6Address = nodeIPv6
+		ipv6MachineNetwork = cidr
+		ipv6Gateway = gw6
+		ipv6DNS = dnsV6
+	}
+
+	return nil
+}
+
+// validateClusterAPIAndUserIPSpec ensures that:
+//  1. the cluster API is reachable, by attempting to read the node internal IPs
+//  2. the user-provided IP family configuration (IPv4/IPv6/both) is compatible
+//     with the cluster's configured IP families (single-stack or dual-stack).
+func validateClusterAPIAndUserIPSpec(
+	ctx context.Context,
+	client runtimeClient.Client,
+) error {
+	ips, err := lcautils.GetNodeInternalIPs(ctx, client)
+	if err != nil {
+		return fmt.Errorf("failed to contact cluster API: %w", err)
+	}
+
+	clusterHasIPv4, clusterHasIPv6 := common.DetectClusterIPFamilies(ips)
+
+	ipv4Provided := ipv4Address != "" || ipv4MachineNetwork != "" || ipv4Gateway != "" || ipv4DNS != ""
+	ipv6Provided := ipv6Address != "" || ipv6MachineNetwork != "" || ipv6Gateway != "" || ipv6DNS != ""
+
+	if ipv4Provided && !clusterHasIPv4 {
+		return fmt.Errorf("ipv4 is specified, but the cluster does not have IPv4")
+	}
+
+	if ipv6Provided && !clusterHasIPv6 {
+		return fmt.Errorf("ipv6 is specified, but the cluster does not have IPv6")
+	}
+
+	return nil
+}
+
+// validateIPFamilyConfigArgs validates IPv4/IPv6 arguments for consistency and correctness.
+// It enforces that each family is either fully specified or omitted, and that
+// addresses and gateways belong to their respective machine networks.
+func validateIPFamilyConfigArgs() error {
+	ipv4All := ipv4Address != "" && ipv4MachineNetwork != "" && ipv4Gateway != "" && ipv4DNS != ""
+	ipv4None := ipv4Address == "" && ipv4MachineNetwork == "" && ipv4Gateway == "" && ipv4DNS == ""
+	ipv6All := ipv6Address != "" && ipv6MachineNetwork != "" && ipv6Gateway != "" && ipv6DNS != ""
+	ipv6None := ipv6Address == "" && ipv6MachineNetwork == "" && ipv6Gateway == "" && ipv6DNS == ""
+
+	if (!ipv4All && !ipv4None) || (!ipv6All && !ipv6None) {
+		return fmt.Errorf("both address, machine-network, gateway and DNS must be provided together for each IP family")
+	}
+
+	if ipv4None && ipv6None {
+		return fmt.Errorf("at least one of IPv4 or IPv6 must be provided")
+	}
+
+	if ipv4All {
+		if err := lcautils.ValidateIPFamilyConfig(
+			common.IPv4FamilyName,
+			ipv4Address,
+			ipv4MachineNetwork,
+			ipv4Gateway,
+			ipv4DNS,
+		); err != nil {
+			return fmt.Errorf("invalid IPv4 config: %w", err)
+		}
+	}
+
+	if ipv6All {
+		if err := lcautils.ValidateIPFamilyConfig(
+			common.IPv6FamilyName,
+			ipv6Address,
+			ipv6MachineNetwork,
+			ipv6Gateway,
+			ipv6DNS,
+		); err != nil {
+			return fmt.Errorf("invalid IPv6 config: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// logRunFlags logs the effective flags used by the ip-config run command.
+func logRunFlags() {
+	pkgLog.Infof("ip-config run effective flags:")
+
+	if ipv4Address != "" {
+		pkgLog.Infof("  ipv4-address=%s", ipv4Address)
+	}
+	if ipv4MachineNetwork != "" {
+		pkgLog.Infof("  ipv4-machine-network=%s", ipv4MachineNetwork)
+	}
+	if ipv4Gateway != "" {
+		pkgLog.Infof("  ipv4-gateway=%s", ipv4Gateway)
+	}
+	if ipv4DNS != "" {
+		pkgLog.Infof("  ipv4-dns=%s", ipv4DNS)
+	}
+	if ipv6Address != "" {
+		pkgLog.Infof("  ipv6-address=%s", ipv6Address)
+	}
+	if ipv6MachineNetwork != "" {
+		pkgLog.Infof("  ipv6-machine-network=%s", ipv6MachineNetwork)
+	}
+	if ipv6Gateway != "" {
+		pkgLog.Infof("  ipv6-gateway=%s", ipv6Gateway)
+	}
+	if ipv6DNS != "" {
+		pkgLog.Infof("  ipv6-dns=%s", ipv6DNS)
+	}
+	if vlanID != 0 {
+		pkgLog.Infof("  vlan-id=%d", vlanID)
+	}
+	if pullSecretRefName != "" {
+		pkgLog.Infof("  pull-secret-ref-name=%s", pullSecretRefName)
+	}
+	if recertImage != "" {
+		pkgLog.Infof("  recert-image=%s", recertImage)
+	}
+	if dnsIPFamily != "" {
+		pkgLog.Infof("  dns-ip-family=%s", dnsIPFamily)
+	}
+}
+
+// validateRunFlags validates all run cmd flags including IP configs, VLAN and DNS family.
+func validateRunFlags(ctx context.Context, client runtimeClient.Client) error {
+	if err := validateIPFamilyConfigArgs(); err != nil {
+		return fmt.Errorf("invalid IP config arguments: %w", err)
+	}
+
+	if err := validateClusterAPIAndUserIPSpec(ctx, client); err != nil {
+		return fmt.Errorf("failed to validate cluster API and user IP spec: %w", err)
+	}
+
+	if vlanID < 0 {
+		return fmt.Errorf("vlan-id must be >= 0")
+	}
+
+	if dnsIPFamily != "" {
+		switch dnsIPFamily {
+		case common.IPv4FamilyName:
+		case common.IPv6FamilyName:
+		default:
+			return fmt.Errorf("dns-ip-family must be one of: %s|%s", common.IPv4FamilyName, common.IPv6FamilyName)
+		}
+	}
+
+	return nil
+}

--- a/lca-cli/cmd/postpivotcmd.go
+++ b/lca-cli/cmd/postpivotcmd.go
@@ -61,7 +61,7 @@ func postPivot() {
 	opsClient := ops.NewOps(log, hostCommandsExecutor)
 	rpmOstreeClient := rpmostreeclient.NewClient("initmonitor", hostCommandsExecutor)
 	ostreeClient := ostreeclient.NewClient(hostCommandsExecutor, false)
-	rebootClient := reboot.NewRebootClient(&logr.Logger{}, hostCommandsExecutor, rpmOstreeClient, ostreeClient, opsClient)
+	rebootClient := reboot.NewIBURebootClient(&logr.Logger{}, hostCommandsExecutor, rpmOstreeClient, ostreeClient, opsClient)
 
 	postPivotRunner := postpivot.NewPostPivot(scheme, log, opsClient,
 		common.ImageRegistryAuthFile, common.OptOpenshift, common.KubeconfigFile)

--- a/lca-cli/cmd/root.go
+++ b/lca-cli/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	ipconfigcmd "github.com/openshift-kni/lifecycle-agent/lca-cli/cmd/ipconfig"
 )
 
 // Create logger
@@ -55,6 +56,9 @@ func addCommonFlags(cmd *cobra.Command) {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Display verbose logs")
 	rootCmd.PersistentFlags().BoolVarP(&noColor, "no-color", "c", false, "Control colored output")
+
+	// Register grouped ip-config command and its subcommands
+	rootCmd.AddCommand(ipconfigcmd.NewIPConfigCmd(log))
 }
 
 var (

--- a/lca-cli/common.go
+++ b/lca-cli/common.go
@@ -1,0 +1,6 @@
+package lcacli
+
+import _ "embed"
+
+//go:embed installation_configuration_files/services/lca-init-monitor.service
+var LcaInitMonitorServiceFile string

--- a/lca-cli/initmonitor/initmonitor.go
+++ b/lca-cli/initmonitor/initmonitor.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	"github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
 	"github.com/openshift-kni/lifecycle-agent/internal/reboot"
 	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
@@ -16,6 +18,8 @@ import (
 
 	"github.com/go-logr/logr"
 )
+
+const ipConfigMode = "ipconfig"
 
 type InitMonitor struct {
 	scheme               *runtime.Scheme
@@ -26,12 +30,18 @@ type InitMonitor struct {
 	rpmOstreeClient      *rpmostreeclient.Client
 	ostreeClient         ostreeclient.IClient
 	rebootClient         reboot.RebootIntf
+	mode                 string
 }
 
-func NewInitMonitor(scheme *runtime.Scheme, log *logrus.Logger, hostCommandsExecutor ops.Execute, ops ops.Ops, component string) *InitMonitor {
+func NewInitMonitor(scheme *runtime.Scheme, log *logrus.Logger, hostCommandsExecutor ops.Execute, ops ops.Ops, component, mode string) *InitMonitor {
 	rpmOstreeClient := rpmostreeclient.NewClient("initmonitor", hostCommandsExecutor)
 	ostreeClient := ostreeclient.NewClient(hostCommandsExecutor, false)
-	rebootClient := reboot.NewRebootClient(&logr.Logger{}, hostCommandsExecutor, rpmOstreeClient, ostreeClient, ops)
+	var rebootClient reboot.RebootIntf
+	if mode == ipConfigMode {
+		rebootClient = reboot.NewIPCRebootClient(&logr.Logger{}, hostCommandsExecutor, rpmOstreeClient, ostreeClient, ops)
+	} else {
+		rebootClient = reboot.NewIBURebootClient(&logr.Logger{}, hostCommandsExecutor, rpmOstreeClient, ostreeClient, ops)
+	}
 	return &InitMonitor{
 		scheme:               scheme,
 		log:                  log,
@@ -41,11 +51,12 @@ func NewInitMonitor(scheme *runtime.Scheme, log *logrus.Logger, hostCommandsExec
 		rpmOstreeClient:      rpmOstreeClient,
 		ostreeClient:         ostreeClient,
 		rebootClient:         rebootClient,
+		mode:                 mode,
 	}
 }
 
 func (m *InitMonitor) RunInitMonitor() error {
-	rollbackCfg, err := m.rebootClient.ReadIBUAutoRollbackConfigFile()
+	rollbackCfg, err := m.rebootClient.ReadAutoRollbackConfigFile()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -67,14 +78,39 @@ func (m *InitMonitor) RunInitMonitor() error {
 
 	timeout := time.Duration(rollbackCfg.InitMonitorTimeout) * time.Second
 
-	m.log.Infof("Launching LCA Init Monitor timeout. Automatic rollback will occur in %s if upgrade is not completed successfully within that time", timeout)
+	// Adjust log message based on mode
+	contextText := "upgrade"
+	if m.mode == ipConfigMode {
+		contextText = "ip-config"
+	}
+	m.log.Infof("Launching LCA Init Monitor timeout. Automatic rollback will occur in %s if %s is not completed successfully within that time", timeout, contextText)
 
 	time.Sleep(timeout)
 
-	// If we reach this point, the init monitor was not shut down by the Upgrade handler, so trigger rollback
+	// If we reach this point, the init monitor was not shut down by the handler, so trigger rollback
 
 	msg := fmt.Sprintf("Rollback due to LCA Init Monitor timeout, after %s", timeout)
 	m.log.Info(msg)
+
+	if m.mode == ipConfigMode {
+		if err := m.ops.RemountSysroot(); err != nil {
+			// prefer to continue with rollback even if we can't write the rollback marker file
+			m.log.Error(err, "failed to remount sysroot")
+		}
+
+		oldStateroot, err := m.rpmOstreeClient.GetUnbootedStaterootName()
+		if err != nil {
+			// prefer to continue with rollback even if we can't write the rollback marker file
+			m.log.Error(err, "failed to get unbooted stateroot name")
+		}
+
+		oldStaterootPath := common.GetStaterootPath(oldStateroot)
+		rollbackMarkerFile := filepath.Join(oldStaterootPath, common.IPConfigMonitorRollbackMarkerFile)
+		if err := m.ops.WriteFile(rollbackMarkerFile, []byte(""), 0o644); err != nil {
+			// prefer to continue with rollback even if we can't write the rollback marker file
+			m.log.Error(err, "failed to write ip-config monitor rollback marker file")
+		}
+	}
 
 	if err := m.rebootClient.InitiateRollback(msg); err != nil {
 		return fmt.Errorf("unable to auto rollback: %w", err)
@@ -84,7 +120,7 @@ func (m *InitMonitor) RunInitMonitor() error {
 }
 
 func (m *InitMonitor) checkSvcUnitRollbackNeeded() bool {
-	rollbackCfg, err := m.rebootClient.ReadIBUAutoRollbackConfigFile()
+	rollbackCfg, err := m.rebootClient.ReadAutoRollbackConfigFile()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false

--- a/lca-cli/ipconfig/constants.go
+++ b/lca-cli/ipconfig/constants.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfig
+
+const (
+	// External bridge name and related identifiers
+	BridgeExternalName    = "br-ex"
+	BrExMachineConfigName = "10-br-ex"
+
+	// Default route destinations used when discovering host gateways via nmstate
+	DefaultRouteV4 = "0.0.0.0/0"
+	DefaultRouteV6 = "::/0"
+
+	// Systemd unit name for nodeip rerun
+	NodeipRerunUnitName = "sno-nodeip-rerun.service"
+)
+
+// MachineConfigPool and annotation string keys
+const (
+	MCPMasterName               = "master"
+	MachineConfigDesiredAnnoKey = "machineconfiguration.openshift.io/desiredConfig"
+	MachineConfigCurrentAnnoKey = "machineconfiguration.openshift.io/currentConfig"
+)
+
+// MachineConfigPool condition type names
+const (
+	MCPConditionUpdating = "Updating"
+	MCPConditionUpdated  = "Updated"
+	MCPConditionDegraded = "Degraded"
+)

--- a/lca-cli/ipconfig/prepare.go
+++ b/lca-cli/ipconfig/prepare.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfig
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	intOstree "github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
+	"github.com/openshift-kni/lifecycle-agent/internal/reboot"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
+	rpmOstree "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
+	"github.com/openshift-kni/lifecycle-agent/utils"
+)
+
+// OstreeData groups metadata about the old and new stateroots involved in the
+// IP configuration prepare flow.
+type OstreeData struct {
+	OldStateroot *StaterootData
+	NewStateroot *StaterootData
+}
+
+// StaterootData describes a stateroot's identity and deployment metadata.
+type StaterootData struct {
+	Name           string
+	Path           string
+	DeploymentDir  string
+	DeploymentName string
+}
+
+// PrepareHandler coordinates preparing a new stateroot for IP configuration
+// changes by deploying, copying state, and setting default deployment.
+type PrepareHandler struct {
+	log        *logrus.Logger
+	ops        ops.Ops
+	ostreeData *OstreeData
+	ostree     intOstree.IClient
+	rpm        rpmOstree.IClient
+	reboot     reboot.RebootIntf
+	k8s        runtimeclient.Client
+}
+
+// NewPrepareHandler creates a new PrepareHandler instance.
+func NewPrepareHandler(
+	log *logrus.Logger,
+	ops ops.Ops,
+	ostreeData *OstreeData,
+	ostree intOstree.IClient,
+	rpm rpmOstree.IClient,
+	reboot reboot.RebootIntf,
+	k8s runtimeclient.Client,
+) *PrepareHandler {
+	return &PrepareHandler{
+		log:        log,
+		ops:        ops,
+		ostreeData: ostreeData,
+		ostree:     ostree,
+		rpm:        rpm,
+		reboot:     reboot,
+		k8s:        k8s,
+	}
+}
+
+// Run executes the prepare sequence: stop services, deploy/prepare the new
+// stateroot, and re-enable services in the appropriate roots.
+func (p *PrepareHandler) Run(ctx context.Context) (err error) {
+	p.log.Info("IP config prepare started")
+
+	p.log.Info("Fetching current kernel args")
+	kargs, err := utils.BuildKernelArgumentsFromMCOFile(common.MCDCurrentConfig)
+	if err != nil {
+		err = fmt.Errorf("failed to get current kernel args: %w", err)
+		return
+	}
+
+	p.log.Info("Stopping cluster services")
+	if err = p.ops.StopClusterServices(); err != nil {
+		err = fmt.Errorf("failed to stop cluster services: %w", err)
+		return
+	}
+
+	defer func() {
+		p.log.Info("Enabling cluster services in old stateroot")
+		if internalErr := p.ops.EnableClusterServices(""); internalErr != nil {
+			if err == nil {
+				err = internalErr
+			} else {
+				err = fmt.Errorf("%s; also failed to enable cluster services: %w", err.Error(), internalErr)
+			}
+		}
+	}()
+
+	p.log.Info("Preparing new stateroot")
+	if err = p.prepareNewStateroot(p.ostreeData, kargs); err != nil {
+		return fmt.Errorf("failed to prepare new stateroot: %w", err)
+	}
+
+	p.log.Info("Enabling cluster services in new stateroot")
+	if err = p.ops.EnableClusterServices(
+		p.ostreeData.NewStateroot.DeploymentDir,
+	); err != nil {
+		err = fmt.Errorf("failed to enable cluster services: %w", err)
+		return
+	}
+
+	p.log.Info("IP config prepare done successfully")
+
+	return nil
+}
+
+// prepareNewStateroot deploys the new stateroot if needed, copies data, and
+// sets it as default (when supported).
+func (p *PrepareHandler) prepareNewStateroot(
+	ostreeData *OstreeData,
+	kernelArgs []string,
+) error {
+	if err := p.ensureSysrootWritable(); err != nil {
+		return fmt.Errorf("failed to ensure sysroot writable: %w", err)
+	}
+
+	if ostreeData.NewStateroot.DeploymentName == "" {
+		p.log.Infof("New stateroot %s is not deployed, deploying it", ostreeData.NewStateroot.Name)
+
+		bootedCommit, err := p.getBootedCommit()
+		if err != nil {
+			return fmt.Errorf("failed to get booted commit: %w", err)
+		}
+
+		if err = p.deployNewStateroot(
+			ostreeData,
+			lo.FromPtr(bootedCommit),
+			kernelArgs,
+		); err != nil {
+			return fmt.Errorf("failed to deploy new stateroot: %w", err)
+		}
+	} else {
+		p.log.Infof("New stateroot %s is already deployed, skipping deploy", ostreeData.NewStateroot.Name)
+	}
+
+	if err := p.copyStateRootData(ostreeData); err != nil {
+		return fmt.Errorf("failed to copy state root data: %w", err)
+	}
+
+	if err := p.setDefaultDeploymentIfEnabled(ostreeData.NewStateroot.Name); err != nil {
+		return fmt.Errorf("failed to set default deployment: %w", err)
+	}
+
+	return nil
+}
+
+func (p *PrepareHandler) ensureSysrootWritable() error {
+	if err := p.ops.RemountSysroot(); err != nil {
+		return fmt.Errorf("failed to remount /sysroot rw: %w", err)
+	}
+	return nil
+}
+
+// getBootedCommit returns the checksum of the currently booted rpm-ostree deployment.
+func (p *PrepareHandler) getBootedCommit() (*string, error) {
+	status, err := p.rpm.QueryStatus()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query rpm-ostree status: %w", err)
+	}
+
+	var bootedCommit string
+	for _, d := range status.Deployments {
+		if d.Booted {
+			bootedCommit = d.Checksum
+			break
+		}
+	}
+
+	if bootedCommit == "" {
+		return nil, fmt.Errorf("failed to determine booted deployment commit")
+	}
+
+	return &bootedCommit, nil
+}
+
+// deployNewStateroot initializes OSTree for the new stateroot and deploys the
+// booted commit with the provided kernel args, updating the ostreeData fields.
+func (p *PrepareHandler) deployNewStateroot(
+	ostreeData *OstreeData,
+	bootedCommit string,
+	kargs []string,
+) error {
+	common.OstreeDeployPathPrefix = "/sysroot"
+	if err := p.ostree.OSInit(ostreeData.NewStateroot.Name); err != nil {
+		return fmt.Errorf("failed to initialize ostree: %w", err)
+	}
+
+	if err := p.ostree.Deploy(ostreeData.NewStateroot.Name, bootedCommit, kargs, p.rpm, false); err != nil {
+		return fmt.Errorf("failed ostree admin deploy: %w", err)
+	}
+
+	deploymentName, err := p.ostree.GetDeployment(ostreeData.NewStateroot.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get deployment for %s: %w", ostreeData.NewStateroot.Name, err)
+	}
+	ostreeData.NewStateroot.DeploymentName = deploymentName
+
+	deploymentDir, err := p.ostree.GetDeploymentDir(ostreeData.NewStateroot.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get deployment dir for %s: %w", ostreeData.NewStateroot.Name, err)
+	}
+	ostreeData.NewStateroot.DeploymentDir = deploymentDir
+
+	return nil
+}
+
+// copyStateRootData copies important state from the old stateroot to the new one.
+func (p *PrepareHandler) copyStateRootData(ostreeData *OstreeData) error {
+	if err := p.copyVar(
+		ostreeData.OldStateroot.Path,
+		ostreeData.NewStateroot.Path,
+	); err != nil {
+		return err
+	}
+
+	if err := p.copyEtc(
+		ostreeData.OldStateroot.DeploymentDir,
+		ostreeData.NewStateroot.DeploymentDir,
+	); err != nil {
+		return err
+	}
+
+	if err := p.copyDeploymentOrigin(
+		ostreeData.OldStateroot.Path,
+		ostreeData.NewStateroot.Path,
+		ostreeData.OldStateroot.DeploymentName,
+		ostreeData.NewStateroot.DeploymentName,
+	); err != nil {
+		return fmt.Errorf("failed to copy deployment origin: %w", err)
+	}
+
+	return nil
+}
+
+// setDefaultDeploymentIfEnabled sets the given stateroot as default when supported.
+func (p *PrepareHandler) setDefaultDeploymentIfEnabled(newStateroot string) error {
+	if !p.ostree.IsOstreeAdminSetDefaultFeatureEnabled() {
+		return fmt.Errorf("ostree admin set default feature is not enabled")
+	}
+
+	idx, err := p.rpm.GetDeploymentIndex(newStateroot)
+	if err != nil {
+		return fmt.Errorf("failed to get deployment index for %s: %w", newStateroot, err)
+	}
+
+	if err := p.ostree.SetDefaultDeployment(idx); err != nil {
+		return fmt.Errorf("failed to set default deployment: %w", err)
+	}
+
+	return nil
+}
+
+// copyVar copies the var directory preserving SELinux contexts and attributes
+func (p *PrepareHandler) copyVar(oldSRPath, newSRPath string) error {
+	// Copy var directory preserving SELinux contexts and attributes
+	if _, err := p.ops.RunInHostNamespace(
+		"bash", "-c",
+		fmt.Sprintf(
+			"cp -ar --preserve=context '%s/' '%s/'",
+			filepath.Join(oldSRPath, "var"),
+			newSRPath,
+		),
+	); err != nil {
+		return fmt.Errorf("failed to copy var: %w", err)
+	}
+	return nil
+}
+
+// copyEtc copies the deployment's etc directory preserving SELinux contexts
+func (p *PrepareHandler) copyEtc(oldDeploymentDir, newDeploymentDir string) error {
+	if _, err := p.ops.RunInHostNamespace(
+		"bash", "-c",
+		fmt.Sprintf(
+			"cp -ar --preserve=context '%s/' '%s/'",
+			filepath.Join(oldDeploymentDir, "etc"),
+			newDeploymentDir,
+		),
+	); err != nil {
+		return fmt.Errorf("failed to copy etc: %w", err)
+	}
+	return nil
+}
+
+// copyOrigin copies the .origin file between deployments preserving SELinux context
+func (p *PrepareHandler) copyDeploymentOrigin(oldSRPath, newSRPath, oldDeploymentName, newDeploymentName string) error {
+	oldOriginPath := filepath.Join(oldSRPath, "deploy", fmt.Sprintf("%s.origin", oldDeploymentName))
+	newOriginPath := filepath.Join(newSRPath, "deploy", fmt.Sprintf("%s.origin", newDeploymentName))
+
+	if _, err := p.ops.RunInHostNamespace(
+		"bash", "-c",
+		fmt.Sprintf(
+			"cp -a --preserve=context '%s' '%s'",
+			oldOriginPath,
+			newOriginPath,
+		),
+	); err != nil {
+		return fmt.Errorf("failed to copy origin file: %w", err)
+	}
+	return nil
+}

--- a/lca-cli/ipconfig/rollback.go
+++ b/lca-cli/ipconfig/rollback.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfig
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	intOstree "github.com/openshift-kni/lifecycle-agent/internal/ostreeclient"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
+	rpmOstree "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
+)
+
+type RollbackHandler struct {
+	log    *logrus.Logger
+	ops    ops.Ops
+	ostree intOstree.IClient
+	rpm    rpmOstree.IClient
+}
+
+// NewRollbackHandler constructs a RollbackHandler to revert an IP configuration
+// by switching the default OSTree deployment back to a specified stateroot.
+func NewRollbackHandler(log *logrus.Logger, ops ops.Ops, ostree intOstree.IClient, rpm rpmOstree.IClient) *RollbackHandler {
+	return &RollbackHandler{log: log, ops: ops, ostree: ostree, rpm: rpm}
+}
+
+// Run performs the rollback by setting the default deployment to the one
+// associated with the provided stateroot, if the OSTree feature is available.
+func (h *RollbackHandler) Run(stateroot string) error {
+	h.log.Infof("IP config rollback started with stateroot: %s", stateroot)
+
+	if h.ostree.IsOstreeAdminSetDefaultFeatureEnabled() {
+		idx, err := h.rpm.GetDeploymentIndex(stateroot)
+		if err != nil {
+			return fmt.Errorf("failed to get deployment index for %s: %w", stateroot, err)
+		}
+		if err := h.ostree.SetDefaultDeployment(idx); err != nil {
+			return fmt.Errorf("failed to set default deployment: %w", err)
+		}
+	}
+
+	h.log.Info("IP config rollback done successfully")
+
+	return nil
+}

--- a/lca-cli/ipconfig/run.go
+++ b/lca-cli/ipconfig/run.go
@@ -1,0 +1,843 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipconfig
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	"github.com/openshift-kni/lifecycle-agent/internal/recert"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
+	"github.com/openshift-kni/lifecycle-agent/utils"
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+)
+
+type RecertClusterData struct {
+	InstallConfig        string
+	IngressCertificateCN string
+	CurrentNodeIPs       []string
+	CryptoDir            string
+	PullSecretFile       string
+}
+
+// NetworkIPConfig is a minimal representation of an IP and its machine network.
+type NetworkIPConfig struct {
+	IP             string
+	MachineNetwork string
+	Gateway        string
+	DNSServer      string
+}
+
+// IPConfigHandler handles the IP change process.
+type IPConfigHandler struct {
+	log               *logrus.Logger
+	ops               ops.Ops
+	executor          ops.Execute
+	recertImage       string
+	IPConfigs         []*NetworkIPConfig
+	runtimeClient     runtimeclient.Client
+	PullSecretRefName string
+	VLANID            int
+	DNSIPFamily       string
+}
+
+// NewIPConfig creates a new IPConfigHandler instance.
+func NewIPConfig(
+	log *logrus.Logger,
+	ops ops.Ops,
+	executor ops.Execute,
+	runtimeClient runtimeclient.Client,
+	recertImage string,
+	ipConfigs []*NetworkIPConfig,
+	pullSecretRefName string,
+	vlanID int,
+	dnsIPFamily string,
+) *IPConfigHandler {
+	return &IPConfigHandler{
+		log:               log,
+		ops:               ops,
+		executor:          executor,
+		recertImage:       recertImage,
+		runtimeClient:     runtimeClient,
+		IPConfigs:         ipConfigs,
+		PullSecretRefName: pullSecretRefName,
+		VLANID:            vlanID,
+		DNSIPFamily:       dnsIPFamily,
+	}
+}
+
+// Run executes the full IP configuration change workflow, including
+// generating machine configuration, adjusting DNS overrides, stopping
+// cluster services, running recert, and re-enabling services.
+func (i *IPConfigHandler) Run(ctx context.Context) error {
+	i.log.Info("IP config run started")
+
+	// Requires running cluster - start
+
+	i.log.Info("Preparing recert cluster data")
+	prepareRecertClusterData, err := i.prepareRecertClusterData(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to prepare recert cluster data: %w", err)
+	}
+
+	i.log.Info("Creating network configuration")
+	if err := i.CreateNetworkConfiguration(ctx); err != nil {
+		return fmt.Errorf("failed to create network configuration: %w", err)
+	}
+
+	i.log.Info("Configuring dnsmasq override")
+	if err := i.configureDNSMasq(ctx); err != nil {
+		return fmt.Errorf("failed to configure dnsmasq override: %w", err)
+	}
+
+	// Requires running cluster - end
+
+	i.log.Info("Stopping cluster services")
+	if err := i.ops.StopClusterServices(); err != nil {
+		return fmt.Errorf("failed to stop cluster services: %w", err)
+	}
+
+	i.log.Info("Running recert flow")
+	if err := i.runRecert(prepareRecertClusterData); err != nil {
+		return fmt.Errorf("failed to run recert flow: %w", err)
+	}
+
+	i.log.Info("Ensuring nodeip rerun service")
+	if err := i.ensureNodeIPRerunService(i.IPConfigs[0].MachineNetwork); err != nil {
+		return fmt.Errorf("failed to ensure nodeip rerun service: %w", err)
+	}
+
+	i.log.Info("Cleaning up nmstate residual state files")
+	if err := i.cleanupNMStateAppliedFiles(); err != nil {
+		return fmt.Errorf("failed to clean up nmstate residual state files: %w", err)
+	}
+
+	i.log.Info("Removing stale files for regeneration")
+	if err := i.removeStaleFilesForRegeneration(); err != nil {
+		return fmt.Errorf("failed to remove stale files for regeneration: %w", err)
+	}
+
+	i.log.Info("Enabling cluster services")
+	if err := i.ops.EnableClusterServices(""); err != nil {
+		return fmt.Errorf("failed to enable cluster services: %w", err)
+	}
+
+	i.log.Info("IP config run completed successfully")
+
+	return nil
+}
+
+// prepareRecertClusterData collects cluster data and artifacts required by the
+// recert tool (install-config, crypto, ingress CN, node IPs, auth).
+func (i *IPConfigHandler) prepareRecertClusterData(
+	ctx context.Context,
+) (*RecertClusterData, error) {
+	cryptoDir := path.Join(common.LCAWorkspaceDir, common.KubeconfigCryptoDir)
+	if err := i.createCryptoDir(cryptoDir); err != nil {
+		return nil, fmt.Errorf("failed to create crypto directory: %w", err)
+	}
+
+	if err := i.collectKubeConfigCrypto(ctx, cryptoDir); err != nil {
+		return nil, fmt.Errorf("failed to collect kubeconfig crypto: %w", err)
+	}
+
+	ingressCertificateCN, err := utils.GetIngressCertificateCN(ctx, i.runtimeClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ingress certificate CN: %w", err)
+	}
+	i.log.Info("Found ingress certificate CN")
+
+	installConfig, err := utils.GetInstallConfig(ctx, i.runtimeClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get install config: %w", err)
+	}
+	i.log.Info("Found install config")
+
+	currentNodeIPs, err := utils.GetNodeInternalIPs(ctx, i.runtimeClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current node internal IPs: %w", err)
+	}
+
+	var pullSecretFile = common.ImageRegistryAuthFile
+	if i.PullSecretRefName != "" {
+		authPath, err := materializeAuthFileFromPullSecretRef(ctx, i.runtimeClient, i.PullSecretRefName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to materialize pull secret file: %w", err)
+		}
+		defer os.Remove(common.PathOutsideChroot(authPath))
+		pullSecretFile = authPath
+	}
+
+	return &RecertClusterData{
+		InstallConfig:        installConfig,
+		IngressCertificateCN: ingressCertificateCN,
+		CryptoDir:            cryptoDir,
+		CurrentNodeIPs:       currentNodeIPs,
+		PullSecretFile:       pullSecretFile,
+	}, nil
+}
+
+// runRecert writes a recert configuration and executes the full recert flow
+// to regenerate certificates and manifests for the new IP configuration.
+func (i *IPConfigHandler) runRecert(clusterData *RecertClusterData) error {
+	i.log.Info("Creating recert configuration file")
+
+	oldIPs := make([]string, len(i.IPConfigs))
+	newIPs := make([]string, len(i.IPConfigs))
+	newMachineNetworks := make([]string, len(i.IPConfigs))
+
+	for i, cfg := range i.IPConfigs {
+		oldIP, matchErr := selectIPOfSameFamily(cfg.IP, clusterData.CurrentNodeIPs)
+		if matchErr != nil {
+			return fmt.Errorf("failed to select old IP to match new IP %s: %w", cfg.IP, matchErr)
+		}
+		oldIPs[i] = oldIP
+		newIPs[i] = cfg.IP
+		newMachineNetworks[i] = cfg.MachineNetwork
+	}
+
+	recertConfig, err := recert.CreateRecertConfigFileForIPConfig(
+		oldIPs,
+		newIPs,
+		newMachineNetworks,
+		clusterData.InstallConfig,
+		clusterData.CryptoDir,
+		clusterData.IngressCertificateCN,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create recert configuration file: %w", err)
+	}
+
+	configPath := filepath.Join(common.LCAWorkspaceDir, recert.RecertConfigFile)
+	if err := utils.MarshalToFile(recertConfig, configPath); err != nil {
+		return fmt.Errorf("failed to marshal recert config file to %s: %w", configPath, err)
+	}
+
+	i.log.Info("Starting recert full flow")
+
+	err = i.ops.RecertFullFlow(
+		i.recertImage,
+		clusterData.PullSecretFile,
+		configPath,
+		nil,
+		nil,
+		"-v", fmt.Sprintf("%s:%s", common.LCAWorkspaceDir, common.LCAWorkspaceDir),
+	)
+	if err != nil {
+		return fmt.Errorf("failed recert full flow: %w", err)
+	}
+
+	return nil
+}
+
+// selectIPOfSameFamily picks the first candidate IP that matches the family (IPv4/IPv6) of newIP
+func selectIPOfSameFamily(newIP string, candidates []string) (string, error) {
+	family := ipFamilyOfString(newIP)
+	for _, c := range candidates {
+		if ipFamilyOfString(c) == family {
+			return c, nil
+		}
+	}
+	return "", fmt.Errorf("no %s NodeInternalIP found", family)
+}
+
+// ipFamilyOfString returns "IPv6" if the IP contains a colon, otherwise "IPv4"
+func ipFamilyOfString(ip string) string {
+	if strings.Contains(ip, ":") {
+		return common.IPv6FamilyName
+	}
+	return common.IPv4FamilyName
+}
+
+// InferPrimaryStack determines the primary IP family by reading the node's current primary IP
+// and returns a pointer to "IPv4" or "IPv6".
+func InferPrimaryStack() (*string, error) {
+	data, err := os.ReadFile(utils.PrimaryIPPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read primary IP: %w", err)
+	}
+
+	primaryIP := strings.TrimSpace(string(data))
+	if primaryIP == "" {
+		return nil, fmt.Errorf("primary IP not found")
+	}
+
+	ip := net.ParseIP(primaryIP)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid primary IP: %s", primaryIP)
+	}
+
+	if ip.To4() != nil {
+		return lo.ToPtr(common.IPv4FamilyName), nil
+	}
+
+	if ip.To16() != nil {
+		return lo.ToPtr(common.IPv6FamilyName), nil
+	}
+
+	return nil, fmt.Errorf("invalid primary IP: %s", primaryIP)
+}
+
+// BuildIPConfigs creates the ordered slice of NetworkIPConfig with primary first.
+func BuildIPConfigs(
+	ipv4Addr, ipv4Net, ipv4Gw, ipv4DNS string,
+	ipv6Addr, ipv6Net, ipv6Gw, ipv6DNS string,
+	primary string,
+) []*NetworkIPConfig {
+	var ipv4Config *NetworkIPConfig
+	if ipv4Addr != "" || ipv4Net != "" || ipv4Gw != "" || ipv4DNS != "" {
+		ipv4Config = &NetworkIPConfig{
+			IP:             ipv4Addr,
+			MachineNetwork: ipv4Net,
+			Gateway:        ipv4Gw,
+			DNSServer:      ipv4DNS,
+		}
+	}
+
+	var ipv6Config *NetworkIPConfig
+	if ipv6Addr != "" || ipv6Net != "" || ipv6Gw != "" || ipv6DNS != "" {
+		ipv6Config = &NetworkIPConfig{
+			IP:             ipv6Addr,
+			MachineNetwork: ipv6Net,
+			Gateway:        ipv6Gw,
+			DNSServer:      ipv6DNS,
+		}
+	}
+
+	ipConfigs := []*NetworkIPConfig{}
+	switch primary {
+	case common.IPv4FamilyName:
+		if ipv4Config != nil {
+			ipConfigs = append(ipConfigs, ipv4Config)
+		}
+
+		if ipv6Config != nil {
+			ipConfigs = append(ipConfigs, ipv6Config)
+		}
+	case common.IPv6FamilyName:
+		if ipv6Config != nil {
+			ipConfigs = append(ipConfigs, ipv6Config)
+		}
+
+		if ipv4Config != nil {
+			ipConfigs = append(ipConfigs, ipv4Config)
+		}
+	}
+
+	return ipConfigs
+}
+
+// detectBrExNetworkInterface discovers the *physical* host interface that is
+// plugged into the external OVS bridge (`br-ex`). The IP configured on this
+// interface becomes the node's primary/external IP (for API, egress, etc.),
+// so we must reliably identify it before generating network MachineConfigs.
+// To do this we query `ovs-vsctl list-ports br-ex` and ignore OVS-internal
+// patch ports, returning only the real NIC that backs `br-ex`.
+func (i *IPConfigHandler) detectBrExNetworkInterface() (string, error) {
+	i.log.Infof("Detecting %s network interface", BridgeExternalName)
+
+	if output, err := i.executor.Execute("ovs-vsctl", "list-ports", BridgeExternalName); err == nil {
+		ports := strings.Fields(output)
+		for _, port := range ports {
+			// Skip OVS patch ports; we only care about the underlying host NIC
+			// Example output:
+			//   ovs-vsctl list-ports br-ex
+			//   ens3
+			//   patch-br-ex_test-infra-cluster-06d0a16b-master-0-to-br-int
+			if !strings.Contains(port, BridgeExternalName) {
+				i.log.Infof("Found interface via ovs-vsctl: %s", port)
+				return port, nil
+			}
+		}
+	} else {
+		i.log.Debugf("failed to query ovs-vsctl list-ports %s: %v", BridgeExternalName, err)
+	}
+
+	return "", fmt.Errorf("no connected network interface found")
+}
+
+// ensureNodeIPRerunService installs and enables a one-shot systemd service
+// to re-run nodeip detection after reboot, using a hint derived from the new network.
+func (i *IPConfigHandler) ensureNodeIPRerunService(newMachineNetwork string) error {
+	i.log.Infof("Installing one-shot nodeip rerun service at %s", utils.NodeipRerunUnitPath)
+
+	baseIP := strings.Split(newMachineNetwork, "/")[0]
+	hintSed := strings.ReplaceAll(baseIP, "/", "\\/")
+
+	templateData := &utils.NodeIPRerunServiceTemplateData{
+		BaseIP:  baseIP,
+		HintSed: hintSed,
+	}
+
+	unitContent, err := utils.GenerateNodeIPRerunService(templateData)
+	if err != nil {
+		return fmt.Errorf("failed to generate nodeip rerun service content: %w", err)
+	}
+
+	if err := os.WriteFile(common.PathOutsideChroot(utils.NodeipRerunUnitPath), []byte(unitContent), common.FileMode0600); err != nil {
+		return fmt.Errorf("failed to write nodeip rerun service file: %w", err)
+	}
+
+	if _, err := i.executor.Execute("systemctl", "daemon-reload"); err != nil {
+		return fmt.Errorf("failed to reload systemd daemon: %w", err)
+	}
+
+	if _, err := i.executor.Execute("systemctl", "enable", NodeipRerunUnitName); err != nil {
+		return fmt.Errorf("failed to enable %s: %w", NodeipRerunUnitName, err)
+	}
+
+	i.log.Info("Nodeip rerun service configured successfully")
+	return nil
+}
+
+// configureDNSMasq writes a dnsmasq override to prefer the selected IP
+// (optionally constrained to a specific IP family) and updates MCO filter.
+func (i *IPConfigHandler) configureDNSMasq(ctx context.Context) error {
+	overrideIP, err := i.getDNSOverrideIP()
+	if err != nil {
+		return err
+	}
+	i.log.Infof("Setting new dnsmasq configuration for %s", overrideIP)
+
+	if err := updateDNSMasqOverrideIP(overrideIP); err != nil {
+		return err
+	}
+
+	if i.DNSIPFamily != "" {
+		if err := common.SetDNSMasqFilterInMachineConfig(ctx, i.runtimeClient, i.DNSIPFamily); err != nil {
+			return fmt.Errorf("failed to update dnsmasq filter in machine config: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// getDNSOverrideIP selects the IP to use for dnsmasq overrides based on the
+// configured IP family (if any), falling back to the first available IP.
+func (i *IPConfigHandler) getDNSOverrideIP() (string, error) {
+	overrideIP := ""
+	for _, cfg := range i.IPConfigs {
+		if cfg != nil && cfg.IP != "" && ipFamilyOfString(cfg.IP) == i.DNSIPFamily {
+			overrideIP = cfg.IP
+			break
+		}
+	}
+
+	if overrideIP == "" && len(i.IPConfigs) > 0 && i.IPConfigs[0] != nil {
+		overrideIP = i.IPConfigs[0].IP
+	}
+
+	if overrideIP == "" {
+		return "", fmt.Errorf("no IP available to configure dnsmasq overrides")
+	}
+
+	return overrideIP, nil
+}
+
+// updateDNSMasqOverrideIP updates or appends the dnsmasq override env variable
+// in the dnsmasq overrides file without disturbing other configuration lines.
+func updateDNSMasqOverrideIP(overrideIP string) error {
+	overridesPath := common.PathOutsideChroot(common.DnsmasqOverrides)
+
+	var lines []string
+	if existing, err := os.ReadFile(overridesPath); err == nil {
+		trimmed := strings.TrimRight(string(existing), "\n")
+		if trimmed != "" {
+			lines = strings.Split(trimmed, "\n")
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read existing dnsmasq overrides: %w", err)
+	}
+
+	keyPrefix := common.DnsmasqOverrideEnvKeyIP + "="
+	newLine := fmt.Sprintf("%s%s", keyPrefix, overrideIP)
+	updated := false
+
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), keyPrefix) {
+			lines[i] = newLine
+			updated = true
+			break
+		}
+	}
+
+	if !updated {
+		lines = append(lines, newLine)
+	}
+
+	content := strings.Join(lines, "\n")
+	if content != "" {
+		content += "\n"
+	}
+
+	if err := os.WriteFile(overridesPath, []byte(content), common.FileMode0600); err != nil {
+		return fmt.Errorf("failed to set dnsmasq overrides: %w", err)
+	}
+
+	return nil
+}
+
+// cleanupNMStateAppliedFiles removes residual nmstate files that may interfere
+// with subsequent network reconfiguration.
+// It returns an error if removal of any file fails for a reason other than the
+// file not existing.
+func (i *IPConfigHandler) cleanupNMStateAppliedFiles() error {
+	i.log.Info("Cleaning up nmstate residual state files")
+
+	filesToRemove := []string{
+		common.PathOutsideChroot("/etc/nmstate/openshift/applied"),
+		common.PathOutsideChroot("/etc/nmstate/cluster.yml"),
+		common.PathOutsideChroot("/etc/nmstate/cluster.applied"),
+	}
+
+	for _, file := range filesToRemove {
+		if err := os.Remove(file); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("failed to remove %s: %w", file, err)
+		}
+		i.log.Infof("Removed nmstate file: %s", file)
+	}
+
+	i.log.Info("Cleaned up nmstate residual state on node")
+	return nil
+}
+
+// removeStaleFilesForRegeneration deletes known files so that components
+// regenerate their state safely after IP changes.
+func (i *IPConfigHandler) removeStaleFilesForRegeneration() error {
+	i.log.Infof("Removing stale files for regeneration")
+	files := []string{
+		common.OvnIcEtcFolder,
+		common.MultusCerts,
+		common.OvsConfDb,
+		common.OvsConfDbLock,
+	}
+	if err := utils.RemoveListOfFiles(i.log, files); err != nil {
+		return fmt.Errorf("failed to remove stale files for regeneration in %v: %w", files, err)
+	}
+	return nil
+}
+
+// createMachineConfig creates a machine config for IP configuration changes
+func (i *IPConfigHandler) createMachineConfig(interfaceName string) (*machineconfigv1.MachineConfig, error) {
+	newIPs := make([]string, len(i.IPConfigs))
+	newMachineNetworks := make([]string, len(i.IPConfigs))
+	var ipv4Gw, ipv6Gw, ipv4DNS, ipv6DNS string
+	for i, cfg := range i.IPConfigs {
+		newIPs[i] = cfg.IP
+		newMachineNetworks[i] = cfg.MachineNetwork
+		if strings.Contains(cfg.IP, ":") {
+			if cfg.Gateway != "" {
+				ipv6Gw = cfg.Gateway
+			}
+			if cfg.DNSServer != "" {
+				ipv6DNS = cfg.DNSServer
+			}
+		} else {
+			if cfg.Gateway != "" {
+				ipv4Gw = cfg.Gateway
+			}
+			if cfg.DNSServer != "" {
+				ipv4DNS = cfg.DNSServer
+			}
+		}
+	}
+
+	nmstateConfig, err := utils.GenerateNMState(
+		interfaceName,
+		newIPs,
+		newMachineNetworks,
+		ipv4Gw,
+		ipv6Gw,
+		ipv4DNS,
+		ipv6DNS,
+		i.VLANID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate NMState config: %w", err)
+	}
+
+	encodedContent := base64.StdEncoding.EncodeToString([]byte(nmstateConfig))
+	ignitionConfig, err := utils.GenerateIgnitionNMState(&utils.IgnitionNMStateTemplateData{
+		EncodedContent: encodedContent,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ignition config: %w", err)
+	}
+
+	mc := &machineconfigv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: BrExMachineConfigName,
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": "master",
+			},
+		},
+		Spec: machineconfigv1.MachineConfigSpec{
+			Config: runtime.RawExtension{
+				Raw: []byte(ignitionConfig),
+			},
+		},
+	}
+
+	return mc, nil
+}
+
+// applyNetworkConfigurationMachineConfig creates or updates the MachineConfig
+// that applies the nmstate configuration for the detected interface.
+// TODO: Try to simplify this flow while still achieving create / update of the
+// required MC while maintaining idempotency.
+func (i *IPConfigHandler) applyNetworkConfigurationMachineConfig(ctx context.Context, interfaceName string) error {
+	i.log.Info("Applying machine config for IP changes")
+
+	mc, err := i.createMachineConfig(interfaceName)
+	if err != nil {
+		return fmt.Errorf("failed to create machine config: %w", err)
+	}
+
+	if err := i.runtimeClient.Create(ctx, mc); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create machine config: %w", err)
+		}
+
+		existingMC := &machineconfigv1.MachineConfig{}
+		if getErr := i.runtimeClient.Get(ctx, types.NamespacedName{Name: mc.Name}, existingMC); getErr != nil {
+			return fmt.Errorf("failed to get existing machine config: %w", getErr)
+		}
+
+		// If spec is identical, treat as idempotent and skip update.
+		if bytes.Equal(existingMC.Spec.Config.Raw, mc.Spec.Config.Raw) {
+			i.log.Infof("Machine config %s already up to date; skipping update", mc.Name)
+			return nil
+		}
+
+		mc.ResourceVersion = existingMC.ResourceVersion
+		if updateErr := i.runtimeClient.Update(ctx, mc); updateErr != nil {
+			return fmt.Errorf("failed to update existing machine config: %w", updateErr)
+		}
+		i.log.Infof("Updated existing machine config: %s", mc.Name)
+	} else {
+		i.log.Infof("Created machine config: %s", mc.Name)
+	}
+
+	return nil
+}
+
+// CreateNetworkConfiguration applies MachineConfig to create nmstate configuration
+// and waits for rollout on MCP/master and the node.
+func (i *IPConfigHandler) CreateNetworkConfiguration(ctx context.Context) error {
+	iface, err := i.detectBrExNetworkInterface()
+	if err != nil {
+		return fmt.Errorf("failed to detect %s network interface: %w", BridgeExternalName, err)
+	}
+	i.log.Infof("Detected %s network interface: %s", BridgeExternalName, iface)
+
+	if err := i.applyNetworkConfigurationMachineConfig(ctx, iface); err != nil {
+		return fmt.Errorf("failed to apply network configuration machine config: %w", err)
+	}
+
+	// TODO: Try to simlify the wait for MC to apply
+	if err := i.waitForMCPMasterUpdated(ctx); err != nil {
+		return err
+	}
+
+	if err := i.waitForNodeToApplyRenderedMC(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// waitForMCPMasterUpdated mirrors the shell logic: first detect updating/rendered change,
+// then wait for Updated=True and Degraded!=True with new rendered.
+func (i *IPConfigHandler) waitForMCPMasterUpdated(ctx context.Context) error {
+	i.log.Info("Waiting for MachineConfigPool/master to roll out a new rendered configuration")
+
+	// Fetch initial rendered name
+	mcp := &machineconfigv1.MachineConfigPool{}
+	if err := i.runtimeClient.Get(ctx, types.NamespacedName{Name: MCPMasterName}, mcp); err != nil {
+		return fmt.Errorf("failed to get mcp/master: %w", err)
+	}
+	prevRendered := ""
+	if mcp.Status.Configuration.Name != "" {
+		prevRendered = mcp.Status.Configuration.Name
+	}
+	if prevRendered != "" {
+		i.log.Infof("Current MCP/master rendered: %s", prevRendered)
+	}
+
+	deadlineCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+
+	if err := wait.PollUntilContextTimeout(deadlineCtx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if err := i.runtimeClient.Get(ctx, types.NamespacedName{Name: MCPMasterName}, mcp); err != nil {
+			i.log.Warnf("failed to get mcp/master: %v", err)
+			return false, nil
+		}
+		rendered := mcp.Status.Configuration.Name
+		updating := mcpConditionStatus(mcp.Status.Conditions, MCPConditionUpdating)
+		if rendered != prevRendered || updating == mcpConditionTrue {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("timed out waiting for MCP master to begin rollout: %w", err)
+	}
+
+	// Phase 2: wait for Updated=True, Degraded!=True and rendered changed
+	if err := wait.PollUntilContextTimeout(deadlineCtx, 10*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if err := i.runtimeClient.Get(ctx, types.NamespacedName{Name: MCPMasterName}, mcp); err != nil {
+			i.log.Warnf("failed to get mcp/master: %v", err)
+			return false, nil
+		}
+		rendered := mcp.Status.Configuration.Name
+		updated := mcpConditionStatus(mcp.Status.Conditions, MCPConditionUpdated)
+		degraded := mcpConditionStatus(mcp.Status.Conditions, MCPConditionDegraded)
+		if rendered != "" && rendered != prevRendered && updated == mcpConditionTrue && degraded != mcpConditionTrue {
+			i.log.Infof("MachineConfigPool master rolled out new rendered %s (previous %s)", rendered, prevRendered)
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("timed out waiting for MCP master to reach Updated with new rendered config: %w", err)
+	}
+
+	return nil
+}
+
+// waitForNodeToApplyRenderedMC waits for the single node to have desired/current annotations equal to MCP rendered.
+func (i *IPConfigHandler) waitForNodeToApplyRenderedMC(ctx context.Context) error {
+	nodeName, err := utils.GetLocalNodeName(ctx, i.runtimeClient)
+	if err != nil {
+		return fmt.Errorf("failed to get local node name: %w", err)
+	}
+
+	i.log.Infof("Waiting for node %s to apply new MachineConfig", nodeName)
+
+	deadlineCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+
+	// Helper to fetch current MCP rendered name (may change during wait)
+	getRendered := func(ctx context.Context) string {
+		mcp := &machineconfigv1.MachineConfigPool{}
+		if err := i.runtimeClient.Get(ctx, types.NamespacedName{Name: MCPMasterName}, mcp); err != nil {
+			return ""
+		}
+		return mcp.Status.Configuration.Name
+	}
+
+	if err := wait.PollUntilContextTimeout(deadlineCtx, 10*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		rendered := getRendered(ctx)
+		node := &corev1.Node{}
+		if err := i.runtimeClient.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+			i.log.Warnf("failed to get node %s: %v", nodeName, err)
+			return false, nil
+		}
+		ann := node.GetAnnotations()
+		desired := ann[MachineConfigDesiredAnnoKey]
+		current := ann[MachineConfigCurrentAnnoKey]
+
+		if rendered != "" {
+			if desired == rendered && current == rendered {
+				i.log.Infof("Node %s desiredConfig/currentConfig match MCP configuration %s", nodeName, rendered)
+				return true, nil
+			}
+		} else {
+			if desired != "" && desired == current {
+				i.log.Infof("Node %s currentConfig equals desiredConfig (%s)", nodeName, desired)
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("timed out waiting for node %s to apply new MachineConfig: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+const mcpConditionTrue = "True"
+
+// mcpConditionStatus returns the Status string for a given MCP condition type if present, otherwise empty string.
+func mcpConditionStatus(conds []machineconfigv1.MachineConfigPoolCondition, condType string) string {
+	for _, c := range conds {
+		if string(c.Type) == condType {
+			return string(c.Status)
+		}
+	}
+	return ""
+}
+
+func (i *IPConfigHandler) createCryptoDir(cryptoDir string) error {
+	if err := os.MkdirAll(cryptoDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create crypto directory: %w", err)
+	}
+	return nil
+}
+
+func (i *IPConfigHandler) collectKubeConfigCrypto(ctx context.Context, cryptoDir string) error {
+	i.log.Info("Collecting kubeconfig crypto")
+	if err := utils.BackupKubeconfigCrypto(ctx, i.runtimeClient, cryptoDir); err != nil {
+		return fmt.Errorf("failed to collect kubeconfig crypto: %w", err)
+	}
+	return nil
+}
+
+// materializeAuthFileFromPullSecretRef fetches the dockerconfigjson secret by name in the LCA namespace
+// and writes it to an auth file under the LCA workspace, returning the path to the file.
+func materializeAuthFileFromPullSecretRef(
+	ctx context.Context,
+	client runtimeclient.Client,
+	secretName string,
+) (string, error) {
+	secret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{
+		Namespace: common.LcaNamespace,
+		Name:      secretName,
+	}, secret); err != nil {
+		return "", fmt.Errorf("failed to fetch pull secret %s/%s: %w", common.LcaNamespace, secretName, err)
+	}
+	dockercfg, ok := secret.Data[corev1.DockerConfigJsonKey]
+	if !ok || len(dockercfg) == 0 {
+		return "", fmt.Errorf("secret %s/%s missing key %s", common.LcaNamespace, secretName, corev1.DockerConfigJsonKey)
+	}
+	authPath := path.Join(common.LCAWorkspaceDir, "recert-pull-secret.json")
+	if err := os.WriteFile(common.PathOutsideChroot(authPath), dockercfg, 0o600); err != nil {
+		return "", fmt.Errorf("failed to write pull secret auth file: %w", err)
+	}
+	return authPath, nil
+}

--- a/lca-cli/ops/execute.go
+++ b/lca-cli/ops/execute.go
@@ -131,6 +131,8 @@ func nsenterArgs() []string {
 		"--mount",
 		// TODO: Document why we need the IPC namespace
 		"--ipc",
+		// Enter the host network namespace so networking tools see host routes/links
+		"--net",
 		"--pid",
 		"--",
 	}

--- a/lca-cli/ops/mock_ops.go
+++ b/lca-cli/ops/mock_ops.go
@@ -9,6 +9,7 @@
 package ops
 
 import (
+	os "os"
 	reflect "reflect"
 
 	logrus "github.com/sirupsen/logrus"
@@ -53,6 +54,20 @@ func (mr *MockOpsMockRecorder) Chroot(chrootPath any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chroot", reflect.TypeOf((*MockOps)(nil).Chroot), chrootPath)
 }
 
+// CopyFile mocks base method.
+func (m *MockOps) CopyFile(src, dest string, perm os.FileMode) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyFile", src, dest, perm)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CopyFile indicates an expected call of CopyFile.
+func (mr *MockOpsMockRecorder) CopyFile(src, dest, perm any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyFile", reflect.TypeOf((*MockOps)(nil).CopyFile), src, dest, perm)
+}
+
 // CreateExtraPartition mocks base method.
 func (m *MockOps) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionNumber uint) error {
 	m.ctrl.T.Helper()
@@ -79,6 +94,20 @@ func (m *MockOps) CreateIsoWithEmbeddedIgnition(log logrus.FieldLogger, ignition
 func (mr *MockOpsMockRecorder) CreateIsoWithEmbeddedIgnition(log, ignitionBytes, baseIsoPath, outputIsoPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIsoWithEmbeddedIgnition", reflect.TypeOf((*MockOps)(nil).CreateIsoWithEmbeddedIgnition), log, ignitionBytes, baseIsoPath, outputIsoPath)
+}
+
+// EnableClusterServices mocks base method.
+func (m *MockOps) EnableClusterServices(root string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableClusterServices", root)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnableClusterServices indicates an expected call of EnableClusterServices.
+func (mr *MockOpsMockRecorder) EnableClusterServices(root any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableClusterServices", reflect.TypeOf((*MockOps)(nil).EnableClusterServices), root)
 }
 
 // ExtractTarWithSELinux mocks base method.
@@ -169,6 +198,20 @@ func (mr *MockOpsMockRecorder) IsImageMounted(img any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsImageMounted", reflect.TypeOf((*MockOps)(nil).IsImageMounted), img)
 }
 
+// IsNotExist mocks base method.
+func (m *MockOps) IsNotExist(err error) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsNotExist", err)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsNotExist indicates an expected call of IsNotExist.
+func (mr *MockOpsMockRecorder) IsNotExist(err any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNotExist", reflect.TypeOf((*MockOps)(nil).IsNotExist), err)
+}
+
 // ListBlockDevices mocks base method.
 func (m *MockOps) ListBlockDevices() ([]BlockDevice, error) {
 	m.ctrl.T.Helper()
@@ -213,6 +256,36 @@ func (mr *MockOpsMockRecorder) MountImage(img any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MountImage", reflect.TypeOf((*MockOps)(nil).MountImage), img)
 }
 
+// ReadDir mocks base method.
+func (m *MockOps) ReadDir(path string) ([]os.DirEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadDir", path)
+	ret0, _ := ret[0].([]os.DirEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadDir indicates an expected call of ReadDir.
+func (mr *MockOpsMockRecorder) ReadDir(path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDir", reflect.TypeOf((*MockOps)(nil).ReadDir), path)
+}
+
+// ReadFile mocks base method.
+func (m *MockOps) ReadFile(filename string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadFile", filename)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadFile indicates an expected call of ReadFile.
+func (mr *MockOpsMockRecorder) ReadFile(filename any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockOps)(nil).ReadFile), filename)
+}
+
 // RecertFullFlow mocks base method.
 func (m *MockOps) RecertFullFlow(recertContainerImage, authFile, configFile string, preRecertOperations, postRecertOperations func() error, additionalPodmanParams ...string) error {
 	m.ctrl.T.Helper()
@@ -232,6 +305,20 @@ func (mr *MockOpsMockRecorder) RecertFullFlow(recertContainerImage, authFile, co
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecertFullFlow", reflect.TypeOf((*MockOps)(nil).RecertFullFlow), varargs...)
 }
 
+// RemountBoot mocks base method.
+func (m *MockOps) RemountBoot() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemountBoot")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemountBoot indicates an expected call of RemountBoot.
+func (mr *MockOpsMockRecorder) RemountBoot() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemountBoot", reflect.TypeOf((*MockOps)(nil).RemountBoot))
+}
+
 // RemountSysroot mocks base method.
 func (m *MockOps) RemountSysroot() error {
 	m.ctrl.T.Helper()
@@ -244,6 +331,34 @@ func (m *MockOps) RemountSysroot() error {
 func (mr *MockOpsMockRecorder) RemountSysroot() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemountSysroot", reflect.TypeOf((*MockOps)(nil).RemountSysroot))
+}
+
+// RemoveAllFiles mocks base method.
+func (m *MockOps) RemoveAllFiles(path string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveAllFiles", path)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveAllFiles indicates an expected call of RemoveAllFiles.
+func (mr *MockOpsMockRecorder) RemoveAllFiles(path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllFiles", reflect.TypeOf((*MockOps)(nil).RemoveAllFiles), path)
+}
+
+// RemoveFile mocks base method.
+func (m *MockOps) RemoveFile(path string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveFile", path)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveFile indicates an expected call of RemoveFile.
+func (mr *MockOpsMockRecorder) RemoveFile(path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFile", reflect.TypeOf((*MockOps)(nil).RemoveFile), path)
 }
 
 // RestoreOriginalSeedCrypto mocks base method.
@@ -333,6 +448,25 @@ func (mr *MockOpsMockRecorder) RunRecert(recertContainerImage, authFile, recertC
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunRecert", reflect.TypeOf((*MockOps)(nil).RunRecert), varargs...)
 }
 
+// RunSystemdAction mocks base method.
+func (m *MockOps) RunSystemdAction(args ...string) (string, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RunSystemdAction", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunSystemdAction indicates an expected call of RunSystemdAction.
+func (mr *MockOpsMockRecorder) RunSystemdAction(args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunSystemdAction", reflect.TypeOf((*MockOps)(nil).RunSystemdAction), args...)
+}
+
 // RunUnauthenticatedEtcdServer mocks base method.
 func (m *MockOps) RunUnauthenticatedEtcdServer(authFile, name string) error {
 	m.ctrl.T.Helper()
@@ -359,6 +493,49 @@ func (m *MockOps) SetupContainersFolderCommands() error {
 func (mr *MockOpsMockRecorder) SetupContainersFolderCommands() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupContainersFolderCommands", reflect.TypeOf((*MockOps)(nil).SetupContainersFolderCommands))
+}
+
+// StatFile mocks base method.
+func (m *MockOps) StatFile(name string) (os.FileInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StatFile", name)
+	ret0, _ := ret[0].(os.FileInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StatFile indicates an expected call of StatFile.
+func (mr *MockOpsMockRecorder) StatFile(name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatFile", reflect.TypeOf((*MockOps)(nil).StatFile), name)
+}
+
+// StopClusterServices mocks base method.
+func (m *MockOps) StopClusterServices() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopClusterServices")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopClusterServices indicates an expected call of StopClusterServices.
+func (mr *MockOpsMockRecorder) StopClusterServices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopClusterServices", reflect.TypeOf((*MockOps)(nil).StopClusterServices))
+}
+
+// StopEtcdServer mocks base method.
+func (m *MockOps) StopEtcdServer(authfile, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopEtcdServer", authfile, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopEtcdServer indicates an expected call of StopEtcdServer.
+func (mr *MockOpsMockRecorder) StopEtcdServer(authfile, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopEtcdServer", reflect.TypeOf((*MockOps)(nil).StopEtcdServer), authfile, name)
 }
 
 // SystemctlAction mocks base method.
@@ -407,6 +584,20 @@ func (m *MockOps) UnmountAndRemoveImage(img string) error {
 func (mr *MockOpsMockRecorder) UnmountAndRemoveImage(img any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmountAndRemoveImage", reflect.TypeOf((*MockOps)(nil).UnmountAndRemoveImage), img)
+}
+
+// WriteFile mocks base method.
+func (m *MockOps) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteFile", filename, data, perm)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteFile indicates an expected call of WriteFile.
+func (mr *MockOpsMockRecorder) WriteFile(filename, data, perm any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockOps)(nil).WriteFile), filename, data, perm)
 }
 
 // waitForEtcd mocks base method.

--- a/lca-cli/ops/ops.go
+++ b/lca-cli/ops/ops.go
@@ -1,7 +1,24 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ops
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,11 +32,14 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	"github.com/openshift-kni/lifecycle-agent/internal/recert"
+
 	"github.com/openshift-kni/lifecycle-agent/utils"
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
+	cp "github.com/otiai10/copy"
 )
 
 const (
@@ -35,16 +55,27 @@ var podmanRecertArgs = []string{
 //go:generate mockgen -source=ops.go -package=ops -destination=mock_ops.go
 type Ops interface {
 	SystemctlAction(action string, args ...string) (string, error)
+	RunSystemdAction(args ...string) (string, error)
 	RunInHostNamespace(command string, args ...string) (string, error)
 	RunBashInHostNamespace(command string, args ...string) (string, error)
 	RunListOfCommands(cmds []*CMD) error
+	ReadFile(filename string) ([]byte, error)
+	WriteFile(filename string, data []byte, perm os.FileMode) error
+	CopyFile(src, dest string, perm os.FileMode) error
+	RemoveFile(path string) error
+	RemoveAllFiles(path string) error
+	ReadDir(path string) ([]os.DirEntry, error)
+	StatFile(name string) (os.FileInfo, error)
+	IsNotExist(err error) bool
 	ForceExpireSeedCrypto(recertContainerImage, authFile string, hasKubeAdminPassword bool) error
 	RestoreOriginalSeedCrypto(recertContainerImage, authFile string) error
 	RunUnauthenticatedEtcdServer(authFile, name string) error
+	StopEtcdServer(authfile, name string) error
 	waitForEtcd(healthzEndpoint string) error
 	RunRecert(recertContainerImage, authFile, recertConfigFile string, additionalPodmanParams ...string) error
 	ExtractTarWithSELinux(srcPath, destPath string) error
 	RemountSysroot() error
+	RemountBoot() error
 	ImageExists(img string) (bool, error)
 	IsImageMounted(img string) (bool, error)
 	UnmountAndRemoveImage(img string) error
@@ -60,6 +91,8 @@ type Ops interface {
 	GetHostname() (string, error)
 	CreateIsoWithEmbeddedIgnition(log logrus.FieldLogger, ignitionBytes []byte, baseIsoPath, outputIsoPath string) error
 	GetContainerStorageTarget() (string, error)
+	StopClusterServices() error
+	EnableClusterServices(root string) error
 }
 
 type CMD struct {
@@ -95,6 +128,14 @@ func (o *ops) SystemctlAction(action string, args ...string) (string, error) {
 	return output, err
 }
 
+func (o *ops) RunSystemdAction(args ...string) (string, error) {
+	o.log.Infof("Running systemd-run %s", args)
+	output, err := o.hostCommandsExecutor.Execute("systemd-run", args...)
+	if err != nil {
+		err = fmt.Errorf("failed executing systemd-run with args %s: %w", args, err)
+	}
+	return output, err
+}
 func (o *ops) RunBashInHostNamespace(command string, args ...string) (string, error) {
 	args = append([]string{command}, args...)
 	execute, err := o.hostCommandsExecutor.Execute("bash", "-c", strings.Join(args, " "))
@@ -196,6 +237,14 @@ func (o *ops) RunUnauthenticatedEtcdServer(authFile, name string) error {
 	}
 	o.log.Info("Unauthenticated etcd server for recert is up and running")
 
+	return nil
+}
+
+func (o *ops) StopEtcdServer(authfile, name string) error {
+	o.log.Info("Stopping the unauthenticated etcd server")
+	if _, err := o.RunInHostNamespace(podman, "stop", common.EtcdContainerName); err != nil {
+		o.log.WithError(err).Errorf("failed to stop %s container.", common.EtcdContainerName)
+	}
 	return nil
 }
 
@@ -306,6 +355,13 @@ func (o *ops) RemountSysroot() error {
 	return nil
 }
 
+func (o *ops) RemountBoot() error {
+	if _, err := o.hostCommandsExecutor.Execute("mount", "/boot", "-o", "remount,rw"); err != nil {
+		return fmt.Errorf("failed to remount boot: %w", err)
+	}
+	return nil
+}
+
 func (o *ops) ImageExists(img string) (bool, error) {
 	_, err := o.hostCommandsExecutor.Execute(podman, "image", "exists", img)
 	if err != nil {
@@ -403,12 +459,7 @@ func (o *ops) RecertFullFlow(recertContainerImage, authFile, configFile string,
 		return fmt.Errorf("failed to run etcd, err: %w", err)
 	}
 
-	defer func() {
-		o.log.Info("Killing the unauthenticated etcd server")
-		if _, err := o.RunInHostNamespace(podman, "stop", common.EtcdContainerName); err != nil {
-			o.log.WithError(err).Errorf("failed to kill %s container.", common.EtcdContainerName)
-		}
-	}()
+	defer o.StopEtcdServer(authFile, common.EtcdContainerName)
 
 	if preRecertOperations != nil {
 		if err := preRecertOperations(); err != nil {
@@ -501,6 +552,45 @@ func (o *ops) RunListOfCommands(cmds []*CMD) error {
 		}
 	}
 	return nil
+}
+
+// nolint: wrapcheck // this method intentionally returns the underlying os error directly
+func (o *ops) ReadFile(filename string) ([]byte, error) {
+	return os.ReadFile(filename)
+}
+
+// nolint: wrapcheck // this method intentionally returns the underlying os error directly
+func (o *ops) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(filename, data, perm)
+}
+
+// nolint: wrapcheck // this method intentionally returns the underlying copy error directly
+func (o *ops) CopyFile(src, dest string, perm os.FileMode) error {
+	return cp.Copy(src, dest, cp.Options{AddPermission: perm})
+}
+
+// nolint: wrapcheck // this method intentionally returns the underlying os error directly
+func (o *ops) RemoveFile(path string) error {
+	return os.Remove(path)
+}
+
+// nolint: wrapcheck // this method intentionally returns the underlying os error directly
+func (o *ops) RemoveAllFiles(path string) error {
+	return os.RemoveAll(path)
+}
+
+// nolint: wrapcheck // this method intentionally returns the underlying os error directly
+func (o *ops) ReadDir(path string) ([]os.DirEntry, error) {
+	return os.ReadDir(path)
+}
+
+// nolint: wrapcheck // this method intentionally returns the underlying os error directly
+func (o *ops) StatFile(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (o *ops) IsNotExist(err error) bool {
+	return os.IsNotExist(err)
 }
 
 func (o *ops) CreateExtraPartition(installationDisk, extraPartitionLabel, extraPartitionStart string, extraPartitionNumber uint) error {
@@ -612,4 +702,65 @@ func (o *ops) GetContainerStorageTarget() (string, error) {
 
 	}
 	return "", fmt.Errorf("failed to find mountpoint target in %s", containerStorageMountUnit)
+}
+
+// StopClusterServices stops kubelet and crio services with proper container cleanup
+func (o *ops) StopClusterServices() error {
+	o.log.Info("Stop kubelet service")
+	_, err := o.SystemctlAction("stop", "kubelet.service")
+	if err != nil {
+		return fmt.Errorf("failed to stop kubelet: %w", err)
+	}
+
+	o.log.Info("Disabling kubelet service")
+	_, err = o.SystemctlAction("disable", "kubelet.service")
+	if err != nil {
+		return fmt.Errorf("failed to disable kubelet: %w", err)
+	}
+
+	o.log.Info("Stopping containers and CRI-O runtime.")
+	crioSystemdStatus, err := o.SystemctlAction("is-active", "crio")
+	var exitErr *exec.ExitError
+	// If ExitCode is 3, the command succeeded and told us that crio is down
+	if err != nil && errors.As(err, &exitErr) && exitErr.ExitCode() != 3 {
+		return fmt.Errorf("failed to checking crio status: %w", err)
+	}
+	o.log.Info("crio status is ", crioSystemdStatus)
+	if crioSystemdStatus == "active" {
+		// CRI-O is active, so stop running containers with retry
+		_ = wait.PollUntilContextCancel(context.TODO(), time.Second, true, func(ctx context.Context) (done bool, err error) {
+			o.log.Info("Stop running containers")
+			args := []string{"ps", "-q", "|", "xargs", "--no-run-if-empty", "--max-args", "1", "--max-procs", "10", "crictl", "stop", "--timeout", "5"}
+			_, err = o.RunBashInHostNamespace("crictl", args...)
+			if err != nil {
+				return false, fmt.Errorf("failed to stop running containers: %w", err)
+			}
+			return true, nil
+		})
+
+		// Execute a D-Bus call to stop the CRI-O runtime
+		o.log.Debug("Stopping CRI-O engine")
+		_, err = o.SystemctlAction("stop", "crio.service")
+		if err != nil {
+			return fmt.Errorf("failed to stop crio engine: %w", err)
+		}
+		o.log.Info("Running containers and CRI-O engine stopped successfully.")
+	} else {
+		o.log.Info("Skipping running containers and CRI-O engine already stopped.")
+	}
+
+	return nil
+}
+
+func (o *ops) EnableClusterServices(root string) error {
+	args := []string{}
+	if root != "" {
+		args = append(args, "--root", root)
+	}
+	args = append(args, "kubelet.service")
+	_, err := o.SystemctlAction("enable", args...)
+	if err != nil {
+		return fmt.Errorf("failed to enable kubelet: %w", err)
+	}
+	return nil
 }

--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -69,7 +69,7 @@ func NewPostPivot(scheme *runtime.Scheme, log *logrus.Logger, ops ops.Ops, authF
 }
 
 var (
-	dnsmasqOverrides   = "/etc/default/sno_dnsmasq_configuration_overrides"
+	dnsmasqOverrides   = common.DnsmasqOverrides
 	nmConnectionFolder = common.NMConnectionFolder
 	nodePrimaryIPFile  = "/run/nodeip-configuration/primary-ip"
 	nodeIPHintFile     = "/etc/default/nodeip-configuration"
@@ -685,7 +685,7 @@ func (p *PostPivot) changeRegistryInCSVDeployment(ctx context.Context, client ru
 func (p *PostPivot) cleanup() error {
 	p.log.Info("Cleaning up")
 	listOfDirs := []string{p.workingDir, common.SeedDataDir}
-	if err := utils.RemoveListOfFolders(p.log, listOfDirs); err != nil {
+	if err := utils.RemoveListOfFiles(p.log, listOfDirs); err != nil {
 		return fmt.Errorf("failed to cleanup in postpivot %s: %w", listOfDirs, err)
 	}
 	return nil

--- a/utils/client_helper.go
+++ b/utils/client_helper.go
@@ -461,3 +461,91 @@ func getClusterNetworks(ctx context.Context, client runtimeclient.Client) ([]str
 
 	return clusterNetworks, network.Status.ServiceNetwork, nil
 }
+
+func GetInstallConfig(ctx context.Context, client runtimeclient.Reader) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("runtime client not available")
+	}
+
+	configMap := &corev1.ConfigMap{}
+	err := client.Get(ctx, runtimeclient.ObjectKey{Name: "cluster-config-v1", Namespace: "kube-system"}, configMap)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch cluster-config-v1 ConfigMap: %w", err)
+	}
+
+	installConfig, exists := configMap.Data["install-config"]
+	if !exists {
+		return "", fmt.Errorf("install-config not found in cluster-config-v1 ConfigMap")
+	}
+
+	return installConfig, nil
+}
+
+// getLocalNodeName returns the current node's name from the hostname.
+func GetLocalNodeName(ctx context.Context, client client.Reader) (string, error) {
+	nodeList := &corev1.NodeList{}
+	if err := client.List(ctx, nodeList); err != nil {
+		return "", fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	if len(nodeList.Items) != 1 {
+		return "", fmt.Errorf("expected exactly one node, got %d", len(nodeList.Items))
+	}
+
+	return nodeList.Items[0].Name, nil
+}
+
+func GetNodeInternalIPs(ctx context.Context, client client.Reader) ([]string, error) {
+	nodeName, err := GetLocalNodeName(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	node := &corev1.Node{}
+	if err := client.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		return nil, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+
+	var ips []string
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			ips = append(ips, addr.Address)
+		}
+	}
+
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("failed to find node internal ip addresses")
+	}
+
+	return ips, nil
+}
+
+// installConfigSubset captures only the fields we need from install-config
+type installConfigSubset struct {
+	Networking struct {
+		MachineNetwork []struct {
+			CIDR string `yaml:"cidr"`
+		} `yaml:"machineNetwork"`
+	} `yaml:"networking"`
+}
+
+func GetMachineNetworks(ctx context.Context, client runtimeclient.Reader) ([]string, error) {
+	installConfig, err := GetInstallConfig(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get install config: %w", err)
+	}
+
+	var ic installConfigSubset
+	if err := yaml.Unmarshal([]byte(installConfig), &ic); err != nil {
+		return nil, fmt.Errorf("failed to parse install-config yaml: %w", err)
+	}
+
+	var machineNetworks []string
+	for _, mn := range ic.Networking.MachineNetwork {
+		if mn.CIDR != "" {
+			machineNetworks = append(machineNetworks, mn.CIDR)
+		}
+	}
+
+	return machineNetworks, nil
+}

--- a/utils/client_helper_test.go
+++ b/utils/client_helper_test.go
@@ -1,10 +1,15 @@
 package utils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetNodeInternalIPs_DualStack(t *testing.T) {
@@ -153,4 +158,157 @@ func TestClusterInfo_DualStackFields(t *testing.T) {
 	assert.Equal(t, "4.14.0", clusterInfo.OCPVersion)
 	assert.Equal(t, "test-node", clusterInfo.Hostname)
 	assert.Equal(t, "ingress-operator@123456", clusterInfo.IngressCertificateCN)
+}
+
+func newFakeClient(t *testing.T, objs ...crclient.Object) crclient.Reader {
+	t.Helper()
+	sch := scheme.Scheme
+	return fake.NewClientBuilder().WithScheme(sch).WithObjects(objs...).Build()
+}
+
+func TestGetInstallConfig_Success(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := `networking:
+  machineNetwork:
+  - cidr: 192.0.2.0/24`
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config-v1",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"install-config": cfg,
+		},
+	}
+
+	cl := newFakeClient(t, cm)
+
+	got, err := GetInstallConfig(ctx, cl)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg, got)
+}
+
+func TestGetInstallConfig_NilClient(t *testing.T) {
+	ctx := context.Background()
+	got, err := GetInstallConfig(ctx, nil)
+	assert.Error(t, err)
+	assert.Empty(t, got)
+}
+
+func TestGetLocalNodeName_SingleNode(t *testing.T) {
+	ctx := context.Background()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-0",
+		},
+	}
+
+	cl := newFakeClient(t, node)
+
+	name, err := GetLocalNodeName(ctx, cl)
+	assert.NoError(t, err)
+	assert.Equal(t, "master-0", name)
+}
+
+func TestGetLocalNodeName_MultipleNodes(t *testing.T) {
+	ctx := context.Background()
+
+	node1 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	node2 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}}
+
+	cl := newFakeClient(t, node1, node2)
+
+	name, err := GetLocalNodeName(ctx, cl)
+	assert.Error(t, err)
+	assert.Empty(t, name)
+}
+
+func TestGetNodeInternalIPs_Wrapper(t *testing.T) {
+	ctx := context.Background()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-0",
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "192.0.2.10"},
+				{Type: corev1.NodeInternalIP, Address: "2001:db8::10"},
+			},
+		},
+	}
+
+	cl := newFakeClient(t, node)
+
+	ips, err := GetNodeInternalIPs(ctx, cl)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"192.0.2.10", "2001:db8::10"}, ips)
+}
+
+func TestGetNodeInternalIPs_NoInternal(t *testing.T) {
+	ctx := context.Background()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-0",
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeHostName, Address: "master-0"},
+			},
+		},
+	}
+
+	cl := newFakeClient(t, node)
+
+	ips, err := GetNodeInternalIPs(ctx, cl)
+	assert.Error(t, err)
+	assert.Nil(t, ips)
+}
+
+func TestGetMachineNetworks_Success(t *testing.T) {
+	ctx := context.Background()
+
+	installConfigYAML := `networking:
+  machineNetwork:
+  - cidr: 192.0.2.0/24
+  - cidr: 2001:db8::/64`
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config-v1",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"install-config": installConfigYAML,
+		},
+	}
+
+	cl := newFakeClient(t, cm)
+
+	nets, err := GetMachineNetworks(ctx, cl)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"192.0.2.0/24", "2001:db8::/64"}, nets)
+}
+
+func TestGetMachineNetworks_InvalidYAML(t *testing.T) {
+	ctx := context.Background()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config-v1",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"install-config": ":\n  - not: valid",
+		},
+	}
+
+	cl := newFakeClient(t, cm)
+
+	nets, err := GetMachineNetworks(ctx, cl)
+	assert.Error(t, err)
+	assert.Nil(t, nets)
 }

--- a/utils/ignition.go
+++ b/utils/ignition.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"text/template"
+)
+
+// IgnitionNMStateTemplateData represents the template data for the ignition config
+type IgnitionNMStateTemplateData struct {
+	EncodedContent string
+}
+
+//go:embed templates/ignition-nmstate.json.tmpl
+var ignitionNMStateTemplate string
+
+// GenerateIgnitionNMState renders the ignition JSON for nmstate with the provided data
+func GenerateIgnitionNMState(data *IgnitionNMStateTemplateData) (string, error) {
+	if data == nil || data.EncodedContent == "" {
+		return "", fmt.Errorf("encoded content is required")
+	}
+
+	tmpl, err := template.New("ignition-nmstate").Parse(ignitionNMStateTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse ignition template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute ignition template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// IgnitionDNSMasqFilterTemplateData represents the template data for the dnsmasq filter ignition config
+type IgnitionDNSMasqFilterTemplateData struct {
+	EncodedContent string
+}
+
+//go:embed templates/ignition-dnsmasq-filter.json.tmpl
+var ignitionDNSMasqFilterTemplate string
+
+// GenerateIgnitionDNSMasqFilter renders the ignition JSON for dnsmasq filter file with the provided data
+func GenerateIgnitionDNSMasqFilter(data *IgnitionDNSMasqFilterTemplateData) (string, error) {
+	if data == nil || data.EncodedContent == "" {
+		return "", fmt.Errorf("encoded content is required")
+	}
+
+	tmpl, err := template.New("ignition-dnsmasq-filter").Parse(ignitionDNSMasqFilterTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse ignition template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute ignition template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/utils/network_state.go
+++ b/utils/network_state.go
@@ -1,0 +1,183 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+)
+
+// NmAddr represents an IP address in nmstate output.
+type NmAddr struct {
+	IP           string `json:"ip"`
+	PrefixLength int    `json:"prefix-length"`
+}
+
+// NmIPConf represents IPv4/IPv6 configuration for an interface.
+type NmIPConf struct {
+	Enabled bool     `json:"enabled"`
+	Address []NmAddr `json:"address"`
+}
+
+// NmIf represents a network interface in nmstate output.
+type NmIf struct {
+	Name   string   `json:"name"`
+	Type   string   `json:"type"`
+	IPv4   NmIPConf `json:"ipv4"`
+	IPv6   NmIPConf `json:"ipv6"`
+	Bridge NmBridge `json:"bridge,omitempty"`
+	VLAN   *NmVLAN  `json:"vlan,omitempty"`
+}
+
+// NmRoute represents a route entry in nmstate output.
+type NmRoute struct {
+	Destination      string `json:"destination"`
+	NextHopAddress   string `json:"next-hop-address"`
+	NextHopInterface string `json:"next-hop-interface"`
+}
+
+// NmRoutes represents running and configured routes in nmstate output.
+type NmRoutes struct {
+	Running []NmRoute `json:"running"`
+	Config  []NmRoute `json:"config"`
+}
+
+// NmDNSList represents a list of DNS servers in nmstate output.
+type NmDNSList struct {
+	Server []string `json:"server"`
+}
+
+// NmDNS represents DNS resolver configuration in nmstate output.
+type NmDNS struct {
+	Running NmDNSList `json:"running"`
+	Config  NmDNSList `json:"config"`
+}
+
+// NmState is the top-level nmstate JSON structure.
+type NmState struct {
+	Interfaces  []NmIf   `json:"interfaces"`
+	Routes      NmRoutes `json:"routes"`
+	DNSResolver NmDNS    `json:"dns-resolver"`
+}
+
+// NmBridge represents bridge configuration for an interface.
+type NmBridge struct {
+	Port []struct {
+		Name string `json:"name"`
+	} `json:"port"`
+}
+
+// NmVLAN represents VLAN configuration for an interface.
+type NmVLAN struct {
+	BaseIface string `json:"base-iface"`
+	ID        int    `json:"id"`
+}
+
+// ParseNmstate parses nmstate JSON output into NmState.
+func ParseNmstate(output string) (NmState, error) {
+	var state NmState
+	if err := json.Unmarshal([]byte(output), &state); err != nil {
+		return state, fmt.Errorf("failed to parse nmstate JSON: %w", err)
+	}
+	return state, nil
+}
+
+// ExtractDNS returns the first IPv4 and IPv6 DNS servers from nmstate, preferring running config.
+func ExtractDNS(state NmState) (string, string) {
+	dnsServers := state.DNSResolver.Running.Server
+	if len(dnsServers) == 0 {
+		dnsServers = state.DNSResolver.Config.Server
+	}
+
+	var dnsV4, dnsV6 string
+	for _, s := range dnsServers {
+		if isIPv6String(s) {
+			if dnsV6 == "" {
+				dnsV6 = s
+			}
+		} else {
+			if dnsV4 == "" {
+				dnsV4 = s
+			}
+		}
+	}
+
+	return dnsV4, dnsV6
+}
+
+// FindDefaultGateways searches nmstate routes to find default IPv4 and IPv6 gateways
+// for the given bridge name and default route destinations.
+func FindDefaultGateways(state NmState, bridgeName, defaultRouteV4, defaultRouteV6 string) (string, string) {
+	findGW := func(dest string) string {
+		for _, rt := range state.Routes.Running {
+			if rt.Destination == dest && (rt.NextHopInterface == "" || rt.NextHopInterface == bridgeName) {
+				return rt.NextHopAddress
+			}
+		}
+		for _, rt := range state.Routes.Config {
+			if rt.Destination == dest && (rt.NextHopInterface == "" || rt.NextHopInterface == bridgeName) {
+				return rt.NextHopAddress
+			}
+		}
+		return ""
+	}
+	return findGW(defaultRouteV4), findGW(defaultRouteV6)
+}
+
+// ExtractBrExVLANID inspects the bridge uplink port; if it's a VLAN interface, returns its VLAN ID.
+func ExtractBrExVLANID(state NmState, bridgeName string) (*int, error) {
+	uplink, err := ExtractBrExUplinkName(state, bridgeName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, intf := range state.Interfaces {
+		if intf.Name == uplink && intf.Type == "vlan" && intf.VLAN != nil {
+			return &intf.VLAN.ID, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// ExtractBrExUplinkName returns the uplink port name connected to the given bridge
+// (excluding the bridge internal and patch ports).
+func ExtractBrExUplinkName(state NmState, bridgeName string) (string, error) {
+	for _, intf := range state.Interfaces {
+		if intf.Name == bridgeName && intf.Type == "ovs-bridge" {
+			for _, p := range intf.Bridge.Port {
+				if p.Name != "" && p.Name != bridgeName {
+					return p.Name, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("%s uplink port not found", bridgeName)
+}
+
+// FindMatchingCIDR returns the first CIDR from the list that contains the given IP
+// and matches its IP family. If none is found, returns an empty string.
+func FindMatchingCIDR(ipStr string, cidrs []string) string {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return ""
+	}
+	isV4 := ip.To4() != nil
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil || n == nil {
+			continue
+		}
+		if (n.IP.To4() != nil) != isV4 {
+			continue
+		}
+		if n.Contains(ip) {
+			return c
+		}
+	}
+	return ""
+}
+
+func isIPv6String(s string) bool {
+	ip := net.ParseIP(s)
+	return ip != nil && ip.To4() == nil
+}

--- a/utils/network_state_test.go
+++ b/utils/network_state_test.go
@@ -1,0 +1,181 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNmstate_Success(t *testing.T) {
+	jsonInput := `{
+		"interfaces": [
+			{
+				"name": "br-ex",
+				"type": "ovs-bridge",
+				"ipv4": { "enabled": true, "address": [ { "ip": "192.0.2.10", "prefix-length": 24 } ] },
+				"ipv6": { "enabled": false, "address": [] }
+			}
+		],
+		"routes": { "running": [], "config": [] },
+		"dns-resolver": {
+			"running": { "server": ["1.1.1.1"] },
+			"config": { "server": [] }
+		}
+	}`
+
+	state, err := ParseNmstate(jsonInput)
+	assert.NoError(t, err)
+	assert.Len(t, state.Interfaces, 1)
+	assert.Equal(t, "br-ex", state.Interfaces[0].Name)
+}
+
+func TestParseNmstate_InvalidJSON(t *testing.T) {
+	_, err := ParseNmstate("{invalid json")
+	assert.Error(t, err)
+}
+
+func TestExtractDNS_PrefersRunningThenConfig(t *testing.T) {
+	state := NmState{
+		DNSResolver: NmDNS{
+			Running: NmDNSList{
+				Server: []string{"1.1.1.1", "2001:db8::1"},
+			},
+			Config: NmDNSList{
+				Server: []string{"8.8.8.8", "2001:db8::2"},
+			},
+		},
+	}
+
+	ipv4, ipv6 := ExtractDNS(state)
+	assert.Equal(t, "1.1.1.1", ipv4)
+	assert.Equal(t, "2001:db8::1", ipv6)
+
+	// If running is empty, fall back to config
+	state.DNSResolver.Running.Server = nil
+	ipv4, ipv6 = ExtractDNS(state)
+	assert.Equal(t, "8.8.8.8", ipv4)
+	assert.Equal(t, "2001:db8::2", ipv6)
+}
+
+func TestFindDefaultGateways(t *testing.T) {
+	state := NmState{
+		Routes: NmRoutes{
+			Running: []NmRoute{
+				{Destination: "0.0.0.0/0", NextHopAddress: "192.0.2.1", NextHopInterface: ""},
+				{Destination: "::/0", NextHopAddress: "2001:db8::1", NextHopInterface: "br-ex"},
+			},
+			Config: []NmRoute{
+				{Destination: "0.0.0.0/0", NextHopAddress: "198.51.100.1", NextHopInterface: "other"},
+			},
+		},
+	}
+
+	gw4, gw6 := FindDefaultGateways(state, "br-ex", "0.0.0.0/0", "::/0")
+	assert.Equal(t, "192.0.2.1", gw4)
+	assert.Equal(t, "2001:db8::1", gw6)
+}
+
+func TestExtractBrExUplinkName_Success(t *testing.T) {
+	state := NmState{
+		Interfaces: []NmIf{
+			{
+				Name: "br-ex",
+				Type: "ovs-bridge",
+				Bridge: NmBridge{
+					Port: []struct {
+						Name string `json:"name"`
+					}{
+						{Name: "br-ex"},
+						{Name: "ens3"},
+					},
+				},
+			},
+		},
+	}
+
+	uplink, err := ExtractBrExUplinkName(state, "br-ex")
+	assert.NoError(t, err)
+	assert.Equal(t, "ens3", uplink)
+}
+
+func TestExtractBrExUplinkName_NotFound(t *testing.T) {
+	state := NmState{}
+	_, err := ExtractBrExUplinkName(state, "br-ex")
+	assert.Error(t, err)
+}
+
+func TestExtractBrExVLANID_Found(t *testing.T) {
+	state := NmState{
+		Interfaces: []NmIf{
+			{
+				Name: "br-ex",
+				Type: "ovs-bridge",
+				Bridge: NmBridge{
+					Port: []struct {
+						Name string `json:"name"`
+					}{
+						{Name: "br-ex"},
+						{Name: "vlan123"},
+					},
+				},
+			},
+			{
+				Name: "vlan123",
+				Type: "vlan",
+				VLAN: &NmVLAN{
+					BaseIface: "ens3",
+					ID:        123,
+				},
+			},
+		},
+	}
+
+	id, err := ExtractBrExVLANID(state, "br-ex")
+	assert.NoError(t, err)
+	if assert.NotNil(t, id) {
+		assert.Equal(t, 123, *id)
+	}
+}
+
+func TestExtractBrExVLANID_NoVLAN(t *testing.T) {
+	state := NmState{
+		Interfaces: []NmIf{
+			{
+				Name: "br-ex",
+				Type: "ovs-bridge",
+				Bridge: NmBridge{
+					Port: []struct {
+						Name string `json:"name"`
+					}{
+						{Name: "br-ex"},
+						{Name: "ens3"},
+					},
+				},
+			},
+			{
+				Name: "ens3",
+				Type: "ethernet",
+			},
+		},
+	}
+
+	id, err := ExtractBrExVLANID(state, "br-ex")
+	assert.NoError(t, err)
+	assert.Nil(t, id)
+}
+
+func TestFindMatchingCIDR(t *testing.T) {
+	cidrs := []string{
+		"192.0.2.0/24",
+		"10.0.0.0/8",
+		"2001:db8::/64",
+		"not-a-cidr",
+	}
+
+	assert.Equal(t, "192.0.2.0/24", FindMatchingCIDR("192.0.2.10", cidrs))
+	assert.Equal(t, "2001:db8::/64", FindMatchingCIDR("2001:db8::10", cidrs))
+	// No matching CIDR for this IP
+	assert.Equal(t, "", FindMatchingCIDR("203.0.113.10", []string{"10.0.0.0/8"}))
+	// Invalid IP should return empty string
+	assert.Equal(t, "", FindMatchingCIDR("not-an-ip", cidrs))
+}

--- a/utils/nmstate.go
+++ b/utils/nmstate.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"net"
+	"strings"
+	"text/template"
+)
+
+// NMStateConfig represents the configuration for generating NMState YAML
+type NMStateConfig struct {
+	InterfaceName string
+	VLAN          bool
+	VLANID        int
+	IPv4Config    *IPConfig
+	IPv6Config    *IPConfig
+}
+
+// IPConfig represents IP configuration for a specific protocol
+type IPConfig struct {
+	Address     string
+	PrefixLen   int
+	Enabled     bool
+	DHCPEnabled bool
+	Gateway     string
+	DNSServer   string
+}
+
+// NMStateTemplateData represents the template data for NMState YAML generation
+type NMStateTemplateData struct {
+	InterfaceName string
+	VLANID        int
+	IPv4          IPConfig
+	IPv6          IPConfig
+}
+
+//go:embed templates/nmstate.yaml.tmpl
+var nmstateTemplate string
+
+// GenerateNMStateYAML generates NMState YAML configuration from the provided config
+func GenerateNMStateYAML(config *NMStateConfig) (string, error) {
+	if config.InterfaceName == "" {
+		return "", fmt.Errorf("interface name is required")
+	}
+
+	templateData := NMStateTemplateData{
+		InterfaceName: config.InterfaceName,
+		VLANID:        config.VLANID,
+		IPv4: IPConfig{
+			Enabled:     false,
+			DHCPEnabled: false,
+		},
+		IPv6: IPConfig{
+			Enabled:     false,
+			DHCPEnabled: false,
+		},
+	}
+
+	if config.IPv4Config != nil {
+		templateData.IPv4 = *config.IPv4Config
+	}
+
+	if config.IPv6Config != nil {
+		templateData.IPv6 = *config.IPv6Config
+	}
+
+	tmpl, err := template.New("nmstate").Parse(nmstateTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse NMState template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, templateData); err != nil {
+		return "", fmt.Errorf("failed to execute NMState template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// GenerateNMState generates NMState YAML from IPs and their machine network CIDRs.
+// It derives the prefix length from the provided CIDRs.
+func GenerateNMState(
+	interfaceName string,
+	ips []string,
+	machineNetworks []string,
+	ipv4Gateway string,
+	ipv6Gateway string,
+	ipv4DNS string,
+	ipv6DNS string,
+	vlanID int,
+) (string, error) {
+	if len(ips) == 0 {
+		return "", fmt.Errorf("at least one IP address is required")
+	}
+	if len(ips) != len(machineNetworks) {
+		return "", fmt.Errorf("ips and machineNetworks must be same length")
+	}
+
+	config := &NMStateConfig{InterfaceName: interfaceName, VLANID: vlanID}
+
+	for idx, ip := range ips {
+		cidr := machineNetworks[idx]
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return "", fmt.Errorf("invalid machine network CIDR %q: %w", cidr, err)
+		}
+		ones, _ := ipNet.Mask.Size()
+
+		if strings.Contains(ip, ":") {
+			if config.IPv6Config == nil {
+				config.IPv6Config = &IPConfig{
+					Address:     ip,
+					PrefixLen:   ones,
+					Enabled:     true,
+					DHCPEnabled: false,
+				}
+			}
+		} else {
+			if config.IPv4Config == nil {
+				config.IPv4Config = &IPConfig{
+					Address:     ip,
+					PrefixLen:   ones,
+					Enabled:     true,
+					DHCPEnabled: false,
+				}
+			}
+		}
+	}
+
+	if config.IPv4Config != nil {
+		config.IPv4Config.Gateway = ipv4Gateway
+		config.IPv4Config.DNSServer = ipv4DNS
+	}
+	if config.IPv6Config != nil {
+		config.IPv6Config.Gateway = ipv6Gateway
+		config.IPv6Config.DNSServer = ipv6DNS
+	}
+
+	return GenerateNMStateYAML(config)
+}

--- a/utils/nmstate_test.go
+++ b/utils/nmstate_test.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateNMState_IPv4Only(t *testing.T) {
+	nm, err := GenerateNMState(
+		"eth0",
+		[]string{"192.0.2.10"},
+		[]string{"192.0.2.0/24"},
+		"192.0.2.1",
+		"",
+		"8.8.8.8",
+		"",
+		0,
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, nm, "192.0.2.10")
+	assert.Contains(t, nm, "192.0.2.1")
+	assert.Contains(t, nm, "8.8.8.8")
+}
+
+func TestGenerateNMState_IPv6Only(t *testing.T) {
+	nm, err := GenerateNMState(
+		"eth0",
+		[]string{"2001:db8::10"},
+		[]string{"2001:db8::/64"},
+		"",
+		"2001:db8::1",
+		"",
+		"2001:4860:4860::8888",
+		100,
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, nm, "2001:db8::10")
+	assert.Contains(t, nm, "2001:db8::1")
+	assert.Contains(t, nm, "2001:4860:4860::8888")
+}
+
+func TestGenerateNMState_DualStack(t *testing.T) {
+	nm, err := GenerateNMState(
+		"eth0",
+		[]string{"192.0.2.10", "2001:db8::10"},
+		[]string{"192.0.2.0/24", "2001:db8::/64"},
+		"192.0.2.1",
+		"2001:db8::1",
+		"8.8.8.8",
+		"2001:4860:4860::8888",
+		0,
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, nm, "192.0.2.10")
+	assert.Contains(t, nm, "2001:db8::10")
+}
+
+func TestGenerateNMState_Errors(t *testing.T) {
+	_, err := GenerateNMState(
+		"eth0",
+		[]string{},
+		[]string{},
+		"",
+		"",
+		"",
+		"",
+		0,
+	)
+	assert.Error(t, err)
+
+	_, err = GenerateNMState(
+		"eth0",
+		[]string{"192.0.2.10"},
+		[]string{"192.0.2.0/24", "10.0.0.0/8"},
+		"",
+		"",
+		"",
+		"",
+		0,
+	)
+	assert.Error(t, err)
+
+	_, err = GenerateNMState(
+		"eth0",
+		[]string{"192.0.2.10"},
+		[]string{"not-a-cidr"},
+		"",
+		"",
+		"",
+		"",
+		0,
+	)
+	assert.Error(t, err)
+}

--- a/utils/systemd.go
+++ b/utils/systemd.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"text/template"
+)
+
+const (
+	// NodeIP configuration paths
+	PrimaryIPPath       = "/run/nodeip-configuration/primary-ip"
+	NodeipDefaultsPath  = "/etc/default/nodeip-configuration"
+	NodeipRerunUnitPath = "/etc/systemd/system/sno-nodeip-rerun.service"
+)
+
+// NodeIPRerunServiceTemplateData represents the template data for systemd service generation
+type NodeIPRerunServiceTemplateData struct {
+	BaseIP  string
+	HintSed string
+}
+
+//go:embed templates/sno-nodeip-rerun.service.tmpl
+var nodeipRerunServiceTemplate string
+
+// GenerateNodeIPRerunService generates systemd service content from the provided template data
+func GenerateNodeIPRerunService(data *NodeIPRerunServiceTemplateData) (string, error) {
+	if err := validateNodeIPRerunServiceData(data); err != nil {
+		return "", err
+	}
+
+	tmpl, err := template.New("nodeip-rerun-service").Parse(nodeipRerunServiceTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse systemd service template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute systemd service template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// validateNodeIPRerunServiceData validates the systemd service template data
+func validateNodeIPRerunServiceData(data *NodeIPRerunServiceTemplateData) error {
+	if data == nil {
+		return fmt.Errorf("template data cannot be nil")
+	}
+	if data.BaseIP == "" {
+		return fmt.Errorf("base IP is required")
+	}
+	if data.HintSed == "" {
+		return fmt.Errorf("hint sed is required")
+	}
+	return nil
+}

--- a/utils/systemd_test.go
+++ b/utils/systemd_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateNodeIPRerunService_Success(t *testing.T) {
+	data := &NodeIPRerunServiceTemplateData{
+		BaseIP:  "192.168.1.0",
+		HintSed: "192.168.1.0",
+	}
+
+	unit, err := GenerateNodeIPRerunService(data)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, unit)
+
+	// The rendered unit should contain both the base IP and the sed‑escaped hint
+	assert.Contains(t, unit, "192.168.1.0")
+}
+
+func TestGenerateNodeIPRerunService_NilData(t *testing.T) {
+	unit, err := GenerateNodeIPRerunService(nil)
+	assert.Error(t, err)
+	assert.Equal(t, "", unit)
+}
+
+func TestGenerateNodeIPRerunService_MissingBaseIP(t *testing.T) {
+	data := &NodeIPRerunServiceTemplateData{
+		BaseIP:  "",
+		HintSed: "hint",
+	}
+
+	unit, err := GenerateNodeIPRerunService(data)
+	assert.Error(t, err)
+	assert.Equal(t, "", unit)
+}
+
+func TestGenerateNodeIPRerunService_MissingHintSed(t *testing.T) {
+	data := &NodeIPRerunServiceTemplateData{
+		BaseIP:  "192.168.1.0",
+		HintSed: "",
+	}
+
+	unit, err := GenerateNodeIPRerunService(data)
+	assert.Error(t, err)
+	assert.Equal(t, "", unit)
+}

--- a/utils/templates/ignition-dnsmasq-filter.json.tmpl
+++ b/utils/templates/ignition-dnsmasq-filter.json.tmpl
@@ -1,0 +1,19 @@
+{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/dnsmasq.d/single-node-filter.conf",
+        "overwrite": true,
+        "mode": 420,
+        "contents": {
+          "source": "data:text/plain;charset=utf-8;base64,{{ .EncodedContent }}"
+        }
+      }
+    ]
+  }
+}
+
+

--- a/utils/templates/ignition-nmstate.json.tmpl
+++ b/utils/templates/ignition-nmstate.json.tmpl
@@ -1,0 +1,17 @@
+{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/nmstate/openshift/cluster.yml",
+        "mode": 420,
+        "contents": {
+          "source": "data:text/plain;charset=utf-8;base64,{{ .EncodedContent }}"
+        }
+      }
+    ]
+  }
+}
+

--- a/utils/templates/nmstate.yaml.tmpl
+++ b/utils/templates/nmstate.yaml.tmpl
@@ -1,0 +1,80 @@
+interfaces:
+- name: {{ .InterfaceName }}
+  {{- if gt .VLANID 0 }}
+  type: vlan
+  {{- else }}
+  type: ethernet
+  {{- end }}
+  state: up
+  {{- if gt .VLANID 0 }}
+  vlan:
+    id: {{ .VLANID }}
+  {{- end }}
+  ipv4:
+    enabled: false
+  ipv6:
+    enabled: false
+- name: br-ex
+  type: ovs-bridge
+  state: up
+  ipv4:
+    enabled: false
+    dhcp: false
+  ipv6:
+    enabled: false
+    dhcp: false
+  bridge:
+    options:
+      mcast-snooping-enable: true
+    port:
+    - name: {{ .InterfaceName }}
+    - name: br-ex
+- name: br-ex
+  type: ovs-interface
+  state: up
+  copy-mac-from: {{ .InterfaceName }}
+  ipv4:
+    enabled: {{ .IPv4.Enabled }}
+    dhcp: false
+    {{- if .IPv4.Enabled }}
+    address:
+    - ip: {{ .IPv4.Address }}
+      prefix-length: {{ .IPv4.PrefixLen }}
+    {{- end }}
+  ipv6:
+    enabled: {{ .IPv6.Enabled }}
+    dhcp: false
+    {{- if .IPv6.Enabled }}
+    address:
+    - ip: {{ .IPv6.Address }}
+      prefix-length: {{ .IPv6.PrefixLen }}
+    {{- end }}
+{{- if or .IPv4.Gateway .IPv6.Gateway }}
+routes:
+  config:
+  {{- if .IPv4.Gateway }}
+  - destination: 0.0.0.0/0
+    next-hop-interface: br-ex
+    next-hop-address: {{ .IPv4.Gateway }}
+    metric: 48
+    table-id: 254
+  {{- end }}
+  {{- if .IPv6.Gateway }}
+  - destination: ::/0
+    next-hop-interface: br-ex
+    next-hop-address: {{ .IPv6.Gateway }}
+    metric: 48
+    table-id: 254
+  {{- end }}
+{{- end }}
+{{- if or .IPv4.DNSServer .IPv6.DNSServer }}
+dns-resolver:
+  config:
+    server:
+    {{- if .IPv4.DNSServer }}
+    - {{ .IPv4.DNSServer }}
+    {{- end }}
+    {{- if .IPv6.DNSServer }}
+    - {{ .IPv6.DNSServer }}
+    {{- end }}
+{{- end }}

--- a/utils/templates/sno-nodeip-rerun.service.tmpl
+++ b/utils/templates/sno-nodeip-rerun.service.tmpl
@@ -1,0 +1,25 @@
+[Unit]
+Description=SNO post-boot nodeip-configuration rerun
+Wants=NetworkManager-wait-online.service
+After=NetworkManager-wait-online.service nmstate-configuration.service nmstate.service firstboot-osupdate.target
+Before=kubelet-dependencies.target ovs-configuration.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/bash -lc 'rm -f /run/nodeip-configuration/primary-ip || true'
+ExecStartPre=/usr/bin/bash -lc '\
+  if [[ -f "/etc/default/nodeip-configuration" ]]; then \
+    if grep -q "^KUBELET_NODEIP_HINT=" "/etc/default/nodeip-configuration"; then \
+      sed -i "s/^KUBELET_NODEIP_HINT=.*/KUBELET_NODEIP_HINT={{.HintSed}}/" "/etc/default/nodeip-configuration"; \
+    else \
+      echo "KUBELET_NODEIP_HINT={{.BaseIP}}" >> "/etc/default/nodeip-configuration"; \
+    fi; \
+  else \
+    echo "KUBELET_NODEIP_HINT={{.BaseIP}}" > "/etc/default/nodeip-configuration"; \
+  fi'
+ExecStart=/usr/bin/systemctl restart nodeip-configuration.service
+ExecStartPost=/usr/bin/systemctl restart wait-for-primary-ip.service
+RemainAfterExit=no
+
+[Install]
+WantedBy=kubelet-dependencies.target

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -33,6 +33,7 @@ import (
 	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	cp "github.com/otiai10/copy"
 	"github.com/sirupsen/logrus"
 )
@@ -255,11 +256,11 @@ func ReplaceImageRegistry(image, targetRegistry, sourceRegistry string) (string,
 	return re.ReplaceAllString(image, targetRegistry), nil
 }
 
-func RemoveListOfFolders(log *logrus.Logger, folders []string) error {
-	for _, folder := range folders {
-		log.Infof("Removing %s folder", folder)
-		if err := os.RemoveAll(folder); err != nil {
-			return fmt.Errorf("failed to remove %s folder: %w", folder, err)
+func RemoveListOfFiles(log *logrus.Logger, files []string) error {
+	for _, file := range files {
+		log.Infof("Removing %s file", file)
+		if err := os.RemoveAll(file); err != nil {
+			return fmt.Errorf("failed to remove %s file: %w", file, err)
 		}
 	}
 	return nil
@@ -433,4 +434,35 @@ func LoadGroupedManifestsFromPath(basePath string, log *logr.Logger) ([][]*unstr
 	}
 
 	return sortedManifests, nil
+}
+
+// BuildKernelArguementsFromMCOFile reads the kernel arguments from MCO file
+// and builds the string arguments that ostree admin deploy requires
+func BuildKernelArgumentsFromMCOFile(path string) ([]string, error) {
+	mc := &mcfgv1.MachineConfig{}
+	if err := ReadYamlOrJSONFile(path, mc); err != nil {
+		return nil, fmt.Errorf("failed to read and decode machine config json file: %w", err)
+	}
+
+	args := make([]string, len(mc.Spec.KernelArguments)*2)
+	for i, karg := range mc.Spec.KernelArguments {
+		// if we don't marshal the karg, `"` won't appear in the kernel arguments after reboot
+		if val, err := json.Marshal(karg); err != nil {
+			return nil, fmt.Errorf("failed to marshal karg %s: %w", karg, err)
+		} else {
+			args[2*i] = "--karg-append"
+			args[2*i+1] = string(val)
+		}
+	}
+
+	if mc.Spec.FIPS {
+		args = append(args,
+			"--karg-append", "fips=1",
+			// This is needed because /boot is on a separate partition https://access.redhat.com/solutions/137833
+			// TODO: Should we have this regardless of FIPS?
+			"--karg-append", "boot=LABEL=boot",
+		)
+	}
+
+	return args, nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -214,4 +215,68 @@ func TestReadSeedReconfigurationFromFile(t *testing.T) {
 	assert.Equal(t, seedReconfig.BaseDomain, "test.com")
 	assert.Equal(t, seedReconfig.ClusterName, "test-cluster")
 	assert.Equal(t, len(seedReconfig.NodeLabels), 0)
+}
+
+func TestGetKernelArgumentsFromMCOFile(t *testing.T) {
+	testcases := []struct {
+		name   string
+		data   string
+		expect []string
+	}{
+		{
+			name: "multiple args",
+			data: `{"spec":{"kernelArguments":[    "tsc=nowatchdog",
+			"nosoftlockup",                                                                                                                     
+            "cgroup_no_v1=\"all\"",
+			"nmi_watchdog=0",                                                                                                                   
+			"mce=off",                                                                                                                          
+			"rcutree.kthread_prio=11",
+			"default_hugepagesz=1G",                                        
+			"hugepagesz=1G",
+			"hugepages=32",
+			"rcupdate.rcu_normal_after_boot=0",                                                                                                 
+			"efi=runtime",                                                                                                                      
+			"vfio_pci.enable_sriov=1",                                                                                                          
+			"vfio_pci.disable_idle_d3=1",                                                                                                       
+			"module_blacklist=irdma",                                                                                                           
+			"intel_pstate=disable"         ]}}`,
+			expect: []string{
+				"--karg-append", "\"tsc=nowatchdog\"",
+				"--karg-append", "\"nosoftlockup\"",
+				"--karg-append", "\"cgroup_no_v1=\\\"all\\\"\"",
+				"--karg-append", "\"nmi_watchdog=0\"",
+				"--karg-append", "\"mce=off\"",
+				"--karg-append", "\"rcutree.kthread_prio=11\"",
+				"--karg-append", "\"default_hugepagesz=1G\"",
+				"--karg-append", "\"hugepagesz=1G\"",
+				"--karg-append", "\"hugepages=32\"",
+				"--karg-append", "\"rcupdate.rcu_normal_after_boot=0\"",
+				"--karg-append", "\"efi=runtime\"",
+				"--karg-append", "\"vfio_pci.enable_sriov=1\"",
+				"--karg-append", "\"vfio_pci.disable_idle_d3=1\"",
+				"--karg-append", "\"module_blacklist=irdma\"",
+				"--karg-append", "\"intel_pstate=disable\"",
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// create fixture
+			f, err := os.CreateTemp("", "tmp")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.Remove(f.Name())
+			if _, err := f.Write([]byte(tc.data)); err != nil {
+				log.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				log.Fatal(err)
+			}
+
+			res, err := BuildKernelArgumentsFromMCOFile(f.Name())
+			assert.Equal(t, tc.expect, res)
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -1,0 +1,130 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+)
+
+// ValidateIPFamilyConfig performs family-specific validation for addr, CIDR, gateway and DNS.
+func ValidateIPFamilyConfig(
+	family string,
+	addr string,
+	networkCIDR string,
+	gateway string,
+	dnsServer string,
+) error {
+	if addr != "" {
+		if err := validateIPAddress(family, addr); err != nil {
+			return fmt.Errorf("invalid %s address: %w", strings.ToUpper(family), err)
+		}
+	}
+
+	if networkCIDR != "" {
+		if err := validateNetworkCIDR(family, networkCIDR); err != nil {
+			return fmt.Errorf("invalid %s machine network CIDR: %w", strings.ToLower(family), err)
+		}
+	}
+
+	if gateway != "" {
+		if err := validateIPAddress(family, gateway); err != nil {
+			return fmt.Errorf("invalid %s gateway: %w", strings.ToUpper(family), err)
+		}
+	}
+
+	if dnsServer != "" {
+		if err := validateIPAddress(family, dnsServer); err != nil {
+			return fmt.Errorf("invalid %s DNS server: %w", strings.ToUpper(family), err)
+		}
+	}
+
+	// Validate that the gateway is within the machine network CIDR for IPv4.
+	// IPv6 gateways may not be within the machine network CIDR since they can be the link-local address.
+	if gateway != "" && networkCIDR != "" && family == common.IPv4FamilyName {
+		if err := validateGatewayInNetworkCIDR(family, gateway, networkCIDR); err != nil {
+			return fmt.Errorf("invalid %s gateway: %w", strings.ToUpper(family), err)
+		}
+	}
+
+	return nil
+}
+
+func validateGatewayInNetworkCIDR(family, gateway, networkCIDR string) error {
+	_, ipNet, err := net.ParseCIDR(networkCIDR)
+	if err != nil {
+		return fmt.Errorf(
+			"invalid %s machine network CIDR: %s: %w",
+			strings.ToLower(family), networkCIDR, err,
+		)
+	}
+
+	gatewayIP := net.ParseIP(gateway)
+	if gatewayIP == nil {
+		return fmt.Errorf(
+			"invalid %s gateway: %s: %w", strings.ToUpper(family), gateway, err,
+		)
+	}
+
+	if !ipNet.Contains(gatewayIP) {
+		return fmt.Errorf("%s gateway %s is not within machine network %s",
+			strings.ToUpper(family), gateway, networkCIDR,
+		)
+	}
+
+	return nil
+}
+
+func validateNetworkCIDR(family, networkCIDR string) error {
+	_, ipNet, err := net.ParseCIDR(networkCIDR)
+	if err != nil {
+		return fmt.Errorf("invalid %s machine network CIDR: %s", strings.ToLower(family), networkCIDR)
+	}
+
+	isIPv4 := family == common.IPv4FamilyName
+	isIPv6 := family == common.IPv6FamilyName
+
+	if !isIPv4 && !isIPv6 {
+		return fmt.Errorf("unsupported IP family: %s", family)
+	}
+
+	if isIPv4 {
+		if ipNet.IP.To4() == nil {
+			return fmt.Errorf("invalid %s machine network CIDR: %s", strings.ToLower(family), networkCIDR)
+		}
+	}
+
+	if ipNet.IP.To16() == nil {
+		return fmt.Errorf("invalid %s machine network CIDR: %s", strings.ToLower(family), networkCIDR)
+	}
+
+	return nil
+}
+
+func validateIPAddress(family, ipStr string) error {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return fmt.Errorf("%s is not parsable as a %s address", ipStr, strings.ToUpper(family))
+	}
+
+	isIPv4 := family == common.IPv4FamilyName
+	isIPv6 := family == common.IPv6FamilyName
+
+	if !isIPv4 && !isIPv6 {
+		return fmt.Errorf("unsupported IP family: %s", family)
+	}
+
+	if isIPv4 {
+		if ip.To4() == nil {
+			return fmt.Errorf("%s is not a valid %s address", ipStr, strings.ToUpper(family))
+		}
+		return nil
+	}
+
+	if ip.To16() == nil {
+		return fmt.Errorf("%s is not a valid %s address", ipStr, strings.ToUpper(family))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!---
This template is not mandatory, but it is highly recommended. If you feel like
it's a bad fit for your PR, feel free to delete some or all of it. By filling
it, it will help you to think through the changes you are making and why you
are making them, and hopefully even regret some of them early. It will also
help the reviewer to understand your changes better, which will help them to
review your code more effectively. Remember reviewers time is valuable, and
often without this information, reviewing feels a bit like tedious reverse
engineering.

Be as verbose as you like! You don't have to write paragraphs if you don't
want, even brief notes can be helpful. But a lot of information never hurts.
Remember that often this will be the only record of our decisions / design, and
our only form of communication with other team members about our changes. So
it's good to be thorough.
-->

# Background / Context

IP Configuration is a new flow introduced to provide solution for 2 main use cases -

1. **Rehoming** - Changing SNO and its node IP address as well other basic networking features in a planned connected manner.
2. **Disaster** Recovery - Changing SNO and its node IP address as well as other basic networking features when unplanned disaster occur and uplink is gone.

This commit implements the CLI part of the feature and will be followed with another one for creating wrapper API and controller that will use this cli tool to perform the changes. We are using the cli tool because:

1. **Cluster shutdown** - Some operations shutdown the cluster and therefore we need a way to run commands directly on the host.
2. **Enabled direct usage without k8s** - Can be used to perform the flow directly on the host with no k8s involved.
3. **Easier testing** - When all the core logic is part of the cli, we can test the cli first and only then make the required changes in the controller / API

<!---
Not all reviewers know everything there is to know about the project, use this
section to give a bit of background knowledge about the part of the project
you're changing. Things like links to previous relevant commits, existing
system behavior, how things currently work. Don't describe your changes or what
issue you're solving, just things that are already established. Even if these
seem obvious and the reviewer likely already knows them, it still helps
establish the context of the change.
-->

# Issue / Requirement / Reason for change

Customer demand for these capabilities

<!---
The reason for making this PR. Use this section to describe the issue you're
solving. The shortcomings of the above background. This doesn't have to be an
actual issue/bug, but could also be a requirement that is being addressed or
the need for a new feature. Don't describe your solution just yet, focus on the
problem/requirement. If there's a relevant ticket, also link it here.
-->

# Solution / Feature Overview

To facilitate the IP Configuration flow, new `ip-config command and 3 new sub-commands introduced:

1. `prepare` - Prepares new identical stateroot and reboots into it. This is done because we want to make all the changes in the new stateroot so whatever happens during the flow we can always rollback to the old stateroot (old state). 
May also initialize monitor service that will reboot back to the old stateroot when timed out. 

2. `run` - Performs all the changes to the host / cluster. Should be executed after `prepare` called in the new stateroot after `prepare` called. The operations done:

1. **Collect cluster data**
      a. Gather cryptographic materials required for recert.
      b. Extract the ingress certificate’s Common Name (for recert).
      c. Retrieve the install-config.yaml (for recert).
      d. Detect the node’s current IP addresses (for recert).

2. **Configure networking**
     a. Create a MachineConfig that writes the new nmstate configuration into /etc/nmstate/openshift, which will be applied on the next boot by nmstate.service.

3. **Reconfigure the cluster**
     a. Stop cluster services to safely run recert.
     b. Run recert to update cluster certificates and configuration.
     c. Create a nodeip-configuration-rerun one-shot systemd unit that runs immediately after nmstate.service to re-apply node IP settings.
     d. Update the dnsmasq service (installed by assisted-installer) to use the new IP address.
     e. Clean up previously applied nmstate files under /etc/nmstate.
     f. Remove specific OVN/OVS/Multus state files so they can be regenerated on reboot.
     g. Re-enable cluster services.
     h. Reboot into the new network configuration.

3. `rollback` - reboots back into the old stateroot.

# Testing

To test the changes:

**Preparation**

1. Install an SNO using assisted installer.
2. Clone this repository and checkout to this PR changes.
3. Build the CLI binary - `CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -mod=vendor -a -o build/lca-cli main/lca-cli/main.go`
4. Copy it to the SNO node: `scp build/lca-cli core@<node-ip>:/home/core`

**Run**

1. SSH into the node.
2. Run `sudo /hone/core/lca-cli ip-config prepare --new-stateroot-name <some-name>`. It will reboot into the new stateroot.
3. SSH back into the node.
4. Run `sudo /home/core/lca-cli ip-config run --ipv6-address <ip> --ipv6-dns <dns> --ipv6-gateway <gateway> --ipv6-machine-network <machine-network> --recert-image quay.io/dmanor/recert:ip-change-v5` (for example for single-stack IPv6 changes. For dual-stacl cluster provide both IP families even if they did not change).

# Notes

- The implementation highlights the requirement for a revertible flow so no harm is done in case of failure.
- Some of the changes are duplicating existing IBU code in order to avoid exposing IBU failures due to this change in the short time frame in which this change introduced. Later on this should be changed to share more code. 

<!---
Use this section to give a general overview of the solution you're proposing.
Explain how it helps to solve the issue you described above. No need to go into
code specifics.
-->
<!---

# Checklist

This is a personal checklist that should be applicable to most PRs. It's good
to go over it in order to make sure you haven't missed anything. If you feel
like some of these points are not relevant to your PR, feel free to keep them
unchecked and if you want also explain why you think they're inapplicable.

- [ ] I also copied this entire text into my commit message, and not just the GitHub PR description (`git config commit.template .github/pull_request_template.md`)
- [ ] I performed a rough self-review of my changes
- [ ] I explained non-trivial motivation for my code using code-comments
- [ ] I made sure my code passes linting, tests, and builds correctly
- [ ] I have ran the code and made sure it works as intended, and doesn't introduce any obvious regressions
- [ ] I have not committed any irrelevant changes (if you did, please point them out and why, ideally separate them into a different PR)
- [ ] I added tests (or decided that tests aren't really necessary)
- [ ] I deleted this checklist and all the "<!---" comments (like this one) from the commit message and the PR description, leaving only my own text
-->
