### PR TITLE
CNF-23207: Add GitHub Actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,8 @@ updates:
     package-ecosystem: "gomod"  # See documentation for possible values
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
 version: 2


### PR DESCRIPTION
## Summary

- Add `github-actions` package ecosystem to Dependabot config with weekly schedule
- Enables automatic version-bump PRs for any GitHub Actions used in workflows

Jira: [CNF-23207](https://issues.redhat.com/browse/CNF-23207)

## Related PRs

| Repo | PR | Status |
|------|-----|--------|
| redhat-best-practices-for-k8s/oct | [#35](https://github.com/redhat-best-practices-for-k8s/oct/pull/35) | merged |
| redhat-best-practices-for-k8s/privileged-daemonset | [#55](https://github.com/redhat-best-practices-for-k8s/privileged-daemonset/pull/55) | merged |
| redhat-best-practices-for-k8s/l2discovery | [#36](https://github.com/redhat-best-practices-for-k8s/l2discovery/pull/36) | merged |

## Test plan

- [x] YAML is valid Dependabot v2 config