### PR TITLE
Fix recert sha256 (missing konflux nudge)

### DIFF
--- a/.konflux/overlay/pin_images.in.yaml
+++ b/.konflux/overlay/pin_images.in.yaml
@@ -7,5 +7,5 @@
 # Recert
 - key: recert_image
   source: quay.io/edge-infrastructure/recert:v0
-  target: quay.io/redhat-user-workloads/telco-5g-tenant/recert-4-20@sha256:81b1d531754c1e4e49567fe681c659acf3953bde72d2706a2ff21a637c668f30
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/recert-4-20@sha256:667cb146b46e623b9c99d903c6897e9ea0e91edd83f2936137d76ebf3f28427e
 #


### PR DESCRIPTION
**Why these changes ?** 

Lca is out of sync with the latest recert image: a konflux nudge to sync it seems to be missing at time of writing. This is currently blocking 4.20 lca releases as the bundle points to an old version but this newer one included correctly in the snapshot is not able to match the bundle one, causing a conforma blocker.

