### PR TITLE
CNF-11589: Embed commit SHA and version info into LCA binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ FROM ${BUILDER_IMAGE} as builder
 
 # Default Konflux to false
 ARG KONFLUX="false"
+ARG GIT_COMMIT="unknown"
+ARG VERSION="unknown"
+ARG BUILD_TIME="unknown"
 
 # Explicitly set the working directory
 WORKDIR /opt/app-root
@@ -26,17 +29,19 @@ COPY lca-cli lca-cli
 COPY internal internal
 COPY main main
 COPY utils utils
+COPY version version
 
 # For Konflux, compile with FIPS enabled
 # Otherwise compile normally
-RUN if [[ "${KONFLUX}" == "true" ]]; then \
+RUN LDFLAGS="-X github.com/openshift-kni/lifecycle-agent/version.Version=${VERSION} -X github.com/openshift-kni/lifecycle-agent/version.GitCommit=${GIT_COMMIT} -X github.com/openshift-kni/lifecycle-agent/version.BuildTime=${BUILD_TIME}" && \
+    if [[ "${KONFLUX}" == "true" ]]; then \
         echo "Compiling with fips" && \
-        GOEXPERIMENT=strictfipsruntime CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -mod=vendor -tags strictfipsruntime -o build/manager main/main.go && \
-        GOEXPERIMENT=strictfipsruntime CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -mod=vendor -tags strictfipsruntime -a -o build/lca-cli main/lca-cli/main.go; \
+        GOEXPERIMENT=strictfipsruntime CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -mod=vendor -tags strictfipsruntime -ldflags "${LDFLAGS}" -o build/manager main/main.go && \
+        GOEXPERIMENT=strictfipsruntime CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -mod=vendor -tags strictfipsruntime -ldflags "${LDFLAGS}" -a -o build/lca-cli main/lca-cli/main.go; \
     else \
         echo "Compiling without fips" && \
-        CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -mod=vendor -a -o build/manager main/main.go && \
-        CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -mod=vendor -a -o build/lca-cli main/lca-cli/main.go; \
+        CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -mod=vendor -ldflags "${LDFLAGS}" -a -o build/manager main/main.go && \
+        CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -mod=vendor -ldflags "${LDFLAGS}" -a -o build/lca-cli main/lca-cli/main.go; \
     fi
 
 #####################################################################################################

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ YQ_VERSION ?= v4.45.4
 # You can use podman or docker as a container engine. Notice that there are some options that might be only valid for one of them.
 ENGINE ?= docker
 
+# Version injection via ldflags
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS = -X github.com/openshift-kni/lifecycle-agent/version.Version=$(VERSION) \
+          -X github.com/openshift-kni/lifecycle-agent/version.GitCommit=$(GIT_COMMIT) \
+          -X github.com/openshift-kni/lifecycle-agent/version.BuildTime=$(BUILD_TIME)
+
 # The registry auth file is mounted into the container to allow for private registry pulls.
 # This is automatically detected and mounted into the container if it exists on the host.
 # If it does not exist, a warning is printed and the registry pulls may fail if not public.
@@ -240,7 +247,7 @@ mock-gen: sync-git-submodules $(LOCALBIN) ## Download mockgen locally if necessa
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main/main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/manager main/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	PRECACHE_WORKLOAD_IMG=${IMG} go run ./main/main.go
@@ -249,7 +256,11 @@ debug: manifests generate fmt vet ## Run a controller from your host that accept
 	PRECACHE_WORKLOAD_IMG=${IMG} dlv debug --headless --listen 127.0.0.1:2345 --api-version 2 --accept-multiclient ./main.go
 
 docker-build: ## Build container image with the manager.
-	${ENGINE} build --platform=linux/${GOARCH} -t ${IMG} -f Dockerfile .
+	${ENGINE} build --platform=linux/${GOARCH} \
+		--build-arg VERSION="$(VERSION)" \
+		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+		--build-arg BUILD_TIME="$(BUILD_TIME)" \
+		-t ${IMG} -f Dockerfile .
 
 docker-push: docker-build ## Push container image with the manager.
 	${ENGINE} push ${IMG}
@@ -337,7 +348,7 @@ cli-run: common-deps-update fmt vet ## Run the lca-cli tool from your host.
 	go run main/lca-cli/main.go
 
 cli-build: common-deps-update fmt vet ## Build the lca-cli tool from your host.
-	go build -o bin/lca-cli main/lca-cli/main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/lca-cli main/lca-cli/main.go
 
 # Unittests variables
 TEST_FORMAT ?= standard-verbose

--- a/lca-cli/cmd/root.go
+++ b/lca-cli/cmd/root.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/openshift-kni/lifecycle-agent/internal/common"
 	ipconfigcmd "github.com/openshift-kni/lifecycle-agent/lca-cli/cmd/ipconfig"
+	"github.com/openshift-kni/lifecycle-agent/version"
 )
 
 // Create logger
@@ -38,9 +39,6 @@ var verbose bool
 
 // noColor is the optional flag for controlling ANSI sequence output
 var noColor bool
-
-// version is an optional command that will display the current release version
-var releaseVersion string
 
 func addCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&authFile, "authfile", "a", common.ImageRegistryAuthFile, "The path to the authentication file of the container registry.")
@@ -64,7 +62,7 @@ func init() {
 var (
 	rootCmd = &cobra.Command{
 		Use:     "lca-cli",
-		Version: releaseVersion,
+		Version: version.String(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if verbose {
 				log.SetLevel(logrus.DebugLevel)

--- a/main/main.go
+++ b/main/main.go
@@ -74,6 +74,7 @@ import (
 	"github.com/openshift-kni/lifecycle-agent/lca-cli/ops"
 	rpmostreeclient "github.com/openshift-kni/lifecycle-agent/lca-cli/ostreeclient"
 	lcautils "github.com/openshift-kni/lifecycle-agent/utils"
+	"github.com/openshift-kni/lifecycle-agent/version"
 	utiltls "github.com/openshift/controller-runtime-common/pkg/tls"
 	"github.com/openshift/library-go/pkg/config/leaderelection"
 	"github.com/sirupsen/logrus"
@@ -136,6 +137,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("Starting Lifecycle Agent", "version", version.String())
 
 	scheme.AddKnownTypes(ocpv1.GroupVersion,
 		&ocpv1.ClusterVersion{},

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import "fmt"
+
+var (
+	Version   = "unknown"
+	GitCommit = "unknown"
+	BuildTime = "unknown"
+)
+
+func String() string {
+	return fmt.Sprintf("%s (commit: %s, built: %s)", Version, GitCommit, BuildTime)
+}


### PR DESCRIPTION
**Jira**: [CNF-11589](https://issues.redhat.com/browse/CNF-11589)

## Summary

- Add `version/` package with `Version`, `GitCommit`, and `BuildTime` variables injected via `-ldflags` at build time
- Update Makefile `build`, `cli-build`, `run`, `cli-run`, and `docker-build` targets to pass `-ldflags` with version info
- Update `Dockerfile` to forward `VERSION`, `GIT_COMMIT`, and `BUILD_TIME` as build args into all `go build` commands
- Wire `lca-cli --version` to print version string (replaces unused `releaseVersion` variable)
- Log version info at `manager` startup

Example output:
```
$ lca-cli --version
lca-cli version 5.0.0 (commit: d7d630512, built: 2026-04-30T20:12:56Z)
```

## Test plan

- [x] `make build` -- manager binary compiles with ldflags
- [x] `make cli-build` -- lca-cli binary compiles with ldflags
- [x] `bin/lca-cli --version` -- prints version, commit SHA, and build time
- [x] `make golangci-lint` -- 0 issues
- [x] `make unittest` -- 0 failures
