### PR TITLE
CNF-23184: Upstream catalog-template update — Lifecycle Agent 4.16.6

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-16@sha256:9992a49e96647f1db8e31bb2e90ba168cb4f8924db6ca468ac4457598c34cc8d
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-16@sha256:58d5cb9a3e378f0dc491cead204f3a089cc80e6d4a90d6f1408098ab9b3ecc1c

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -36,6 +36,10 @@ entries:
       - name: lifecycle-agent.v4.16.6
         replaces: lifecycle-agent.v4.16.5
         skipRange: '>=4.14.0 <4.16.6'
+      # v4.16.7
+      - name: lifecycle-agent.v4.16.7
+        replaces: lifecycle-agent.v4.16.6
+        skipRange: '>=4.14.0 <4.16.7'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -68,6 +72,10 @@ entries:
       - name: lifecycle-agent.v4.16.6
         replaces: lifecycle-agent.v4.16.5
         skipRange: '>=4.14.0 <4.16.6'
+      # v4.16.7
+      - name: lifecycle-agent.v4.16.7
+        replaces: lifecycle-agent.v4.16.6
+        skipRange: '>=4.14.0 <4.16.7'
     name: "4.16"
     package: lifecycle-agent
     schema: olm.channel
@@ -90,6 +98,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:48c9b13cffff3eb88e23ee01deba237d334024362cf6daae4a7b840904ce8b65
     schema: olm.bundle
   # v4.16.6 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:593146284f98f9daf051b5d18953e618788b95982e9be72ffdc96f0831b19545
+    schema: olm.bundle
+  # v4.16.7 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.16.6 → 4.16.7.

Generated by release-automator-konflux.