### PR TITLE
OCPBUGS-76416: Align annotations.yaml and bundle labels

### DIFF
--- a/.konflux/Dockerfile.bundle
+++ b/.konflux/Dockerfile.bundle
@@ -12,6 +12,10 @@ WORKDIR /tmp
 ENV MANIFESTS_PATH=/tmp/manifests
 COPY --chown=yq:yq bundle/manifests $MANIFESTS_PATH
 
+# Copy bundle metadata
+ENV METADATA_PATH=/tmp/metadata
+COPY --chown=yq:yq bundle/metadata $METADATA_PATH
+
 # Copy overlay scripts
 ENV OVERLAY_PATH=/tmp/overlay
 RUN mkdir -p $OVERLAY_PATH
@@ -24,6 +28,12 @@ RUN $OVERLAY_PATH/konflux-bundle-overlay.sh  \
     --set-mapping-production \
     --set-pinning-file $OVERLAY_PATH/pin_images.in.yaml \
     --set-release-file $OVERLAY_PATH/release.in.yaml
+
+# Override specific labels in metadata/annotations.yaml using yq (version from release.in.yaml)
+RUN CHANNEL_VERSION=$(yq -r '.variables.version | split(".") | .[0:2] | join(".")' $OVERLAY_PATH/release.in.yaml) && \
+    export CHANNEL_VERSION && \
+    yq -i '.annotations["operators.operatorframework.io.bundle.channels.v1"] = "stable," + strenv(CHANNEL_VERSION)' $METADATA_PATH/annotations.yaml && \
+    yq -i '.annotations["operators.operatorframework.io.bundle.channel.default.v1"] = "stable"' $METADATA_PATH/annotations.yaml
 
 # From here downwards this should mostly match the non-konflux bundle, i.e., `bundle.Dockerfile`
 # However there are a few exceptions:
@@ -38,10 +48,10 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=lifecycle-agent
 LABEL operators.operatorframework.io.bundle.channels.v1=stable,4.22
-LABEL operators.operatorframework.io.bundle.channels.default.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.40.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
@@ -49,5 +59,5 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Copy files to locations specified by labels.
 COPY --from=overlay /tmp/manifests /manifests/
-COPY bundle/metadata /metadata/
+COPY --from=overlay /tmp/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/


### PR DESCRIPTION
The annotations should match the values used in the labels
- Fix default channel label
- Fix kubebuilder label
