### PR TITLE
CNF-21209: Add missing parameters to rpm lockfile

### DIFF
--- a/.konflux/lock-runtime/rpms.in.yaml
+++ b/.konflux/lock-runtime/rpms.in.yaml
@@ -14,6 +14,11 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: "1"
       sslverifystatus: "1"
+      # The SSL_CLIENT_KEY and SSL_CLIENT_CERT values will be provided in the environment on the Konflux cluster
+      # For the local make target, they are instead replaced with sed substitutions
+      sslclientkey: $SSL_CLIENT_KEY
+      sslclientcert: $SSL_CLIENT_CERT
+      #
       metadata_expire: "86400"
       enabled_metadata: "1"
       # This should match the RUNTIME_IMAGE in container_build_args.conf
@@ -28,6 +33,11 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: "1"
       sslverifystatus: "1"
+      # The SSL_CLIENT_KEY and SSL_CLIENT_CERT values will be provided in the environment on the Konflux cluster
+      # For the local make target, they are instead replaced with sed substitutions
+      sslclientkey: $SSL_CLIENT_KEY
+      sslclientcert: $SSL_CLIENT_CERT
+      #
       metadata_expire: "86400"
       enabled_metadata: "1"
       # This should match the RUNTIME_IMAGE in container_build_args.conf
@@ -42,6 +52,11 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: "1"
       sslverifystatus: "1"
+      # The SSL_CLIENT_KEY and SSL_CLIENT_CERT values will be provided in the environment on the Konflux cluster
+      # For the local make target, they are instead replaced with sed substitutions
+      sslclientkey: $SSL_CLIENT_KEY
+      sslclientcert: $SSL_CLIENT_CERT
+      #
       metadata_expire: "86400"
       enabled_metadata: "1"
       # This should match the RUNTIME_IMAGE in container_build_args.conf

--- a/Makefile
+++ b/Makefile
@@ -561,6 +561,14 @@ konflux-update-rpm-lock-runtime: sync-git-submodules ## Update the rpm lock file
 	mkdir -p $(PROJECT_DIR)/.konflux/lock-runtime/tmp/
 	@echo "Copying rpms.in.yaml to lock-runtime directory..."
 	cp $(PROJECT_DIR)/.konflux/lock-runtime/rpms.in.yaml $(PROJECT_DIR)/.konflux/lock-runtime/tmp/rpms.in.yaml
+	@echo "Replacing SSL_CLIENT_KEY and SSL_CLIENT_CERT in lock-runtime/tmp/rpms.in.yaml..."
+	if [ "$$(uname)" = "Darwin" ]; then \
+		sed -i '' 's|sslclientkey: $$SSL_CLIENT_KEY|sslclientkey: /etc/pki/entitlement/placeholder-key.pem|g' $(PROJECT_DIR)/.konflux/lock-runtime/tmp/rpms.in.yaml; \
+		sed -i '' 's|sslclientcert: $$SSL_CLIENT_CERT|sslclientcert: /etc/pki/entitlement/placeholder.pem|g' $(PROJECT_DIR)/.konflux/lock-runtime/tmp/rpms.in.yaml; \
+	else \
+		sed -i 's|sslclientkey: $$SSL_CLIENT_KEY|sslclientkey: /etc/pki/entitlement/placeholder-key.pem|g' $(PROJECT_DIR)/.konflux/lock-runtime/tmp/rpms.in.yaml; \
+		sed -i 's|sslclientcert: $$SSL_CLIENT_CERT|sslclientcert: /etc/pki/entitlement/placeholder.pem|g' $(PROJECT_DIR)/.konflux/lock-runtime/tmp/rpms.in.yaml; \
+	fi
 	@cat $(PROJECT_DIR)/.konflux/lock-runtime/tmp/rpms.in.yaml
 	@echo "Updating rpm lock file for the runtime..."
 	$(MAKE) -C $(PROJECT_DIR)/telco5g-konflux/scripts/rpm-lock generate-rhel9-locks \


### PR DESCRIPTION
- We need to pass the appropriate ssl parameters for Mintmaker to work correctly
- Also update local make target to replace them as necessary
- These changes were made in other repos when this was implemented, but seem to be missing from the original implementation here: https://github.com/openshift-kni/lifecycle-agent/pull/3289/changes
