### PR TITLE
MGMT-22599, MGMT-22762, MGMT-22765: IPC improvements and bug fixes

### DIFF
--- a/api/ipconfig/v1/zz_generated.deepcopy.go
+++ b/api/ipconfig/v1/zz_generated.deepcopy.go
@@ -114,7 +114,7 @@ func (in *IPConfigSpec) DeepCopyInto(out *IPConfigSpec) {
 	}
 	if in.DNSServers != nil {
 		in, out := &in.DNSServers, &out.DNSServers
-		*out = make([]string, len(*in))
+		*out = make([]IPAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.AutoRollbackOnFailure != nil {
@@ -162,7 +162,7 @@ func (in *IPConfigStatus) DeepCopyInto(out *IPConfigStatus) {
 	}
 	if in.DNSServers != nil {
 		in, out := &in.DNSServers, &out.DNSServers
-		*out = make([]string, len(*in))
+		*out = make([]IPAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.History != nil {

--- a/bundle/manifests/lca.openshift.io_ipconfigs.yaml
+++ b/bundle/manifests/lca.openshift.io_ipconfigs.yaml
@@ -99,9 +99,17 @@ spec:
               dnsServers:
                 description: |-
                   DNSServers is the complete ordered list of DNS server IPs (IPv4 and/or IPv6)
-                  to configure on the node.
+                  to configure on the node. Up to 2 DNS servers are supported.
                 items:
+                  description: |-
+                    IPAddress represents an IP address (IPv4 or IPv6).
+                    IPv6 max textual length is 39 chars; we allow some headroom.
+                  maxLength: 45
                   type: string
+                  x-kubernetes-validations:
+                  - message: must be a valid IP address
+                    rule: isIP(self)
+                maxItems: 2
                 type: array
               ipv4:
                 description: IPv4 stack (omit for IPv6-only)
@@ -168,7 +176,8 @@ spec:
                 type: string
               vlanID:
                 description: Optional VLAN applied to br-ex path
-                minimum: 1
+                maximum: 4095
+                minimum: 0
                 type: integer
             required:
             - stage
@@ -242,10 +251,19 @@ spec:
                 - none
                 type: string
               dnsServers:
-                description: DNSServers reports the currently detected ordered list
-                  of DNS server IPs (IPv4 and/or IPv6).
+                description: |-
+                  DNSServers reports the currently detected ordered list of DNS server IPs (IPv4 and/or IPv6).
+                  Up to 2 DNS servers are supported.
                 items:
+                  description: |-
+                    IPAddress represents an IP address (IPv4 or IPv6).
+                    IPv6 max textual length is 39 chars; we allow some headroom.
+                  maxLength: 45
                   type: string
+                  x-kubernetes-validations:
+                  - message: must be a valid IP address
+                    rule: isIP(self)
+                maxItems: 2
                 type: array
               history:
                 description: History stores timing info of different IPConfig stages

--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -176,18 +176,62 @@ spec:
       specDescriptors:
       - displayName: Stage
         path: stage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
       - displayName: IPv4
         path: ipv4
+      - displayName: Address
+        path: ipv4.address
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv4
+      - displayName: Machine Network
+        path: ipv4.machineNetwork
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv4
+      - displayName: Gateway
+        path: ipv4.gateway
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv4
       - displayName: IPv6
         path: ipv6
+      - displayName: Address
+        path: ipv6.address
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv6
+      - displayName: Machine Network
+        path: ipv6.machineNetwork
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv6
+      - displayName: Gateway
+        path: ipv6.gateway
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv6
       - displayName: DNS Servers
         path: dnsServers
+      - displayName: DNS Server 1
+        path: dnsServers[0]
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:DNS Servers
+      - displayName: DNS Server 2
+        path: dnsServers[1]
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:DNS Servers
       - displayName: VLAN ID
         path: vlanID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - displayName: DNS Filter-Out Family
         path: dnsFilterOutFamily
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
       - displayName: Auto Rollback On Failure
         path: autoRollbackOnFailure
       - description: |-
@@ -197,6 +241,7 @@ spec:
         path: autoRollbackOnFailure.initMonitorTimeoutSeconds
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Auto Rollback On Failure
       statusDescriptors:
       - displayName: Observed Generation
         path: observedGeneration

--- a/config/crd/bases/lca.openshift.io_ipconfigs.yaml
+++ b/config/crd/bases/lca.openshift.io_ipconfigs.yaml
@@ -99,9 +99,17 @@ spec:
               dnsServers:
                 description: |-
                   DNSServers is the complete ordered list of DNS server IPs (IPv4 and/or IPv6)
-                  to configure on the node.
+                  to configure on the node. Up to 2 DNS servers are supported.
                 items:
+                  description: |-
+                    IPAddress represents an IP address (IPv4 or IPv6).
+                    IPv6 max textual length is 39 chars; we allow some headroom.
+                  maxLength: 45
                   type: string
+                  x-kubernetes-validations:
+                  - message: must be a valid IP address
+                    rule: isIP(self)
+                maxItems: 2
                 type: array
               ipv4:
                 description: IPv4 stack (omit for IPv6-only)
@@ -168,7 +176,8 @@ spec:
                 type: string
               vlanID:
                 description: Optional VLAN applied to br-ex path
-                minimum: 1
+                maximum: 4095
+                minimum: 0
                 type: integer
             required:
             - stage
@@ -242,10 +251,19 @@ spec:
                 - none
                 type: string
               dnsServers:
-                description: DNSServers reports the currently detected ordered list
-                  of DNS server IPs (IPv4 and/or IPv6).
+                description: |-
+                  DNSServers reports the currently detected ordered list of DNS server IPs (IPv4 and/or IPv6).
+                  Up to 2 DNS servers are supported.
                 items:
+                  description: |-
+                    IPAddress represents an IP address (IPv4 or IPv6).
+                    IPv6 max textual length is 39 chars; we allow some headroom.
+                  maxLength: 45
                   type: string
+                  x-kubernetes-validations:
+                  - message: must be a valid IP address
+                    rule: isIP(self)
+                maxItems: 2
                 type: array
               history:
                 description: History stores timing info of different IPConfig stages

--- a/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
+++ b/config/manifests/bases/lifecycle-agent.clusterserviceversion.yaml
@@ -56,18 +56,62 @@ spec:
       specDescriptors:
       - displayName: Stage
         path: stage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
       - displayName: IPv4
         path: ipv4
+      - displayName: Address
+        path: ipv4.address
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv4
+      - displayName: Machine Network
+        path: ipv4.machineNetwork
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv4
+      - displayName: Gateway
+        path: ipv4.gateway
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv4
       - displayName: IPv6
         path: ipv6
+      - displayName: Address
+        path: ipv6.address
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv6
+      - displayName: Machine Network
+        path: ipv6.machineNetwork
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv6
+      - displayName: Gateway
+        path: ipv6.gateway
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:IPv6
       - displayName: DNS Servers
         path: dnsServers
+      - displayName: DNS Server 1
+        path: dnsServers[0]
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:DNS Servers
+      - displayName: DNS Server 2
+        path: dnsServers[1]
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:DNS Servers
       - displayName: VLAN ID
         path: vlanID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - displayName: DNS Filter-Out Family
         path: dnsFilterOutFamily
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select
       - displayName: Auto Rollback On Failure
         path: autoRollbackOnFailure
       - description: |-
@@ -77,6 +121,7 @@ spec:
         path: autoRollbackOnFailure.initMonitorTimeoutSeconds
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Auto Rollback On Failure
       statusDescriptors:
       - displayName: Observed Generation
         path: observedGeneration

--- a/controllers/ipc_config_handlers.go
+++ b/controllers/ipc_config_handlers.go
@@ -650,7 +650,9 @@ func (h *IPCConfigTwoPhaseHandler) writeIPConfigPrePivotConfig(ipc *ipcv1.IPConf
 	}
 
 	if len(ipc.Spec.DNSServers) > 0 {
-		cfg.DNSServers = append([]string{}, ipc.Spec.DNSServers...)
+		cfg.DNSServers = lo.Map(ipc.Spec.DNSServers, func(s ipcv1.IPAddress, _ int) string {
+			return string(s)
+		})
 	}
 
 	if ipc.Spec.VLANID > 0 {
@@ -850,7 +852,7 @@ func (h *IPCConfigStageHandler) validateClusterAndNetworkSpecCompatability(
 	}
 
 	for _, s := range ipc.Spec.DNSServers {
-		ip := net.ParseIP(s)
+		ip := net.ParseIP(string(s))
 		if ip == nil {
 			return fmt.Errorf("dnsServers contains an invalid IP: %q", s)
 		}

--- a/controllers/ipc_config_handlers_test.go
+++ b/controllers/ipc_config_handlers_test.go
@@ -469,7 +469,7 @@ func TestIPCConfigTwoPhaseHandler_PrePivot(t *testing.T) {
 			MachineNetwork: "2001:db8::/64",
 			Gateway:        "2001:db8::1",
 		}
-		ipc.Status.DNSServers = []string{"192.0.2.53", "2001:db8::53"}
+		ipc.Status.DNSServers = []ipcv1.IPAddress{"192.0.2.53", "2001:db8::53"}
 		ipc.Status.VLANID = 123
 		ipc.Status.DNSFilterOutFamily = "ipv6"
 		k8sClient := newFakeClientWithStatus(t, scheme, ipc)
@@ -841,13 +841,13 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 			MachineNetwork: "192.0.2.0/24",
 			Gateway:        "192.0.2.1",
 		}
-		ipc.Spec.DNSServers = []string{"192.0.2.53"}
+		ipc.Spec.DNSServers = []ipcv1.IPAddress{"192.0.2.53"}
 		ipc.Status.IPv4 = &ipcv1.IPv4Status{
 			Address:        "192.0.2.99",   // mismatch
 			MachineNetwork: "192.0.2.0/24", // match
 			Gateway:        "192.0.2.1",
 		}
-		ipc.Status.DNSServers = []string{"192.0.2.53"}
+		ipc.Status.DNSServers = []ipcv1.IPAddress{"192.0.2.53"}
 		k8sClient := newFakeClientWithStatus(t, scheme, ipc)
 
 		oldHC := CheckHealth
@@ -1368,13 +1368,13 @@ func TestStatusIPsMatchSpec(t *testing.T) {
 			MachineNetwork: "2001:db8::/64",
 			Gateway:        "fe80::1",
 		}
-		ipc.Spec.DNSServers = []string{"2001:db8::53"}
+		ipc.Spec.DNSServers = []ipcv1.IPAddress{"2001:db8::53"}
 		ipc.Status.IPv6 = &ipcv1.IPv6Status{
 			Address:        "2001:db8::10",
 			MachineNetwork: "2001:db8::/64",
 			Gateway:        "fe80::1",
 		}
-		ipc.Status.DNSServers = []string{"2001:db8::53"}
+		ipc.Status.DNSServers = []ipcv1.IPAddress{"2001:db8::53"}
 		assert.NoError(t, statusIPsMatchSpec(ipc))
 	})
 }
@@ -1421,8 +1421,8 @@ func TestIPAndCIDRHelpers(t *testing.T) {
 		ipc := mkConfigIPC(t, false)
 		ipc.Spec.IPv4 = &ipcv1.IPv4Config{Address: "192.0.2.10"}
 		ipc.Status.IPv4 = &ipcv1.IPv4Status{Address: "192.0.2.10"}
-		ipc.Spec.DNSServers = []string{"192.0.2.54"}
-		ipc.Status.DNSServers = []string{"192.0.2.53"}
+		ipc.Spec.DNSServers = []ipcv1.IPAddress{"192.0.2.54"}
+		ipc.Status.DNSServers = []ipcv1.IPAddress{"192.0.2.53"}
 
 		err := validateAddressChanges(ipc)
 		assert.Error(t, err)
@@ -1447,7 +1447,7 @@ func TestValidateClusterAndNetworkSpecCompatability_DNSServerFamilyChecks(t *tes
 
 		ipc := mkConfigIPC(t, false)
 		ipc.Spec.IPv4 = &ipcv1.IPv4Config{Address: "192.0.2.20"}
-		ipc.Spec.DNSServers = []string{"192.0.2.53"}
+		ipc.Spec.DNSServers = []ipcv1.IPAddress{"192.0.2.53"}
 
 		k8sClient := newFakeClientWithStatus(t, scheme, ipc, nodeV4, mc)
 		h := &IPCConfigStageHandler{
@@ -1467,7 +1467,7 @@ func TestValidateClusterAndNetworkSpecCompatability_DNSServerFamilyChecks(t *tes
 
 		ipc := mkConfigIPC(t, false)
 		ipc.Spec.IPv4 = &ipcv1.IPv4Config{Address: "192.0.2.20"}
-		ipc.Spec.DNSServers = []string{"2001:db8::53"}
+		ipc.Spec.DNSServers = []ipcv1.IPAddress{"2001:db8::53"}
 
 		k8sClient := newFakeClientWithStatus(t, scheme, ipc, nodeV4, mc)
 		h := &IPCConfigStageHandler{

--- a/controllers/ipc_idle_handlers.go
+++ b/controllers/ipc_idle_handlers.go
@@ -83,7 +83,8 @@ func (h *IPCIdleStageHandler) Handle(
 		}
 
 		controllerutils.SetIPIdleStatusFalse(
-			ipc, controllerutils.ConditionReasons.InProgress,
+			ipc,
+			controllerutils.ConditionReasons.InProgress,
 			controllerutils.InProgressOfBecomingIdle,
 		)
 		if err := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); err != nil {
@@ -106,7 +107,7 @@ func (h *IPCIdleStageHandler) Handle(
 		logger.Info("Running health checks")
 		if err := CheckHealth(ctx, h.NoncachedClient, logger); err != nil {
 			msg := fmt.Sprintf("Waiting for system to stabilize: %s", err.Error())
-			controllerutils.SetIPIdleStatusFalse(ipc, controllerutils.ConditionReasons.Stabilizing, msg)
+			controllerutils.SetIPIdleStatusFalse(ipc, controllerutils.ConditionReasons.InProgress, msg)
 			if uerr := controllerutils.UpdateIPCStatus(ctx, h.Client, ipc); uerr != nil {
 				logger.Error(uerr, "Failed to update IPConfig status after health check failure")
 				return requeueWithError(fmt.Errorf("failed to update ipconfig status: %w", uerr))

--- a/controllers/ipc_idle_handlers_test.go
+++ b/controllers/ipc_idle_handlers_test.go
@@ -221,7 +221,7 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 		assert.Equal(t, requeueWithHealthCheckInterval(), res2)
 
 		updated2 := mustGetIPC(t, k8sClient, common.IPConfigName)
-		assertIdleCond(t, updated2, metav1.ConditionFalse, controllerutils.ConditionReasons.Stabilizing, "Waiting for system to stabilize")
+		assertIdleCond(t, updated2, metav1.ConditionFalse, controllerutils.ConditionReasons.InProgress, "Waiting for system to stabilize")
 	})
 
 	t.Run("status update fails before stage validation => returns requeueWithError", func(t *testing.T) {
@@ -288,7 +288,7 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 		assert.Equal(t, requeueWithHealthCheckInterval(), res)
 
 		updated := mustGetIPC(t, k8sClient, common.IPConfigName)
-		assertIdleCond(t, updated, metav1.ConditionFalse, controllerutils.ConditionReasons.Stabilizing, "Waiting for system to stabilize")
+		assertIdleCond(t, updated, metav1.ConditionFalse, controllerutils.ConditionReasons.InProgress, "Waiting for system to stabilize")
 		assertStatusInvariants(t, updated, ipc)
 	})
 
@@ -480,7 +480,7 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 			{
 				Type:               string(controllerutils.ConditionTypes.Idle),
 				Status:             metav1.ConditionFalse,
-				Reason:             string(controllerutils.ConditionReasons.Stabilizing),
+				Reason:             string(controllerutils.ConditionReasons.InProgress),
 				Message:            "old idle condition",
 				ObservedGeneration: ipc.Generation,
 			},
@@ -569,7 +569,7 @@ func TestIPCIdleStageHandler_Handle(t *testing.T) {
 		updated := mustGetIPC(t, k8sClient, common.IPConfigName)
 		_, annPresent := updated.GetAnnotations()[controllerutils.ManualCleanupAnnotation]
 		assert.False(t, annPresent, "manual cleanup annotation should be removed")
-		assertIdleCond(t, updated, metav1.ConditionFalse, controllerutils.ConditionReasons.Stabilizing, "Waiting for system to stabilize")
+		assertIdleCond(t, updated, metav1.ConditionFalse, controllerutils.ConditionReasons.InProgress, "Waiting for system to stabilize")
 		assertStatusInvariants(t, updated, ipc)
 	})
 

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -71,7 +71,6 @@ var ConditionReasons = struct {
 	FinalizeCompleted       ConditionReason
 	FinalizeFailed          ConditionReason
 	InvalidTransition       ConditionReason
-	Stabilizing             ConditionReason
 	Blocked                 ConditionReason
 }{
 	Idle:                    "Idle",
@@ -87,7 +86,6 @@ var ConditionReasons = struct {
 	FinalizeCompleted:       "FinalizeCompleted",
 	FinalizeFailed:          "FinalizeFailed",
 	InvalidTransition:       "InvalidTransition",
-	Stabilizing:             "Stabilizing",
 	// Blocked condition reason is used to specify IPC or IBU is blocked by each other.
 	// They are not allowed to run their flows simultaneously due to conflicts.
 	Blocked: "Blocked",


### PR DESCRIPTION
1. Change the condition reason in Idle stage during cluster stablization to "in progress" rather than "stablizing". "stablizing" was not considered as an "in progress" reason.
2. Add admission validation for maximum value for vlan ID (4095).
3. Add admission validation for maximum amount of DNS servers (2).
4. Add admission validation for each IP address of DNS server must be a valid IP address (ipv4/ipv6).
5. Add/fix UI descriptors.

