### PR TITLE
CNF-23236: Upstream catalog-template update — Lifecycle Agent 4.21.2

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-21@sha256:03a0d7a9cc2e7feb5a95f139ab1835183bff0686521e9c6d7b04e2bad6a48a23
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-21@sha256:3f73e33c3829f5a3f87ec9f1cb9e79be1421e625663850b0eea462106393af39

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -21,6 +21,10 @@ entries:
       - name: lifecycle-agent.v4.21.2
         replaces: lifecycle-agent.v4.21.1
         skipRange: '>=4.20.0 <4.21.2'
+      # v4.21.3
+      - name: lifecycle-agent.v4.21.3
+        replaces: lifecycle-agent.v4.21.2
+        skipRange: '>=4.20.0 <4.21.3'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -37,6 +41,10 @@ entries:
       - name: lifecycle-agent.v4.21.2
         replaces: lifecycle-agent.v4.21.1
         skipRange: '>=4.20.0 <4.21.2'
+      # v4.21.3
+      - name: lifecycle-agent.v4.21.3
+        replaces: lifecycle-agent.v4.21.2
+        skipRange: '>=4.20.0 <4.21.3'
     name: "4.21"
     package: lifecycle-agent
     schema: olm.channel
@@ -47,6 +55,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:1614516bd2eeb674590f52ac3e90399bb4ba802df02ba374e5bcb69e5a00ac35
     schema: olm.bundle
   # v4.21.2 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:61d47ada8de83f1c3cf34c86dfcfb3ce55b91c436502946a513ae5af2f6e0378
+    schema: olm.bundle
+  # v4.21.3 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.21.2 → 4.21.3.

Generated by release-automator-konflux.