### PR TITLE
[release-4.17] OCPBUGS-76428: Align annotations.yaml and bundle labels

### DIFF
--- a/.konflux/Dockerfile.bundle
+++ b/.konflux/Dockerfile.bundle
@@ -12,6 +12,10 @@ WORKDIR /tmp
 ENV MANIFESTS_PATH=/tmp/manifests
 COPY --chown=yq:yq bundle/manifests $MANIFESTS_PATH
 
+# Copy bundle metadata
+ENV METADATA_PATH=/tmp/metadata
+COPY --chown=yq:yq bundle/metadata $METADATA_PATH
+
 # Copy overlay scripts
 ENV OVERLAY_PATH=/tmp/overlay
 RUN mkdir -p $OVERLAY_PATH
@@ -24,6 +28,12 @@ RUN $OVERLAY_PATH/konflux-bundle-overlay.sh  \
     --set-mapping-production \
     --set-pinning-file $OVERLAY_PATH/pin_images.in.yaml \
     --set-release-file $OVERLAY_PATH/release.in.yaml
+
+# Override specific labels in metadata/annotations.yaml using yq (version from release.in.yaml)
+RUN CHANNEL_VERSION=$(yq -r '.variables.version | split(".") | .[0:2] | join(".")' $OVERLAY_PATH/release.in.yaml) && \
+    export CHANNEL_VERSION && \
+    yq -i '.annotations["operators.operatorframework.io.bundle.channels.v1"] = "stable," + strenv(CHANNEL_VERSION)' $METADATA_PATH/annotations.yaml && \
+    yq -i '.annotations["operators.operatorframework.io.bundle.channel.default.v1"] = "stable"' $METADATA_PATH/annotations.yaml
 
 # From here downwards this should mostly match the non-konflux bundle, i.e., `bundle.Dockerfile`
 # However there are a few exceptions:
@@ -38,7 +48,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=lifecycle-agent
 LABEL operators.operatorframework.io.bundle.channels.v1=stable,4.17
-LABEL operators.operatorframework.io.bundle.channels.default.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
@@ -49,5 +59,5 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Copy files to locations specified by labels.
 COPY --from=overlay /tmp/manifests /manifests/
-COPY bundle/metadata /metadata/
+COPY --from=overlay /tmp/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/


### PR DESCRIPTION
Backport of OCPBUGS-76416 (main), OCPBUGS-76424 (release-4.21), OCPBUGS-76425 (release-4.20), OCPBUGS-76426 (release-4.19), OCPBUGS-76427 (release-4.18)

The annotations should match the values used in the labels
- Fix default channel label
- Explicitly set available channels in annotations.yaml to match label