### PR TITLE
CNF-23470: Upstream catalog-template update — Lifecycle Agent 4.20.4

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:7d0ed64893da47478b2bd63490492a0ead81a9715ebc0d82a493fd085d47b4a4
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:5d118f4270c64772eb2476106c3f940e7b831627704ae31b1588bef67b76823d

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -29,6 +29,10 @@ entries:
       - name: lifecycle-agent.v4.20.4
         replaces: lifecycle-agent.v4.20.3
         skipRange: '>=4.18.0 <4.20.4'
+      # v4.20.5
+      - name: lifecycle-agent.v4.20.5
+        replaces: lifecycle-agent.v4.20.4
+        skipRange: '>=4.18.0 <4.20.5'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -53,6 +57,10 @@ entries:
       - name: lifecycle-agent.v4.20.4
         replaces: lifecycle-agent.v4.20.3
         skipRange: '>=4.18.0 <4.20.4'
+      # v4.20.5
+      - name: lifecycle-agent.v4.20.5
+        replaces: lifecycle-agent.v4.20.4
+        skipRange: '>=4.18.0 <4.20.5'
     name: "4.20"
     package: lifecycle-agent
     schema: olm.channel
@@ -69,6 +77,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:9e5d547584e0e2219e664fe6c0a2cb78f39e7180670b6ae7c2cbdbe4030a6708
     schema: olm.bundle
   # v4.20.4 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:f05879638caeb3ca2e064bfa3a7c46d6cecf64e322c8c304806190c24eabba12
+    schema: olm.bundle
+  # v4.20.5 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.20.4 → 4.20.5.

Generated by release-automator-konflux.