### PR TITLE
MGMT-22551: Block hosts with dynamic IP assignment in IPC flow

### DIFF
--- a/controllers/ipc_config_handlers.go
+++ b/controllers/ipc_config_handlers.go
@@ -1010,6 +1010,47 @@ func (h *IPCConfigStageHandler) validateSNO(ctx context.Context) error {
 	return nil
 }
 
+func (h *IPCConfigStageHandler) validateStaticNetworking() error {
+	output, err := h.ChrootOps.RunInHostNamespace("nmstatectl", "show", "--json", "-q")
+	if err != nil {
+		return fmt.Errorf("failed to run nmstatectl show --json for static networking validation: %w", err)
+	}
+
+	state, err := lcautils.ParseNmstate(output)
+	if err != nil {
+		return fmt.Errorf("failed to parse nmstate output for static networking validation: %w", err)
+	}
+
+	var reasons []string
+
+	intf, err := lcautils.GetBrExInterface(state)
+	if err != nil {
+		return fmt.Errorf("failed to get br-ex interface: %w", err)
+	}
+
+	if intf.IPv4.Enabled && intf.IPv4.DHCP {
+		reasons = append(reasons, "IPv4 DHCP enabled")
+	}
+
+	if intf.IPv6.Enabled {
+		if intf.IPv6.Autoconf {
+			reasons = append(reasons, "IPv6 DHCP and autoconf enabled")
+		}
+		if intf.IPv6.DHCP {
+			reasons = append(reasons, "IPv6 DHCP enabled")
+		}
+	}
+
+	if len(reasons) > 0 {
+		return fmt.Errorf(
+			"ip-config flow is supported only on SNOs with static networking; detected dynamic configuration: %s",
+			strings.Join(reasons, "; "),
+		)
+	}
+
+	return nil
+}
+
 func exportIPConfigForUncontrolledRollback(ipc *ipcv1.IPConfig, chrootOps ops.Ops) error {
 	ipcCopy := ipc.DeepCopy()
 	controllerutils.SetIPConfigStatusFailed(ipcCopy, "Uncontrolled rollback")
@@ -1027,6 +1068,10 @@ func exportIPConfigForUncontrolledRollback(ipc *ipcv1.IPConfig, chrootOps ops.Op
 func (h *IPCConfigStageHandler) validateConfigStart(ctx context.Context, ipc *ipcv1.IPConfig) error {
 	if err := h.validateSNO(ctx); err != nil {
 		return fmt.Errorf("validation of SNO failed: %w", err)
+	}
+
+	if err := h.validateStaticNetworking(); err != nil {
+		return fmt.Errorf("validation of static networking failed: %w", err)
 	}
 
 	if err := h.validateDNSMasqMCExists(ctx); err != nil {

--- a/controllers/ipc_controller.go
+++ b/controllers/ipc_controller.go
@@ -565,7 +565,7 @@ func (r *IPConfigReconciler) refreshNetworkStatus(ctx context.Context, ipc *ipcv
 		controllerutils.DefaultRouteV4,
 		controllerutils.DefaultRouteV6,
 	)
-	vlanID, err := lcautils.ExtractBrExVLANID(state, controllerutils.BridgeExternalName)
+	vlanID, err := lcautils.ExtractBrExVLANID(state)
 	if err != nil {
 		return fmt.Errorf("failed to extract BrEx VLAN ID: %w", err)
 	}

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -161,6 +161,10 @@ const (
 	IPv4FamilyName = "ipv4"
 	IPv6FamilyName = "ipv6"
 	DNSFamilyNone  = "none"
+
+	OvsBridgeInterfaceType = "ovs-bridge"
+	OvsInterfaceType       = "ovs-interface"
+	OvsBridgeExternalName  = "br-ex"
 )
 
 // DNSMasq-related constants

--- a/utils/network_state_test.go
+++ b/utils/network_state_test.go
@@ -90,14 +90,14 @@ func TestExtractBrExUplinkName_Success(t *testing.T) {
 		},
 	}
 
-	uplink, err := ExtractBrExUplinkName(state, "br-ex")
+	uplink, err := ExtractBrExUplinkName(state)
 	assert.NoError(t, err)
 	assert.Equal(t, "ens3", uplink)
 }
 
 func TestExtractBrExUplinkName_NotFound(t *testing.T) {
 	state := NmState{}
-	_, err := ExtractBrExUplinkName(state, "br-ex")
+	_, err := ExtractBrExUplinkName(state)
 	assert.Error(t, err)
 }
 
@@ -127,7 +127,7 @@ func TestExtractBrExVLANID_Found(t *testing.T) {
 		},
 	}
 
-	id, err := ExtractBrExVLANID(state, "br-ex")
+	id, err := ExtractBrExVLANID(state)
 	assert.NoError(t, err)
 	if assert.NotNil(t, id) {
 		assert.Equal(t, 123, *id)
@@ -156,7 +156,7 @@ func TestExtractBrExVLANID_NoVLAN(t *testing.T) {
 		},
 	}
 
-	id, err := ExtractBrExVLANID(state, "br-ex")
+	id, err := ExtractBrExVLANID(state)
 	assert.NoError(t, err)
 	assert.Nil(t, id)
 }


### PR DESCRIPTION
IPC support only static networking at the moment.

**Note** - IPC test in this PR depand on https://github.com/rh-ecosystem-edge/ib-orchestrate-vm/pull/109