### PR TITLE
CNF-23135: Upstream catalog-template update — Lifecycle Agent 4.19.3

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-19@sha256:7002a8ceac62cf263ef8e688b4001e119d7db8aa5c1b94753e39843a70878b37
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-19@sha256:884347d8732cb404d6f0f9b1f75497166a48fb03905d810b61ca326f948da08a

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -24,6 +24,10 @@ entries:
       - name: lifecycle-agent.v4.19.3
         replaces: 'lifecycle-agent.v4.19.2'
         skipRange: '>=4.18.0 <4.19.3'
+      # v4.19.4
+      - name: lifecycle-agent.v4.19.4
+        replaces: lifecycle-agent.v4.19.3
+        skipRange: '>=4.18.0 <4.19.4'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -44,6 +48,10 @@ entries:
       - name: lifecycle-agent.v4.19.3
         replaces: 'lifecycle-agent.v4.19.2'
         skipRange: '>=4.18.0 <4.19.3'
+      # v4.19.4
+      - name: lifecycle-agent.v4.19.4
+        replaces: lifecycle-agent.v4.19.3
+        skipRange: '>=4.18.0 <4.19.4'
     name: "4.19"
     package: lifecycle-agent
     schema: olm.channel
@@ -57,6 +65,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:08fad0dc3e3a90306562d8bccc3c1e16ff0bb2a26624e4189bf3358a6a6f81cd
     schema: olm.bundle
   # v4.19.3 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:7abb5108b6a730fbb0605618081ca4f8cc9f371451476dbf132fa74833f6eca5
+    schema: olm.bundle
+  # v4.19.4 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.19.3 → 4.19.4.

Generated by release-automator-konflux.