### PR TITLE
CNF-21209: Create dummy Dockerfile for Mintmaker

### DIFF
--- a/.konflux/lock-runtime/Dockerfile.mintmaker
+++ b/.konflux/lock-runtime/Dockerfile.mintmaker
@@ -1,0 +1,5 @@
+# Due to a limitation in Mintmaker, we need to create a dummy Dockerfile that does not use ARGs
+# This should match the RUNTIME_IMAGE in container_build_args.conf
+# Mintmaker should keep these in sync automatically when it performs updates
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+#

--- a/.konflux/lock-runtime/rpms.in.yaml
+++ b/.konflux/lock-runtime/rpms.in.yaml
@@ -16,10 +16,6 @@ contentOrigin:
       sslverifystatus: "1"
       metadata_expire: "86400"
       enabled_metadata: "1"
-      # This should match the RUNTIME_IMAGE in container_build_args.conf
-      # Mintmaker should keep these in sync automatically when it performs updates
-      varsFromImage: registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
-      #
     - repoid: ubi-9-for-$basearch-baseos-rpms
       name: Red Hat Universal Base Image 9 for $basearch - BaseOS (RPMs)
       baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os
@@ -30,10 +26,6 @@ contentOrigin:
       sslverifystatus: "1"
       metadata_expire: "86400"
       enabled_metadata: "1"
-      # This should match the RUNTIME_IMAGE in container_build_args.conf
-      # Mintmaker should keep these in sync automatically when it performs updates
-      varsFromImage: registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
-      #
     - repoid: codeready-builder-for-ubi-9-$basearch-rpms
       name: Red Hat CodeReady Linux Builder for UBI 9 $basearch (RPMs)
       baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/os/
@@ -44,11 +36,9 @@ contentOrigin:
       sslverifystatus: "1"
       metadata_expire: "86400"
       enabled_metadata: "1"
-      # This should match the RUNTIME_IMAGE in container_build_args.conf
-      # Mintmaker should keep these in sync automatically when it performs updates
-      varsFromImage: registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
-      #
 packages:
   - util-linux-core
   - rsync
   - tar
+context:
+  containerfile: Dockerfile.mintmaker

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
             "datasourceTemplate": "docker",
             "managerFilePatterns": [
                 "/.*container_build_args\\.conf$/",
-                "/.*rpms\\.in\\.yaml$/"
+                "/.*Dockerfile\\.mintmaker$/"
             ],
             "matchStrings": [
                 "(?<depName>[\\w\\-\\.\\/]+):?(?<currentValue>[\\w\\-\\.]+)?@(?<currentDigest>sha256:[a-f0-9]+)"


### PR DESCRIPTION
- Create a dummy dockerfile for Mintmaker that does not use any BUILD ARGS
- Update renovate.json to keep this file in sync with container_build_args.conf
- Update rpms.in.yaml to set the context for Mintmaker to use the new dummy file
