### PR TITLE
MGMT-22606, MGMT-22609, MGMT-22610: Fix ipc bugs

### DIFF
--- a/api/ipconfig/v1/types.go
+++ b/api/ipconfig/v1/types.go
@@ -40,9 +40,10 @@ import (
 // +kubebuilder:validation:XValidation:message="can not change spec.dnsFilterOutFamily while ipconfig is not idle",rule="!has(oldSelf.status) || oldSelf.status.conditions.exists(c, c.type=='Idle' && c.status=='True') || has(oldSelf.spec.dnsFilterOutFamily) && has(self.spec.dnsFilterOutFamily) && oldSelf.spec.dnsFilterOutFamily==self.spec.dnsFilterOutFamily || !has(self.spec.dnsFilterOutFamily) && !has(oldSelf.spec.dnsFilterOutFamily)"
 // +kubebuilder:validation:XValidation:message="can not change spec.autoRollbackOnFailure while ipconfig is not idle",rule="!has(oldSelf.status) || oldSelf.status.conditions.exists(c, c.type=='Idle' && c.status=='True') || has(oldSelf.spec.autoRollbackOnFailure) && has(self.spec.autoRollbackOnFailure) && oldSelf.spec.autoRollbackOnFailure==self.spec.autoRollbackOnFailure || !has(self.spec.autoRollbackOnFailure) && !has(oldSelf.spec.autoRollbackOnFailure)"
 // +kubebuilder:validation:XValidation:message="can not change spec.vlanID while ipconfig is not idle",rule="!has(oldSelf.status) || oldSelf.status.conditions.exists(c, c.type=='Idle' && c.status=='True') || has(oldSelf.spec.vlanID) && has(self.spec.vlanID) && oldSelf.spec.vlanID==self.spec.vlanID || !has(self.spec.vlanID) && !has(oldSelf.spec.vlanID)"
+// +kubebuilder:validation:XValidation:message="spec.dnsFilterOutFamily may be set to 'ipv4' or 'ipv6' only on dual-stack clusters",rule="!has(self.spec.dnsFilterOutFamily) || self.spec.dnsFilterOutFamily=='' || self.spec.dnsFilterOutFamily=='none' || has(self.status) && has(self.status.ipv4) && self.status.ipv4.address!='' && has(self.status.ipv6) && self.status.ipv6.address!=''"
 // +kubebuilder:validation:XValidation:message="the stage transition is not permitted. Please refer to status.validNextStages for valid transitions. If status.validNextStages is not present, it indicates that no transitions are currently allowed", rule="!has(oldSelf.status) || has(oldSelf.status.validNextStages) && self.spec.stage in oldSelf.status.validNextStages || has(oldSelf.spec.stage) && has(self.spec.stage) && oldSelf.spec.stage==self.spec.stage"
 
-// IPConfig is the Schema for controlling node IP configuration lifecycle via lca-cli ip-config.
+// IPConfig is the Schema for IPConfigs API
 type IPConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -201,6 +202,9 @@ type IPConfigStatus struct {
 	// ValidNextStages enumerates allowed next transitions from current stage
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Valid Next Stage"
 	ValidNextStages []IPConfigStage `json:"validNextStages,omitempty"`
+
+	// RollbackAvailabilityExpiration reflects the point at which rolling back may require manual recovery from expired control plane certificates.
+	RollbackAvailabilityExpiration metav1.Time `json:"rollbackAvailabilityExpiration,omitempty"`
 
 	// IPv4 reports the currently detected IPv4 configuration (if any)
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="IPv4"

--- a/api/ipconfig/v1/zz_generated.deepcopy.go
+++ b/api/ipconfig/v1/zz_generated.deepcopy.go
@@ -149,6 +149,7 @@ func (in *IPConfigStatus) DeepCopyInto(out *IPConfigStatus) {
 		*out = make([]IPConfigStage, len(*in))
 		copy(*out, *in)
 	}
+	in.RollbackAvailabilityExpiration.DeepCopyInto(&out.RollbackAvailabilityExpiration)
 	if in.IPv4 != nil {
 		in, out := &in.IPv4, &out.IPv4
 		*out = new(IPv4Status)

--- a/bundle/manifests/lca.openshift.io_ipconfigs.yaml
+++ b/bundle/manifests/lca.openshift.io_ipconfigs.yaml
@@ -48,8 +48,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: IPConfig is the Schema for controlling node IP configuration
-          lifecycle via lca-cli ip-config.
+        description: IPConfig is the Schema for IPConfigs API
         properties:
           apiVersion:
             description: |-
@@ -325,6 +324,12 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              rollbackAvailabilityExpiration:
+                description: RollbackAvailabilityExpiration reflects the point at
+                  which rolling back may require manual recovery from expired control
+                  plane certificates.
+                format: date-time
+                type: string
               validNextStages:
                 description: ValidNextStages enumerates allowed next transitions from
                   current stage
@@ -370,6 +375,11 @@ spec:
             && c.status==''True'') || has(oldSelf.spec.vlanID) && has(self.spec.vlanID)
             && oldSelf.spec.vlanID==self.spec.vlanID || !has(self.spec.vlanID) &&
             !has(oldSelf.spec.vlanID)'
+        - message: spec.dnsFilterOutFamily may be set to 'ipv4' or 'ipv6' only on
+            dual-stack clusters
+          rule: '!has(self.spec.dnsFilterOutFamily) || self.spec.dnsFilterOutFamily==''''
+            || self.spec.dnsFilterOutFamily==''none'' || has(self.status) && has(self.status.ipv4)
+            && self.status.ipv4.address!='''' && has(self.status.ipv6) && self.status.ipv6.address!='''''
         - message: the stage transition is not permitted. Please refer to status.validNextStages
             for valid transitions. If status.validNextStages is not present, it indicates
             that no transitions are currently allowed

--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -165,8 +165,7 @@ spec:
       - displayName: Valid Next Stage
         path: validNextStages
       version: v1
-    - description: IPConfig is the Schema for controlling node IP configuration lifecycle
-        via lca-cli ip-config.
+    - description: IPConfig is the Schema for IPConfigs API via lca-cli ip-config.
       displayName: IP Configuration
       kind: IPConfig
       name: ipconfigs.lca.openshift.io

--- a/config/crd/bases/lca.openshift.io_ipconfigs.yaml
+++ b/config/crd/bases/lca.openshift.io_ipconfigs.yaml
@@ -48,8 +48,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: IPConfig is the Schema for controlling node IP configuration
-          lifecycle via lca-cli ip-config.
+        description: IPConfig is the Schema for IPConfigs API
         properties:
           apiVersion:
             description: |-
@@ -325,6 +324,12 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              rollbackAvailabilityExpiration:
+                description: RollbackAvailabilityExpiration reflects the point at
+                  which rolling back may require manual recovery from expired control
+                  plane certificates.
+                format: date-time
+                type: string
               validNextStages:
                 description: ValidNextStages enumerates allowed next transitions from
                   current stage
@@ -370,6 +375,11 @@ spec:
             && c.status==''True'') || has(oldSelf.spec.vlanID) && has(self.spec.vlanID)
             && oldSelf.spec.vlanID==self.spec.vlanID || !has(self.spec.vlanID) &&
             !has(oldSelf.spec.vlanID)'
+        - message: spec.dnsFilterOutFamily may be set to 'ipv4' or 'ipv6' only on
+            dual-stack clusters
+          rule: '!has(self.spec.dnsFilterOutFamily) || self.spec.dnsFilterOutFamily==''''
+            || self.spec.dnsFilterOutFamily==''none'' || has(self.status) && has(self.status.ipv4)
+            && self.status.ipv4.address!='''' && has(self.status.ipv6) && self.status.ipv6.address!='''''
         - message: the stage transition is not permitted. Please refer to status.validNextStages
             for valid transitions. If status.validNextStages is not present, it indicates
             that no transitions are currently allowed

--- a/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
+++ b/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
@@ -45,8 +45,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: IPConfig is the Schema for controlling node IP configuration lifecycle
-        via lca-cli ip-config.
+    - description: IPConfig is the Schema for IPConfigs API via lca-cli ip-config.
       displayName: IP Configuration
       kind: IPConfig
       name: ipconfigs.lca.openshift.io

--- a/controllers/ipc_config_handlers.go
+++ b/controllers/ipc_config_handlers.go
@@ -97,7 +97,7 @@ func (h *IPCConfigStageHandler) Handle(ctx context.Context, ipc *ipcv1.IPConfig)
 			controllerutils.SetIPStatusInvalidTransition(
 				ipc, fmt.Sprintf("invalid IPConfig stage: %s", ipc.Spec.Stage),
 			)
-			if err := h.Client.Status().Update(ctx, ipc); err != nil {
+			if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 				logger.Error(err, "Failed to update IPConfig status after invalid transition")
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 			}
@@ -105,7 +105,7 @@ func (h *IPCConfigStageHandler) Handle(ctx context.Context, ipc *ipcv1.IPConfig)
 		}
 
 		controllerutils.ClearIPInvalidTransitionStatusConditions(ipc)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			logger.Error(err, "Failed to clear IPConfig invalid transition status conditions")
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
@@ -115,14 +115,14 @@ func (h *IPCConfigStageHandler) Handle(ctx context.Context, ipc *ipcv1.IPConfig)
 			controllerutils.ConditionReasons.ConfigurationInProgress,
 			controllerutils.ConfigurationInProgress,
 		)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			logger.Error(err, "Failed to update IPConfig idle status to configuration in progress")
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 
 		if err := h.validateConfigStart(ctx, ipc); err != nil {
 			controllerutils.SetIPConfigStatusFailed(ipc, fmt.Sprintf("config validation failed: %s", err.Error()))
-			if err := h.Client.Status().Update(ctx, ipc); err != nil {
+			if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 				logger.Error(err, "Failed to update IPConfig status after validation failure")
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 			}
@@ -132,7 +132,7 @@ func (h *IPCConfigStageHandler) Handle(ctx context.Context, ipc *ipcv1.IPConfig)
 		}
 
 		controllerutils.SetIPConfigStatusInProgress(ipc, controllerutils.ConfigurationInProgress)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			logger.Error(err, "Failed to update IPConfig status to in-progress")
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
@@ -187,7 +187,7 @@ func (h *IPCConfigStageHandler) Handle(ctx context.Context, ipc *ipcv1.IPConfig)
 
 	controllerutils.StopIPStageHistory(h.Client, logger, ipc)
 	controllerutils.SetIPConfigStatusCompleted(ipc, "Configuration completed successfully")
-	if err := h.Client.Status().Update(ctx, ipc); err != nil {
+	if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 		logger.Error(err, "Failed to update IPConfig status to completed")
 		return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 	}
@@ -207,7 +207,7 @@ func (h *IPCConfigTwoPhaseHandler) PrePivot(
 
 	if err := statusIPsMatchSpec(ipc); err == nil {
 		controllerutils.SetIPConfigStatusCompleted(ipc, "Spec and status match; nothing to do")
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 
@@ -228,7 +228,7 @@ func (h *IPCConfigTwoPhaseHandler) PrePivot(
 		if err := CheckHealth(ctx, h.NoncachedClient, logger.WithName("HealthCheck")); err != nil {
 			msg := fmt.Sprintf("Waiting for system to stabilize: %s", err.Error())
 			controllerutils.SetIPConfigStatusInProgress(ipc, msg)
-			if uerr := h.Client.Status().Update(ctx, ipc); uerr != nil {
+			if uerr := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); uerr != nil {
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", uerr))
 			}
 			return requeueWithHealthCheckInterval(), nil
@@ -237,7 +237,7 @@ func (h *IPCConfigTwoPhaseHandler) PrePivot(
 
 	if err := h.copyLcaCliToHost(logger); err != nil {
 		controllerutils.SetIPConfigStatusFailed(ipc, err.Error())
-		if uerr := h.Client.Status().Update(ctx, ipc); uerr != nil {
+		if uerr := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); uerr != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", uerr))
 		}
 		return requeueWithError(fmt.Errorf("failed to copy lca-cli binary: %w", err))
@@ -245,7 +245,7 @@ func (h *IPCConfigTwoPhaseHandler) PrePivot(
 
 	if err := reboot.WriteIPCAutoRollbackConfigFile(logger, ipc, h.ChrootOps); err != nil {
 		controllerutils.SetIPConfigStatusFailed(ipc, fmt.Sprintf("failed to write ip-config auto-rollback config: %s", err.Error()))
-		if uerr := h.Client.Status().Update(ctx, ipc); uerr != nil {
+		if uerr := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); uerr != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", uerr))
 		}
 		return requeueWithError(fmt.Errorf("failed to write ip-config auto-rollback config: %w", err))
@@ -256,7 +256,7 @@ func (h *IPCConfigTwoPhaseHandler) PrePivot(
 			ipc,
 			fmt.Sprintf("failed to write ip-config pre-pivot config: %s", err.Error()),
 		)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 
@@ -268,7 +268,7 @@ func (h *IPCConfigTwoPhaseHandler) PrePivot(
 			ipc,
 			fmt.Sprintf("failed to write ip-config post-pivot config: %s", err.Error()),
 		)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 
@@ -284,7 +284,7 @@ func (h *IPCConfigTwoPhaseHandler) PrePivot(
 			ipc,
 			fmt.Sprintf("ip-config pre-pivot failed. error: %s", err.Error()),
 		)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 		logger.Error(err, "IP-config pre-pivot failed")
@@ -304,12 +304,28 @@ func (h *IPCConfigTwoPhaseHandler) PostPivot(
 	controllerutils.StartIPPhase(h.Client, logger, ipc, IPConfigPhasePostPivot)
 	logger.Info("Starting post-pivot phase")
 
+	if ipc.Status.RollbackAvailabilityExpiration.IsZero() {
+		unbootedStateroot, err := h.RPMOstreeClient.GetUnbootedStaterootName()
+		if err != nil {
+			return requeueWithError(fmt.Errorf("unable to determine unbooted stateroot path for rollback: %w", err))
+		}
+		expiry, err := common.GetRollbackAvailabilityExpiration(unbootedStateroot, logger)
+		if err != nil {
+			logger.Error(err, "unable to determine rollback availability expiration", "stateroot", unbootedStateroot)
+		} else {
+			ipc.Status.RollbackAvailabilityExpiration.Time = expiry
+			if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
+				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
+			}
+		}
+	}
+
 	if err := h.RebootClient.DisableInitMonitor(); err != nil {
 		controllerutils.SetIPConfigStatusFailed(
 			ipc,
 			fmt.Sprintf("failed to disable init monitor: %s", err.Error()),
 		)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 
@@ -330,7 +346,7 @@ func (h *IPCConfigTwoPhaseHandler) PostPivot(
 				ipc,
 				fmt.Sprintf("Waiting for system to stabilize: %s", err.Error()),
 			)
-			if uerr := h.Client.Status().Update(ctx, ipc); uerr != nil {
+			if uerr := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); uerr != nil {
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", uerr))
 			}
 
@@ -342,7 +358,7 @@ func (h *IPCConfigTwoPhaseHandler) PostPivot(
 	}
 
 	controllerutils.SetIPConfigStatusInProgress(ipc, "Cluster has stabilized")
-	if err := h.Client.Status().Update(ctx, ipc); err != nil {
+	if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 		return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 	}
 
@@ -351,7 +367,7 @@ func (h *IPCConfigTwoPhaseHandler) PostPivot(
 			ipc,
 			fmt.Sprintf("Waiting for current IPs to match spec: %s", err.Error()),
 		)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 
@@ -359,7 +375,7 @@ func (h *IPCConfigTwoPhaseHandler) PostPivot(
 	}
 
 	controllerutils.StopIPPhase(h.Client, logger, ipc, IPConfigPhasePostPivot)
-	if err := h.Client.Status().Update(ctx, ipc); err != nil {
+	if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 		return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 	}
 
@@ -794,7 +810,7 @@ func (h *IPCConfigTwoPhaseHandler) RunLcaCliIPConfigPrePivot(
 	}
 
 	if _, err := h.ChrootOps.RunSystemdAction(args...); err != nil {
-		return fmt.Errorf("ip-config pre-pivot failed")
+		return fmt.Errorf("lca-cli ip-config pre-pivot failed: %w", err)
 	}
 
 	// We should never get here when the ip-config pre-pivot command succeeds.

--- a/controllers/ipc_config_handlers_test.go
+++ b/controllers/ipc_config_handlers_test.go
@@ -639,6 +639,8 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 		mockReboot := reboot.NewMockRebootIntf(gc)
 
 		ipc := mkConfigIPC(t, true)
+		// PostPivot now best-effort persists rollback availability expiration; keep it non-zero to avoid filesystem-dependent logic.
+		ipc.Status.RollbackAvailabilityExpiration = metav1.Now()
 		ipc.SetAnnotations(map[string]string{controllerutils.SkipIPConfigPostConfigurationClusterHealthChecksAnnotation: ""})
 		// Make statusIPsMatchSpec succeed (spec empty but status must be populated).
 		ipc.Status.IPv4 = &ipcv1.IPv4Status{}
@@ -680,6 +682,8 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 		mockReboot := reboot.NewMockRebootIntf(gc)
 
 		ipc := mkConfigIPC(t, true)
+		// PostPivot now best-effort persists rollback availability expiration; keep it non-zero to avoid filesystem-dependent logic.
+		ipc.Status.RollbackAvailabilityExpiration = metav1.Now()
 		ipc.SetAnnotations(map[string]string{controllerutils.SkipIPConfigPreConfigurationClusterHealthChecksAnnotation: ""})
 		// Make statusIPsMatchSpec succeed (spec empty but status must be populated).
 		ipc.Status.IPv4 = &ipcv1.IPv4Status{}
@@ -721,6 +725,8 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 		mockReboot := reboot.NewMockRebootIntf(gc)
 
 		ipc := mkConfigIPC(t, true)
+		// PostPivot now best-effort persists rollback availability expiration; keep it non-zero to avoid filesystem-dependent logic.
+		ipc.Status.RollbackAvailabilityExpiration = metav1.Now()
 		stuck := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "stuck-imagepullbackoff",
@@ -828,6 +834,8 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 		mockReboot := reboot.NewMockRebootIntf(gc)
 
 		ipc := mkConfigIPC(t, true)
+		// PostPivot now best-effort persists rollback availability expiration; keep it non-zero to avoid filesystem-dependent logic.
+		ipc.Status.RollbackAvailabilityExpiration = metav1.Now()
 		ipc.Spec.IPv4 = &ipcv1.IPv4Config{
 			Address:        "192.0.2.11/24",
 			MachineNetwork: "192.0.2.0/24",
@@ -885,6 +893,8 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 		mockReboot := reboot.NewMockRebootIntf(gc)
 
 		ipc := mkConfigIPC(t, true)
+		// PostPivot now best-effort persists rollback availability expiration; keep it non-zero to avoid filesystem-dependent logic.
+		ipc.Status.RollbackAvailabilityExpiration = metav1.Now()
 		// Make statusIPsMatchSpec succeed (spec empty but status must be populated).
 		ipc.Status.IPv4 = &ipcv1.IPv4Status{}
 		k8sClient := newFakeClientWithStatus(t, scheme, ipc)
@@ -926,6 +936,8 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 		mockReboot := reboot.NewMockRebootIntf(gc)
 
 		ipc := mkConfigIPC(t, true)
+		// PostPivot now best-effort persists rollback availability expiration; keep it non-zero to avoid filesystem-dependent logic.
+		ipc.Status.RollbackAvailabilityExpiration = metav1.Now()
 		ipc.Status.IPv4 = &ipcv1.IPv4Status{}
 		k8sClient := newFakeClientWithStatus(t, scheme, ipc)
 
@@ -972,6 +984,8 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 		mockReboot := reboot.NewMockRebootIntf(gc)
 
 		ipc := mkConfigIPC(t, true)
+		// PostPivot now best-effort persists rollback availability expiration; keep it non-zero to avoid filesystem-dependent logic.
+		ipc.Status.RollbackAvailabilityExpiration = metav1.Now()
 		stuck := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "stuck-delete-fails",

--- a/controllers/ipc_idle_handlers.go
+++ b/controllers/ipc_idle_handlers.go
@@ -65,7 +65,7 @@ func (h *IPCIdleStageHandler) Handle(
 			controllerutils.SetIPStatusInvalidTransition(
 				ipc, fmt.Sprintf("invalid IPConfig stage: %s", ipc.Spec.Stage),
 			)
-			if uerr := h.Client.Status().Update(ctx, ipc); uerr != nil {
+			if uerr := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); uerr != nil {
 				logger.Error(uerr, "Failed to update IPConfig status after invalid transition")
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", uerr))
 			}
@@ -77,7 +77,7 @@ func (h *IPCIdleStageHandler) Handle(
 		}
 
 		controllerutils.ClearIPInvalidTransitionStatusConditions(ipc)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			logger.Error(err, "Failed to clear IPConfig invalid transition status conditions")
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
@@ -86,7 +86,7 @@ func (h *IPCIdleStageHandler) Handle(
 			ipc, controllerutils.ConditionReasons.InProgress,
 			controllerutils.InProgressOfBecomingIdle,
 		)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			logger.Error(err, "Failed to update IPConfig status to in progress of becoming idle")
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
@@ -107,7 +107,7 @@ func (h *IPCIdleStageHandler) Handle(
 		if err := CheckHealth(ctx, h.NoncachedClient, logger); err != nil {
 			msg := fmt.Sprintf("Waiting for system to stabilize: %s", err.Error())
 			controllerutils.SetIPIdleStatusFalse(ipc, controllerutils.ConditionReasons.Stabilizing, msg)
-			if uerr := h.Client.Status().Update(ctx, ipc); uerr != nil {
+			if uerr := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); uerr != nil {
 				logger.Error(uerr, "Failed to update IPConfig status after health check failure")
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", uerr))
 			}
@@ -125,7 +125,7 @@ func (h *IPCIdleStageHandler) Handle(
 				controllerutils.ManualCleanupAnnotation,
 			),
 		)
-		if uerr := h.Client.Status().Update(ctx, ipc); uerr != nil {
+		if uerr := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); uerr != nil {
 			logger.Error(uerr, "Failed to update IPConfig status after cleanup failure")
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", uerr))
 		}
@@ -134,7 +134,8 @@ func (h *IPCIdleStageHandler) Handle(
 	}
 
 	controllerutils.ResetStatusConditions(&ipc.Status.Conditions, ipc.Generation)
-	if err := h.Client.Status().Update(ctx, ipc); err != nil {
+	ipc.Status.RollbackAvailabilityExpiration.Reset()
+	if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 		logger.Error(err, "Failed to update IPConfig status after successful cleanup/reset")
 		return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 	}
@@ -280,7 +281,7 @@ func (h *IPCIdleStageHandler) handleManualCleanup(
 			ipc, controllerutils.ConditionReasons.InProgress,
 			controllerutils.InProgressOfBecomingIdle,
 		)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			return fmt.Errorf("failed to update ipconfig status to in progress of becoming idle: %w", err)
 		}
 		logger.Info("Manual cleanup annotation is found, removed annotation and retrying idle tasks")

--- a/controllers/ipc_idle_handlers_test.go
+++ b/controllers/ipc_idle_handlers_test.go
@@ -224,7 +224,7 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 		assertIdleCond(t, updated2, metav1.ConditionFalse, controllerutils.ConditionReasons.Stabilizing, "Waiting for system to stabilize")
 	})
 
-	t.Run("status update fails before stage validation => returns requeueWithError and does not persist changes", func(t *testing.T) {
+	t.Run("status update fails before stage validation => returns requeueWithError", func(t *testing.T) {
 		gc := gomock.NewController(t)
 		defer gc.Finish()
 
@@ -247,15 +247,14 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 			RPMOstreeClient: mockRpm,
 		}
 
+		// Since status update fails before we can proceed, we should not attempt any cleanup.
+		mockOps.EXPECT().RemountSysroot().Times(0)
+
 		res, err := h.Handle(ctx, ipc)
 		assert.Error(t, err)
 		wantRes, _ := requeueWithError(err)
 		assert.Equal(t, wantRes, res)
 		assert.Contains(t, err.Error(), "failed to update ipconfig status")
-
-		unchanged := mustGetIPC(t, baseClient, common.IPConfigName)
-		assert.Nil(t, meta.FindStatusCondition(unchanged.Status.Conditions, string(controllerutils.ConditionTypes.Idle)))
-		assertStatusInvariants(t, unchanged, ipc)
 	})
 
 	t.Run("healthcheck failing => idle=false stabilizing, requeueWithHealthCheckInterval and error", func(t *testing.T) {

--- a/controllers/ipc_rollback_handlers.go
+++ b/controllers/ipc_rollback_handlers.go
@@ -82,7 +82,7 @@ func (h *IPCRollbackStageHandler) Handle(
 			controllerutils.SetIPStatusInvalidTransition(
 				ipc, fmt.Sprintf("invalid IPConfig stage: %s", ipc.Spec.Stage),
 			)
-			if err := h.Client.Status().Update(ctx, ipc); err != nil {
+			if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 				logger.Error(err, "Failed to update IPConfig status after invalid transition")
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 			}
@@ -94,7 +94,7 @@ func (h *IPCRollbackStageHandler) Handle(
 				ipc,
 				fmt.Sprintf("rollback validation failed: %s", err.Error()),
 			)
-			if err := h.Client.Status().Update(ctx, ipc); err != nil {
+			if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 				logger.Error(err, "Failed to update IPConfig status after validation failure")
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 			}
@@ -104,13 +104,13 @@ func (h *IPCRollbackStageHandler) Handle(
 		}
 
 		controllerutils.ClearIPInvalidTransitionStatusConditions(ipc)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			logger.Error(err, "Failed to clear IPConfig invalid transition status conditions")
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 
 		controllerutils.SetIPRollbackStatusInProgress(ipc, controllerutils.RollbackRequested)
-		if err := h.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 			logger.Error(err, "Failed to update IPConfig rollback status to rollback requested")
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
@@ -157,7 +157,7 @@ func (h *IPCRollbackStageHandler) Handle(
 
 	controllerutils.StopIPStageHistory(h.Client, logger, ipc)
 	controllerutils.SetIPRollbackStatusCompleted(ipc, controllerutils.RollbackCompleted)
-	if err := h.Client.Status().Update(ctx, ipc); err != nil {
+	if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
 		logger.Error(err, "Failed to update IPConfig rollback status to completed")
 		return requeueWithError(fmt.Errorf("failed to update ipconfig rollback status: %w", err))
 	}
@@ -181,7 +181,7 @@ func (r *IPCRollbackTwoPhaseHandler) PrePivot(
 			ipc,
 			fmt.Errorf("failed to determine unbooted stateroot: %w", err).Error(),
 		)
-		if err := r.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, r.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 		return requeueWithError(fmt.Errorf("failed to determine unbooted stateroot: %w", err))
@@ -192,7 +192,7 @@ func (r *IPCRollbackTwoPhaseHandler) PrePivot(
 			ipc,
 			fmt.Errorf("failed to remount sysroot: %w", err).Error(),
 		)
-		if err := r.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, r.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 		return requeueWithError(fmt.Errorf("failed to remount sysroot: %w", err))
@@ -212,7 +212,7 @@ func (r *IPCRollbackTwoPhaseHandler) PrePivot(
 			ipc,
 			fmt.Errorf("failed to marshal IPConfig CR: %w", err).Error(),
 		)
-		if err := r.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, r.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 		return requeueWithError(fmt.Errorf("failed to marshal IPConfig CR: %w", err))
@@ -223,7 +223,7 @@ func (r *IPCRollbackTwoPhaseHandler) PrePivot(
 			ipc,
 			fmt.Errorf("failed to save IPConfig CR before pivot: %w", err).Error(),
 		)
-		if err := r.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, r.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 		return requeueWithError(fmt.Errorf("failed to save IPConfig CR before pivot: %w", err))
@@ -234,7 +234,7 @@ func (r *IPCRollbackTwoPhaseHandler) PrePivot(
 			ipc,
 			fmt.Errorf("failed to schedule ip-config rollback: %w", err).Error(),
 		)
-		if err := r.Client.Status().Update(ctx, ipc); err != nil {
+		if err := controllerutils.UpdateIPCStatus(ctx, r.Client, ipc); err != nil {
 			return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 		}
 		return requeueWithError(err)
@@ -268,7 +268,7 @@ func (r *IPCRollbackTwoPhaseHandler) PostPivot(
 				ipc,
 				fmt.Sprintf("Waiting for system to stabilize: %s", err.Error()),
 			)
-			if err := r.Client.Status().Update(ctx, ipc); err != nil {
+			if err := controllerutils.UpdateIPCStatus(ctx, r.Client, ipc); err != nil {
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", err))
 			}
 

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -729,10 +729,9 @@ func SetIPRollbackStatusCompleted(ipc *ipcv1.IPConfig, msg string) {
 }
 
 // UpdateIPStatus updates IPConfig status and observed generations consistently
-func UpdateIPStatus(ctx context.Context, c client.Client, ipc *ipcv1.IPConfig) error {
+func UpdateIPCStatus(ctx context.Context, c client.Client, ipc *ipcv1.IPConfig) error {
 	if c == nil {
-		// In UT code
-		return nil
+		return fmt.Errorf("client is nil")
 	}
 
 	ipc.Status.ObservedGeneration = ipc.ObjectMeta.Generation

--- a/docs/ip-configuration.md
+++ b/docs/ip-configuration.md
@@ -113,6 +113,8 @@ The API/implementation is designed to be extensible, but the currently supported
   - You can’t set `spec.ipv4` if the cluster is IPv6-only.
   - You can’t set `spec.ipv6` if the cluster is IPv4-only.
   - `dnsFilterOutFamily` is supported only on **dual-stack** clusters.
+    - Setting `spec.dnsFilterOutFamily` to `ipv4` or `ipv6` is only allowed when the cluster is *observably* dual-stack via status (both `status.ipv4.address` and `status.ipv6.address` are present).
+    - `spec.dnsFilterOutFamily: none` (or leaving it unset/empty) is always allowed.
   - `dnsServers` entries must match cluster families (no IPv4 DNS server on IPv6-only, etc.).
 - **Address-change coupling** (current limitation):
   - For each family, changing **gateway** or **machineNetwork** without changing **address** is **not supported**.
@@ -130,6 +132,7 @@ The API/implementation is designed to be extensible, but the currently supported
   - Runs health checks (unless skipped via `lca.openshift.io/ipconfig-skip-pre-configuration-cluster-health-checks`).
   - Performs cleanup (including removing unbooted stateroots and LCA workspace).
   - Resets conditions back to a clean Idle state.
+  - Resets `status.rollbackAvailabilityExpiration` back to empty/zero.
   - **Important**: transitioning to Idle after a successful Config is the **finalization point**; it will remove rollback ability
 
 - **Config**
@@ -275,6 +278,7 @@ If it doesn’t exist, it is created automatically by LCA initialization logic.
   - `ipv4`: filter out A records (prefer IPv6)
   - `ipv6`: filter out AAAA records (prefer IPv4)
   - `none`: explicitly disable filtering (removes the managed dnsmasq filter file)
+  - Note: setting it to `ipv4`/`ipv6` is only allowed when the cluster is observably dual-stack (both `status.ipv4.address` and `status.ipv6.address` are present).
 
 - **`spec.autoRollbackOnFailure.initMonitorTimeoutSeconds`** *(optional)*:
   - Timeout for the init-monitor watchdog; `0` or unset uses default **1800s (30m)**.
@@ -301,6 +305,12 @@ If it doesn’t exist, it is created automatically by LCA initialization logic.
 - **`status.dnsFilterOutFamily`**: inferred active dnsmasq filter-out family (`ipv4`, `ipv6`, or `none`).
 
 - **`status.history`**: timestamps for stage/phase progression (useful for auditing/debugging).
+
+- **`status.rollbackAvailabilityExpiration`**: a timestamp indicating when rolling back may start
+  to require **manual recovery** due to expired control plane / kubelet certificates in the
+  rollback (unbooted) stateroot. This is best-effort computed during Config post-pivot (based on
+  the earliest kubelet client/server certificate expiry, minus 30 minutes) and is reset when
+  returning to `Idle`.
 
 ## Annotations (behavioral controls)
 

--- a/lca-cli/cmd/ipconfig/prepivot.go
+++ b/lca-cli/cmd/ipconfig/prepivot.go
@@ -461,7 +461,9 @@ func validateClusterAPIAndUserIPSpec(
 		if ip.To4() != nil && !clusterHasIPv4 {
 			return fmt.Errorf("specified IPv4 DNS server %q, but the cluster does not have IPv4", s)
 		}
-		if ip.To16() != nil && !clusterHasIPv6 {
+		// Note: ip.To16() is non-nil for IPv4 addresses too; ensure we only treat
+		// it as IPv6 when it's not IPv4.
+		if ip.To4() == nil && ip.To16() != nil && !clusterHasIPv6 {
 			return fmt.Errorf("specified IPv6 DNS server %q, but the cluster does not have IPv6", s)
 		}
 	}

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -86,10 +86,15 @@ func validateNetworkCIDR(family, networkCIDR string) error {
 		if ipNet.IP.To4() == nil {
 			return fmt.Errorf("invalid %s machine network CIDR: %s", strings.ToLower(family), networkCIDR)
 		}
+		return nil
 	}
 
-	if ipNet.IP.To16() == nil {
-		return fmt.Errorf("invalid %s machine network CIDR: %s", strings.ToLower(family), networkCIDR)
+	if isIPv6 {
+		// Note: ip.To16() is non-nil for IPv4 addresses too; ensure we only treat
+		// it as IPv6 when it's not IPv4.
+		if ipNet.IP.To4() != nil || ipNet.IP.To16() == nil {
+			return fmt.Errorf("invalid %s machine network CIDR: %s", strings.ToLower(family), networkCIDR)
+		}
 	}
 
 	return nil
@@ -115,7 +120,9 @@ func validateIPAddress(family, ipStr string) error {
 		return nil
 	}
 
-	if ip.To16() == nil {
+	// Note: ip.To16() is non-nil for IPv4 addresses too; ensure we only treat
+	// it as IPv6 when it's not IPv4.
+	if ip.To4() != nil || ip.To16() == nil {
 		return fmt.Errorf("%s is not a valid %s address", ipStr, strings.ToUpper(family))
 	}
 


### PR DESCRIPTION
1. Fix ipv6 address validation bug.
2. Add input validation for dnsFilterOutFamily - only available for dual-stack clusters.
3. Add Automatic Rollback Expire field
4. Align conditions observedGeneration
5. Align IPC CR description with IBU / seedgen