### PR TITLE
CNF-23147: Upstream catalog-template update — Lifecycle Agent 4.20.3

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:6451d567f072767a9c37fda39ff1d547ed4e6b9c26b7587dce2821eee945a6fa
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:2caea882eb2647a12cbc82895539ee2e9bc302c021cf8a6a9081376c30a7da73

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:4a6da163f6b6c4fa921ed2df3d175e6ad809c4def3b38bfc2be0b734bf30a1c0
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:6451d567f072767a9c37fda39ff1d547ed4e6b9c26b7587dce2821eee945a6fa

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -25,6 +25,10 @@ entries:
       - name: lifecycle-agent.v4.20.3
         replaces: 'lifecycle-agent.v4.20.2'
         skipRange: '>=4.18.0 <4.20.3'
+      # v4.20.4
+      - name: lifecycle-agent.v4.20.4
+        replaces: lifecycle-agent.v4.20.3
+        skipRange: '>=4.18.0 <4.20.4'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -45,6 +49,10 @@ entries:
       - name: lifecycle-agent.v4.20.3
         replaces: 'lifecycle-agent.v4.20.2'
         skipRange: '>=4.18.0 <4.20.3'
+      # v4.20.4
+      - name: lifecycle-agent.v4.20.4
+        replaces: lifecycle-agent.v4.20.3
+        skipRange: '>=4.18.0 <4.20.4'
     name: "4.20"
     package: lifecycle-agent
     schema: olm.channel
@@ -58,6 +66,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:e09c08b220307adf59f0a321ef5246f533fe4202a116b401af857e4dda5a3263
     schema: olm.bundle
   # v4.20.3 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:9e5d547584e0e2219e664fe6c0a2cb78f39e7180670b6ae7c2cbdbe4030a6708
+    schema: olm.bundle
+  # v4.20.4 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.20.3 → 4.20.4.

Generated by release-automator-konflux.