### PR TITLE
NO-ISSUE: Fix DNS servers status in IPC

### DIFF
--- a/api/ipconfig/v1/types.go
+++ b/api/ipconfig/v1/types.go
@@ -226,10 +226,8 @@ type IPConfigStatus struct {
 	IPv6 *IPv6Status `json:"ipv6,omitempty"`
 
 	// DNSServers reports the currently detected ordered list of DNS server IPs (IPv4 and/or IPv6).
-	// Up to 2 DNS servers are supported.
-	// +kubebuilder:validation:MaxItems=2
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="DNS Servers"
-	DNSServers []IPAddress `json:"dnsServers,omitempty"`
+	DNSServers []string `json:"dnsServers,omitempty"`
 
 	// VLANID reports the currently detected VLAN ID on the br-ex uplink path (if any)
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="VLAN ID"

--- a/api/ipconfig/v1/zz_generated.deepcopy.go
+++ b/api/ipconfig/v1/zz_generated.deepcopy.go
@@ -162,7 +162,7 @@ func (in *IPConfigStatus) DeepCopyInto(out *IPConfigStatus) {
 	}
 	if in.DNSServers != nil {
 		in, out := &in.DNSServers, &out.DNSServers
-		*out = make([]IPAddress, len(*in))
+		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
 	if in.History != nil {

--- a/bundle/manifests/lca.openshift.io_ipconfigs.yaml
+++ b/bundle/manifests/lca.openshift.io_ipconfigs.yaml
@@ -251,19 +251,10 @@ spec:
                 - none
                 type: string
               dnsServers:
-                description: |-
-                  DNSServers reports the currently detected ordered list of DNS server IPs (IPv4 and/or IPv6).
-                  Up to 2 DNS servers are supported.
+                description: DNSServers reports the currently detected ordered list
+                  of DNS server IPs (IPv4 and/or IPv6).
                 items:
-                  description: |-
-                    IPAddress represents an IP address (IPv4 or IPv6).
-                    IPv6 max textual length is 39 chars; we allow some headroom.
-                  maxLength: 45
                   type: string
-                  x-kubernetes-validations:
-                  - message: must be a valid IP address
-                    rule: isIP(self)
-                maxItems: 2
                 type: array
               history:
                 description: History stores timing info of different IPConfig stages

--- a/config/crd/bases/lca.openshift.io_ipconfigs.yaml
+++ b/config/crd/bases/lca.openshift.io_ipconfigs.yaml
@@ -251,19 +251,10 @@ spec:
                 - none
                 type: string
               dnsServers:
-                description: |-
-                  DNSServers reports the currently detected ordered list of DNS server IPs (IPv4 and/or IPv6).
-                  Up to 2 DNS servers are supported.
+                description: DNSServers reports the currently detected ordered list
+                  of DNS server IPs (IPv4 and/or IPv6).
                 items:
-                  description: |-
-                    IPAddress represents an IP address (IPv4 or IPv6).
-                    IPv6 max textual length is 39 chars; we allow some headroom.
-                  maxLength: 45
                   type: string
-                  x-kubernetes-validations:
-                  - message: must be a valid IP address
-                    rule: isIP(self)
-                maxItems: 2
                 type: array
               history:
                 description: History stores timing info of different IPConfig stages

--- a/controllers/ipc_config_handlers.go
+++ b/controllers/ipc_config_handlers.go
@@ -479,10 +479,11 @@ func statusIPsMatchSpec(ipc *ipcv1.IPConfig) error {
 	}
 
 	if len(ipc.Spec.DNSServers) > 0 {
-		if !reflect.DeepEqual(ipc.Spec.DNSServers, ipc.Status.DNSServers) {
+		specDNSServers := lo.Map(ipc.Spec.DNSServers, func(s ipcv1.IPAddress, _ int) string { return string(s) })
+		if !reflect.DeepEqual(specDNSServers, ipc.Status.DNSServers) {
 			mismatches = append(
 				mismatches,
-				fmt.Sprintf("dnsServers mismatch: spec=%v status=%v", ipc.Spec.DNSServers, ipc.Status.DNSServers),
+				fmt.Sprintf("dnsServers mismatch: spec=%v status=%v", specDNSServers, ipc.Status.DNSServers),
 			)
 		}
 	}
@@ -906,8 +907,11 @@ func validateAddressChanges(ipc *ipcv1.IPConfig) error {
 		}
 	}
 
-	if len(ipc.Spec.DNSServers) > 0 && len(ipc.Status.DNSServers) > 0 &&
-		!reflect.DeepEqual(ipc.Spec.DNSServers, ipc.Status.DNSServers) {
+	if len(ipc.Spec.DNSServers) > 0 && len(ipc.Status.DNSServers) > 0 {
+		specDNSServers := lo.Map(ipc.Spec.DNSServers, func(s ipcv1.IPAddress, _ int) string { return string(s) })
+		if reflect.DeepEqual(specDNSServers, ipc.Status.DNSServers) {
+			return nil
+		}
 		ipChanged := false
 		if ipc.Spec.IPv4 != nil && ipc.Status.IPv4 != nil && !ipEqual(ipc.Spec.IPv4.Address, ipc.Status.IPv4.Address) {
 			ipChanged = true

--- a/controllers/ipc_config_handlers_test.go
+++ b/controllers/ipc_config_handlers_test.go
@@ -469,7 +469,7 @@ func TestIPCConfigTwoPhaseHandler_PrePivot(t *testing.T) {
 			MachineNetwork: "2001:db8::/64",
 			Gateway:        "2001:db8::1",
 		}
-		ipc.Status.DNSServers = []ipcv1.IPAddress{"192.0.2.53", "2001:db8::53"}
+		ipc.Status.DNSServers = []string{"192.0.2.53", "2001:db8::53"}
 		ipc.Status.VLANID = 123
 		ipc.Status.DNSFilterOutFamily = "ipv6"
 		k8sClient := newFakeClientWithStatus(t, scheme, ipc)
@@ -847,7 +847,7 @@ func TestIPCConfigTwoPhaseHandler_PostPivot(t *testing.T) {
 			MachineNetwork: "192.0.2.0/24", // match
 			Gateway:        "192.0.2.1",
 		}
-		ipc.Status.DNSServers = []ipcv1.IPAddress{"192.0.2.53"}
+		ipc.Status.DNSServers = []string{"192.0.2.53"}
 		k8sClient := newFakeClientWithStatus(t, scheme, ipc)
 
 		oldHC := CheckHealth
@@ -1374,7 +1374,7 @@ func TestStatusIPsMatchSpec(t *testing.T) {
 			MachineNetwork: "2001:db8::/64",
 			Gateway:        "fe80::1",
 		}
-		ipc.Status.DNSServers = []ipcv1.IPAddress{"2001:db8::53"}
+		ipc.Status.DNSServers = []string{"2001:db8::53"}
 		assert.NoError(t, statusIPsMatchSpec(ipc))
 	})
 }
@@ -1422,7 +1422,7 @@ func TestIPAndCIDRHelpers(t *testing.T) {
 		ipc.Spec.IPv4 = &ipcv1.IPv4Config{Address: "192.0.2.10"}
 		ipc.Status.IPv4 = &ipcv1.IPv4Status{Address: "192.0.2.10"}
 		ipc.Spec.DNSServers = []ipcv1.IPAddress{"192.0.2.54"}
-		ipc.Status.DNSServers = []ipcv1.IPAddress{"192.0.2.53"}
+		ipc.Status.DNSServers = []string{"192.0.2.53"}
 
 		err := validateAddressChanges(ipc)
 		assert.Error(t, err)

--- a/controllers/ipc_controller.go
+++ b/controllers/ipc_controller.go
@@ -592,9 +592,7 @@ func (r *IPConfigReconciler) refreshNetworkStatus(ctx context.Context, ipc *ipcv
 	ipc.Status.VLANID = vlan
 
 	dnsServers := lcautils.ExtractDNSServers(state)
-	ipc.Status.DNSServers = lo.Map(dnsServers, func(s string, _ int) ipcv1.IPAddress {
-		return ipcv1.IPAddress(s)
-	})
+	ipc.Status.DNSServers = dnsServers
 
 	fam, err := r.inferDNSFilterOutFamily()
 	if err != nil {

--- a/controllers/ipc_controller_test.go
+++ b/controllers/ipc_controller_test.go
@@ -143,7 +143,7 @@ func assertReconcileTestRefreshedNetwork(t *testing.T, ipc *ipcv1.IPConfig) {
 	// No IPv6 in the fixture => should not be set.
 	assert.Nil(t, ipc.Status.IPv6)
 
-	assert.Equal(t, []ipcv1.IPAddress{"192.0.2.53", "2001:db8::53"}, ipc.Status.DNSServers)
+	assert.Equal(t, []string{"192.0.2.53", "2001:db8::53"}, ipc.Status.DNSServers)
 
 	// No VLAN in nmstate JSON => should not be set.
 	assert.Equal(t, 0, ipc.Status.VLANID)


### PR DESCRIPTION
Avoid validation of the dns servers as it is set by the controller