### PR TITLE
chore: gitignore stale golangci-lint config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ __debug_bin
 
 # tmp directory
 tmp
+
+# Stale golangci-lint config files (active config is .golangci.yml)
+.golangci-test.yml
+.golangci-v1.bck.yml
+.golangci-v1.yml
+.golangci.yml.test


### PR DESCRIPTION
## Summary
- Add `.golangci-test.yml`, `.golangci-v1.bck.yml`, `.golangci-v1.yml`, and `.golangci.yml.test` to `.gitignore`
- These are leftover files from config migration/testing that are not tracked but clutter `git status`
- The active config is `.golangci.yml`

## Test plan
- [ ] Verify `git status` no longer shows the stale config files as untracked