### PR TITLE
MGMT-21789: Improvements / fixes to the IP Configuration flow

### DIFF
--- a/api/ipconfig/v1/types.go
+++ b/api/ipconfig/v1/types.go
@@ -73,20 +73,18 @@ var IPStages = struct {
 }
 
 // IPv4Config represents a single IPv4 stack configuration
-// +kubebuilder:validation:XValidation:message="IPv4 address must be within its machineNetwork CIDR",rule="self.address == \"\" || self.machineNetwork == \"\" || cidr(self.machineNetwork).containsIP(self.address)"
-// +kubebuilder:validation:XValidation:message="IPv4 gateway must be within its machineNetwork CIDR",rule="self.gateway == \"\" || self.machineNetwork == \"\" || cidr(self.machineNetwork).containsIP(self.gateway)"
+// +kubebuilder:validation:XValidation:message="IPv4 address must be within its machineNetwork CIDR",rule="!has(self.address) || self.address == \"\" || !has(self.machineNetwork) || self.machineNetwork == \"\" || cidr(self.machineNetwork).containsIP(self.address)"
+// +kubebuilder:validation:XValidation:message="IPv4 gateway must be within its machineNetwork CIDR",rule="!has(self.gateway) || self.gateway == \"\" || !has(self.machineNetwork) || self.machineNetwork == \"\" || cidr(self.machineNetwork).containsIP(self.gateway)"
 type IPv4Config struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Format=ipv4
 	// Address is the full IPv4 address without prefix length (e.g., 192.0.2.10)
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Address string `json:"address,omitempty"`
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Format=cidr
 	// MachineNetwork is the IPv4 machine network CIDR (e.g., 192.0.2.0/24)
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	MachineNetwork string `json:"machineNetwork,omitempty"`
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Format=ipv4
 	// Gateway is the default IPv4 gateway address
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
@@ -94,20 +92,18 @@ type IPv4Config struct {
 }
 
 // IPv6Config represents a single IPv6 stack configuration
-// +kubebuilder:validation:XValidation:message="IPv6 address must be within its machineNetwork CIDR",rule="self.address == \"\" || self.machineNetwork == \"\" || cidr(self.machineNetwork).containsIP(self.address)"
-// +kubebuilder:validation:XValidation:message="IPv6 gateway must be within its machineNetwork CIDR unless it is link-local",rule="self.gateway == \"\" || self.machineNetwork == \"\" || cidr(self.machineNetwork).containsIP(self.gateway) || cidr(\"fe80::/10\").containsIP(self.gateway)"
+// +kubebuilder:validation:XValidation:message="IPv6 address must be within its machineNetwork CIDR",rule="!has(self.address) || self.address == \"\" || !has(self.machineNetwork) || self.machineNetwork == \"\" || cidr(self.machineNetwork).containsIP(self.address)"
+// +kubebuilder:validation:XValidation:message="IPv6 gateway must be within its machineNetwork CIDR unless it is link-local",rule="!has(self.gateway) || self.gateway == \"\" || !has(self.machineNetwork) || self.machineNetwork == \"\" || cidr(self.machineNetwork).containsIP(self.gateway) || cidr(\"fe80::/10\").containsIP(self.gateway)"
 type IPv6Config struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Format=ipv6
 	// Address is the full IPv6 address without prefix length (e.g., 2001:db8::1)
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Address string `json:"address,omitempty"`
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Format=cidr
 	// MachineNetwork is the IPv6 machine network CIDR (e.g., 2001:db8::/64)
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	MachineNetwork string `json:"machineNetwork,omitempty"`
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Format=ipv6
 	// Gateway is the default IPv6 gateway address
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}

--- a/bundle/manifests/lca.openshift.io_ipconfigs.yaml
+++ b/bundle/manifests/lca.openshift.io_ipconfigs.yaml
@@ -123,14 +123,14 @@ spec:
                     type: string
                 required:
                 - address
-                - gateway
-                - machineNetwork
                 type: object
                 x-kubernetes-validations:
                 - message: IPv4 address must be within its machineNetwork CIDR
-                  rule: self.address == "" || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.address)
+                  rule: '!has(self.address) || self.address == "" || !has(self.machineNetwork)
+                    || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.address)'
                 - message: IPv4 gateway must be within its machineNetwork CIDR
-                  rule: self.gateway == "" || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.gateway)
+                  rule: '!has(self.gateway) || self.gateway == "" || !has(self.machineNetwork)
+                    || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.gateway)'
               ipv6:
                 description: IPv6 stack (omit for IPv4-only)
                 properties:
@@ -150,16 +150,16 @@ spec:
                     type: string
                 required:
                 - address
-                - gateway
-                - machineNetwork
                 type: object
                 x-kubernetes-validations:
                 - message: IPv6 address must be within its machineNetwork CIDR
-                  rule: self.address == "" || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.address)
+                  rule: '!has(self.address) || self.address == "" || !has(self.machineNetwork)
+                    || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.address)'
                 - message: IPv6 gateway must be within its machineNetwork CIDR unless
                     it is link-local
-                  rule: self.gateway == "" || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.gateway)
-                    || cidr("fe80::/10").containsIP(self.gateway)
+                  rule: '!has(self.gateway) || self.gateway == "" || !has(self.machineNetwork)
+                    || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.gateway)
+                    || cidr("fe80::/10").containsIP(self.gateway)'
               stage:
                 description: IPConfigStage defines the type for the stage field
                 enum:

--- a/config/crd/bases/lca.openshift.io_ipconfigs.yaml
+++ b/config/crd/bases/lca.openshift.io_ipconfigs.yaml
@@ -123,14 +123,14 @@ spec:
                     type: string
                 required:
                 - address
-                - gateway
-                - machineNetwork
                 type: object
                 x-kubernetes-validations:
                 - message: IPv4 address must be within its machineNetwork CIDR
-                  rule: self.address == "" || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.address)
+                  rule: '!has(self.address) || self.address == "" || !has(self.machineNetwork)
+                    || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.address)'
                 - message: IPv4 gateway must be within its machineNetwork CIDR
-                  rule: self.gateway == "" || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.gateway)
+                  rule: '!has(self.gateway) || self.gateway == "" || !has(self.machineNetwork)
+                    || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.gateway)'
               ipv6:
                 description: IPv6 stack (omit for IPv4-only)
                 properties:
@@ -150,16 +150,16 @@ spec:
                     type: string
                 required:
                 - address
-                - gateway
-                - machineNetwork
                 type: object
                 x-kubernetes-validations:
                 - message: IPv6 address must be within its machineNetwork CIDR
-                  rule: self.address == "" || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.address)
+                  rule: '!has(self.address) || self.address == "" || !has(self.machineNetwork)
+                    || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.address)'
                 - message: IPv6 gateway must be within its machineNetwork CIDR unless
                     it is link-local
-                  rule: self.gateway == "" || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.gateway)
-                    || cidr("fe80::/10").containsIP(self.gateway)
+                  rule: '!has(self.gateway) || self.gateway == "" || !has(self.machineNetwork)
+                    || self.machineNetwork == "" || cidr(self.machineNetwork).containsIP(self.gateway)
+                    || cidr("fe80::/10").containsIP(self.gateway)'
               stage:
                 description: IPConfigStage defines the type for the stage field
                 enum:

--- a/controllers/ipc_config_handlers.go
+++ b/controllers/ipc_config_handlers.go
@@ -790,7 +790,9 @@ func (h *IPCConfigStageHandler) validateClusterAndNetworkSpecCompatability(
 			return fmt.Errorf("dnsServers contains an IPv4 address %q but the cluster does not have IPv4", s)
 		}
 
-		if ip.To16() != nil && !clusterHasIPv6 {
+		// Note: ip.To16() is non-nil for IPv4 addresses too; ensure we only treat
+		// it as IPv6 when it's not IPv4.
+		if ip.To4() == nil && ip.To16() != nil && !clusterHasIPv6 {
 			return fmt.Errorf("dnsServers contains an IPv6 address %q but the cluster does not have IPv6", s)
 		}
 	}

--- a/utils/network_state.go
+++ b/utils/network_state.go
@@ -83,13 +83,9 @@ func ParseNmstate(output string) (NmState, error) {
 	return state, nil
 }
 
-// ExtractDNSServers returns the ordered DNS server list from nmstate, preferring running config.
+// ExtractDNSServers returns the ordered DNS server list from nmstate
 func ExtractDNSServers(state NmState) []string {
-	dnsServers := state.DNSResolver.Running.Server
-	if len(dnsServers) == 0 {
-		dnsServers = state.DNSResolver.Config.Server
-	}
-	return dnsServers
+	return state.DNSResolver.Running.Server
 }
 
 func findDefaultGateway(state NmState, bridgeName, destination string) *string {

--- a/utils/network_state_test.go
+++ b/utils/network_state_test.go
@@ -34,7 +34,7 @@ func TestParseNmstate_InvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestExtractDNSServers_PrefersRunningThenConfig(t *testing.T) {
+func TestExtractDNSServers_ReturnsRunningOnly(t *testing.T) {
 	state := NmState{
 		DNSResolver: NmDNS{
 			Running: NmDNSList{
@@ -49,10 +49,9 @@ func TestExtractDNSServers_PrefersRunningThenConfig(t *testing.T) {
 	got := ExtractDNSServers(state)
 	assert.Equal(t, []string{"1.1.1.1", "2001:db8::1"}, got)
 
-	// If running is empty, fall back to config
 	state.DNSResolver.Running.Server = nil
 	got = ExtractDNSServers(state)
-	assert.Equal(t, []string{"8.8.8.8", "2001:db8::2"}, got)
+	assert.Empty(t, got)
 }
 
 func TestFindDefaultGateways(t *testing.T) {


### PR DESCRIPTION
-   Make machine network and gateway optional in the API.
-   Write status dns servers only from running servers.
-   Add unit-tests
-   Add missing machineconfig rbac rule