### PR TITLE
CNF-23236: Upstream release-config version bump — Lifecycle Agent 4.21.2

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -9,9 +9,9 @@ variables:
 
       You can find additional guidance in the upstream repository: https://github.com/openshift-kni/lifecycle-agent
   display_name: "Lifecycle Agent"
-  manager_version: "lifecycle-agent.v4.21.2"
+  manager_version: "lifecycle-agent.v4.21.3"
   # min_kube_version should match ocp
   # https://access.redhat.com/solutions/4870701
   min_kube_version: "1.34.0"
   recert_image: PLACEHOLDER_RECERT_IMAGE
-  version: "4.21.2"
+  version: "4.21.3"


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.21.2 → 4.21.3.

Generated by release-automator-konflux.