### PR TITLE
docs: fix typo in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -162,7 +162,7 @@ skopeo copy docker://quay.io/edge-infrastructure/recert docker://${LOCAL_REGISTR
 
 ## Setup dev backup steps
 
-### minio + oadp oprator
+### minio + oadp operator
 
 Consider using podman if you have a HV
 


### PR DESCRIPTION
## Summary
- Fix typo in HACKING.md: `"oadp oprator"` -> `"oadp operator"`

## Test plan
- [ ] Verify the section heading is spelled correctly