### PR TITLE
docs: fix outdated Go version prerequisite in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- go >=1.18
+- go >=1.24
 - Spoke SNO cluster with pull-secret containing credentials to quay.io/${MY_REPO_ID}/
 
 ## Makefile targets


### PR DESCRIPTION
## Summary
- Update the Go version prerequisite in HACKING.md from `>=1.18` to `>=1.24` to match the `go.mod` requirement of Go 1.24.6

## Test plan
- [x] Verify HACKING.md shows the correct Go version prerequisite