### PR TITLE
MGMT-21789: Fix Idle condition handling and IBU gating in ipc

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -54,7 +54,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
-	ipcv1 "github.com/openshift-kni/lifecycle-agent/api/ipconfig/v1"
 	lcautils "github.com/openshift-kni/lifecycle-agent/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -182,21 +181,6 @@ func (r *ImageBasedUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Make sure "next stage" list is initialized
 	ibu.Status.ValidNextStages = getValidNextStageList(ibu, isAfterPivot)
-
-	if ibu.Spec.Stage != ibuv1.Stages.Idle && isTransitionRequested(ibu) {
-		ipc := &ipcv1.IPConfig{}
-		if getErr := r.NoncachedClient.Get(ctx, client.ObjectKey{Name: common.IPConfigName}, ipc); getErr != nil {
-			r.Log.Error(getErr, "failed to get IPConfig for gating")
-			return requeueWithShortInterval(), nil
-		}
-
-		if !(ipc.Spec.Stage == ipcv1.IPStages.Idle && utils.IsIdleConditionTrue(ipc.Status.Conditions)) {
-			r.Log.Info(
-				"Blocking IBU start: IPConfig not Idle",
-				"ipcStage", ipc.Spec.Stage)
-			return doNotRequeue(), nil
-		}
-	}
 
 	if isTransitionRequested(ibu) {
 		if validateStageTransition(ibu, isAfterPivot) {

--- a/controllers/ipc_controller.go
+++ b/controllers/ipc_controller.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 	ipcv1 "github.com/openshift-kni/lifecycle-agent/api/ipconfig/v1"
 	controllerutils "github.com/openshift-kni/lifecycle-agent/controllers/utils"
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
@@ -36,6 +37,7 @@ import (
 
 //+kubebuilder:rbac:groups=lca.openshift.io,resources=ipconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=lca.openshift.io,resources=ipconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=lca.openshift.io,resources=imagebasedupgrades,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get
@@ -125,8 +127,8 @@ func (r *IPConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		}
 	}
 
-	if err := r.refreshStatus(ctx, ipc); err != nil {
-		return requeueWithError(fmt.Errorf("failed to refresh status: %w", err))
+	if err := r.refreshNetworkStatus(ctx, ipc); err != nil {
+		return requeueWithError(fmt.Errorf("failed to refresh network status: %w", err))
 	}
 
 	if err := r.Client.Status().Update(ctx, ipc); err != nil {
@@ -144,6 +146,11 @@ func (r *IPConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		if err := r.Client.Update(ctx, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig annotations: %w", err))
 		}
+	}
+
+	requeueResult, err := r.gateIPConfigByIBU(ctx, ipc)
+	if err != nil || requeueResult.RequeueAfter > 0 {
+		return requeueResult, err
 	}
 
 	// Start stage history timer. The timer is stopped from inside the handlers when they complete successfully
@@ -175,6 +182,62 @@ func (r *IPConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		logger.Error(nil, "invalid IPConfig stage", "stage", ipc.Spec.Stage)
 		return doNotRequeue(), nil
 	}
+}
+
+// gateIPConfigByIBU gates IPConfig reconciliation based on the ImageBasedUpgrade (IBU) CR.
+//
+// IPC is considered "allowed to proceed" only when:
+//   - the IBU CR exists, AND
+//   - IBU spec.stage is Idle, AND
+//   - the IBU Idle condition is present and true.
+//
+// Otherwise IPC gates reconciliation as follows:
+//   - If the IBU CR does not exist yet: requeue immediately (without updating IPC status).
+//   - If the IBU CR exists but has no status conditions yet: mark IPC as Blocked and requeue immediately.
+//   - If IBU is not idle (stage != Idle or Idle condition is not true): mark IPC as Blocked and requeue after a short interval.
+//
+// Notice: this is not mutual exclusion. For delivery reasons, IBU can still start while IPC is
+// not Idle. We should add mutual exclusion between IPC and IBU controllers to avoid this
+// in the future.
+func (r *IPConfigReconciler) gateIPConfigByIBU(
+	ctx context.Context,
+	ipc *ipcv1.IPConfig,
+) (ctrl.Result, error) {
+	ibu := &ibuv1.ImageBasedUpgrade{}
+	if getErr := r.NoncachedClient.Get(ctx, client.ObjectKey{Name: controllerutils.IBUName}, ibu); getErr != nil {
+		if !k8serrors.IsNotFound(getErr) {
+			return requeueWithError(fmt.Errorf("failed to get ImageBasedUpgrade for gating: %w", getErr))
+		}
+		return requeueImmediately(), nil
+	}
+
+	if len(ibu.Status.Conditions) == 0 {
+		controllerutils.SetIPStatusBlocked(ipc, "Blocked by gating: IBU is not initialized")
+		if err := r.Client.Status().Update(ctx, ipc); err != nil {
+			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
+		}
+		return requeueImmediately(), nil
+	}
+
+	if ibu.Spec.Stage == ibuv1.Stages.Idle &&
+		controllerutils.IsIdleConditionTrue(ibu.Status.Conditions) {
+		inProgressCondition := controllerutils.GetIPInProgressCondition(ipc, ipc.Spec.Stage)
+		if inProgressCondition != nil &&
+			inProgressCondition.Reason == string(controllerutils.ConditionReasons.Blocked) {
+			meta.RemoveStatusCondition(&ipc.Status.Conditions, inProgressCondition.Type)
+		}
+		if err := r.Client.Status().Update(ctx, ipc); err != nil {
+			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
+		}
+		return doNotRequeue(), nil
+	}
+
+	controllerutils.SetIPStatusBlocked(ipc, "Blocked by gating: IBU is not idle")
+	if err := r.Client.Status().Update(ctx, ipc); err != nil {
+		return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
+	}
+
+	return requeueWithShortInterval(), nil
 }
 
 func validNextStages(ipc *ipcv1.IPConfig, rpmOstreeClient rpmostreeclient.IClient) ([]ipcv1.IPConfigStage, error) {
@@ -219,6 +282,11 @@ func validNextStages(ipc *ipcv1.IPConfig, rpmOstreeClient rpmostreeclient.IClien
 	idleCondition := meta.FindStatusCondition(ipc.Status.Conditions, string(controllerutils.ConditionTypes.Idle))
 	if idleCondition == nil {
 		return []ipcv1.IPConfigStage{ipcv1.IPStages.Idle}, nil
+	}
+
+	// blocked by IBU, allow same stage only
+	if idleCondition.Reason == string(controllerutils.ConditionReasons.Blocked) {
+		return []ipcv1.IPConfigStage{ipc.Spec.Stage}, nil
 	}
 
 	return []ipcv1.IPConfigStage{}, nil
@@ -365,7 +433,7 @@ func (r *IPConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *IPConfigReconciler) getIPConfig(ctx context.Context, logger logr.Logger) (*ipcv1.IPConfig, error) {
 	ipc := &ipcv1.IPConfig{}
 	if err := r.NoncachedClient.Get(ctx, client.ObjectKey{Name: common.IPConfigName}, ipc); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			if initErr := lcautils.InitIPConfig(ctx, r.Client, &logger); initErr != nil {
 				return nil, fmt.Errorf("failed to initialize IPConfig: %w", initErr)
 			}
@@ -458,15 +526,11 @@ func (r *IPConfigReconciler) cacheRecertImageIfNeeded(ctx context.Context, ipc *
 
 func isIPTransitionRequested(ipc *ipcv1.IPConfig) bool {
 	desiredStage := ipc.Spec.Stage
-	if desiredStage == ipcv1.IPStages.Idle {
-		return !(controllerutils.IsIPStageCompleted(ipc, desiredStage) ||
-			controllerutils.IsIPStageInProgress(ipc, desiredStage))
-	}
 	return !(controllerutils.IsIPStageCompletedOrFailed(ipc, desiredStage) ||
 		controllerutils.IsIPStageInProgress(ipc, desiredStage))
 }
 
-func (r *IPConfigReconciler) refreshStatus(ctx context.Context, ipc *ipcv1.IPConfig) error {
+func (r *IPConfigReconciler) refreshNetworkStatus(ctx context.Context, ipc *ipcv1.IPConfig) error {
 	output, err := r.nmstateShowJSON()
 	if err != nil {
 		return fmt.Errorf("failed to get nmstate output: %w", err)

--- a/controllers/ipc_idle_handlers_test.go
+++ b/controllers/ipc_idle_handlers_test.go
@@ -186,6 +186,14 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 			RPMOstreeClient: mockRpm,
 		}
 
+		oldHC := CheckHealth
+		defer func() { CheckHealth = oldHC }()
+		CheckHealth = func(ctx context.Context, c client.Reader, l logr.Logger) error {
+			t.Fatalf("CheckHealth should not be called when stage validation fails")
+			return nil
+		}
+		mockOps.EXPECT().RemountSysroot().Times(0)
+
 		res, err := h.Handle(ctx, ipc)
 		assert.NoError(t, err)
 		assert.Equal(t, doNotRequeue(), res)
@@ -195,7 +203,7 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 		assertStatusInvariants(t, updated, ipc)
 	})
 
-	t.Run("invalid next stage but status update fails => returns requeueWithError and does not persist changes", func(t *testing.T) {
+	t.Run("status update fails before stage validation => returns requeueWithError and does not persist changes", func(t *testing.T) {
 		gc := gomock.NewController(t)
 		defer gc.Finish()
 
@@ -223,8 +231,6 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 		wantRes, _ := requeueWithError(err)
 		assert.Equal(t, wantRes, res)
 		assert.Contains(t, err.Error(), "failed to update ipconfig status")
-		// Note: Handle currently wraps the *stage validation* error, not the update error.
-		assert.Contains(t, err.Error(), "invalid IPConfig stage")
 
 		unchanged := mustGetIPC(t, baseClient, common.IPConfigName)
 		assert.Nil(t, meta.FindStatusCondition(unchanged.Status.Conditions, string(controllerutils.ConditionTypes.Idle)))
@@ -595,7 +601,7 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 		assertStatusInvariants(t, unchanged, ipc)
 	})
 
-	t.Run("transition not requested but invalid stage in spec => still runs healthcheck/cleanup and can succeed", func(t *testing.T) {
+	t.Run("already idle (transition not requested) => exits early and does not run healthcheck/cleanup", func(t *testing.T) {
 		gc := gomock.NewController(t)
 		defer gc.Finish()
 
@@ -604,10 +610,15 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 		mockOstree := ostreeclient.NewMockIClient(gc)
 
 		ipc := mkIPCForIdle(t)
-		ipc.Spec.Stage = ipcv1.IPStages.Config
-		// Transition not requested: set a completed condition for Config stage.
-		controllerutils.SetIPConfigStatusCompleted(ipc, "done")
-		ipc.Status.ValidNextStages = []ipcv1.IPConfigStage{ipcv1.IPStages.Idle} // would be invalid if validate ran
+		// Transition not requested: Idle is already "completed".
+		ipc.Status.Conditions = []metav1.Condition{{
+			Type:               string(controllerutils.ConditionTypes.Idle),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(controllerutils.ConditionReasons.Idle),
+			Message:            "Idle",
+			ObservedGeneration: ipc.Generation,
+		}}
+		ipc.Status.ValidNextStages = []ipcv1.IPConfigStage{ipcv1.IPStages.Idle}
 
 		k8sClient := newFakeClientWithIPC(t, scheme, ipc)
 		h := &IPCIdleStageHandler{
@@ -620,27 +631,71 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 
 		oldHC := CheckHealth
 		defer func() { CheckHealth = oldHC }()
-		CheckHealth = func(ctx context.Context, c client.Reader, l logr.Logger) error { return nil }
-
-		status := &rpmostreeclient.Status{
-			Deployments: []rpmostreeclient.Deployment{{OSName: "rhcos", Booted: true}},
+		CheckHealth = func(ctx context.Context, c client.Reader, l logr.Logger) error {
+			t.Fatalf("CheckHealth should not be called when idle handler exits early")
+			return nil
 		}
 
-		mockOps.EXPECT().RemountSysroot().Return(nil).Times(1)
-		mockRpm.EXPECT().QueryStatus().Return(status, nil).Times(2)
-		mockOps.EXPECT().RemountBoot().Return(nil).Times(1)
-		mockOps.EXPECT().ReadDir(gomock.Any()).Return([]os.DirEntry{}, nil).Times(1)
-		mockRpm.EXPECT().RpmOstreeCleanup().Return(nil).Times(1)
-		mockOps.EXPECT().StatFile(gomock.Any()).Return(nil, errors.New("not exist")).Times(1)
+		mockOps.EXPECT().RemountSysroot().Times(0)
 
 		res, err := h.Handle(ctx, ipc)
 		assert.NoError(t, err)
 		assert.Equal(t, doNotRequeue(), res)
 
 		updated := mustGetIPC(t, k8sClient, common.IPConfigName)
-		assert.Len(t, updated.Status.Conditions, 1)
 		assertIdleCond(t, updated, metav1.ConditionTrue, controllerutils.ConditionReasons.Idle, "")
 		assertStatusInvariants(t, updated, ipc)
+	})
+
+	t.Run("manual cleanup done but status update fails => returns requeueWithError and does not proceed", func(t *testing.T) {
+		gc := gomock.NewController(t)
+		defer gc.Finish()
+
+		mockOps := ops.NewMockOps(gc)
+		mockRpm := rpmostreeclient.NewMockIClient(gc)
+		mockOstree := ostreeclient.NewMockIClient(gc)
+
+		ipc := mkIPCForIdle(t)
+		ipc.SetAnnotations(map[string]string{controllerutils.ManualCleanupAnnotation: ""})
+		ipc.Status.Conditions = []metav1.Condition{{
+			Type:               string(controllerutils.ConditionTypes.Idle),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(controllerutils.ConditionReasons.Failed),
+			Message:            "failed earlier",
+			ObservedGeneration: ipc.Generation,
+		}}
+
+		baseClient := newFakeClientWithIPC(t, scheme, ipc)
+		wrapped := errStatusClient{Client: baseClient, err: errors.New("status update failed")}
+
+		h := &IPCIdleStageHandler{
+			Client:          wrapped,
+			NoncachedClient: baseClient,
+			ChrootOps:       mockOps,
+			OstreeClient:    mockOstree,
+			RPMOstreeClient: mockRpm,
+		}
+
+		oldHC := CheckHealth
+		defer func() { CheckHealth = oldHC }()
+		CheckHealth = func(ctx context.Context, c client.Reader, l logr.Logger) error {
+			t.Fatalf("CheckHealth should not be called when manual-cleanup status update fails")
+			return nil
+		}
+
+		mockOps.EXPECT().RemountSysroot().Times(0)
+
+		res, err := h.Handle(ctx, ipc)
+		assert.Error(t, err)
+		wantRes, _ := requeueWithError(err)
+		assert.Equal(t, wantRes, res)
+		assert.Contains(t, err.Error(), "failed to handle manual cleanup if failed")
+
+		updated := mustGetIPC(t, baseClient, common.IPConfigName)
+		_, annPresent := updated.GetAnnotations()[controllerutils.ManualCleanupAnnotation]
+		assert.False(t, annPresent, "annotation removal should persist even if status update fails")
+		// Status condition update should not persist when Status().Update fails.
+		assertIdleCond(t, updated, metav1.ConditionFalse, controllerutils.ConditionReasons.Failed, "failed earlier")
 	})
 }
 


### PR DESCRIPTION
This PR fixes the following issues:

1. IPC won't start when IBU is nor Idle - so it won't interfere. (In the future we will do the same for IBU)
2. Fixes IPC Idle conditions handling - Stops running Idle handler when the CR is already Idle