### PR TITLE
[release-4.21] feat: preserve cert-manager TLS certificates during image-based upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tmp
 
 # CLAUDE.md
 CLAUDE.md
+
+# Demo dependencies
+.cert-manager-scripts

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -152,6 +152,6 @@ linters-settings:
       - .WrapPrefixf(
 run:
   concurrency: 6
-  deadline: 5m
+  timeout: 10m
   skip-files:
     - ".*_test\\.go"

--- a/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
+++ b/bundle/manifests/lifecycle-agent.clusterserviceversion.yaml
@@ -415,6 +415,14 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - certificates.k8s.io
           resources:
           - certificatesigningrequests

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -114,6 +114,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - certificates.k8s.io
   resources:
   - certificatesigningrequests

--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -199,7 +199,7 @@ func (u *UpgHandler) PrePivot(ctx context.Context, ibu *ibuv1.ImageBasedUpgrade)
 		return requeueWithError(fmt.Errorf("error while exporting manifests: %w", err))
 	}
 
-	utils.SetUpgradeStatusInProgress(ibu, "Exporting Cluster and LVM configuration")
+	utils.SetUpgradeStatusInProgress(ibu, "Exporting Cluster, LVM, and cert-manager configuration")
 	if updateErr := utils.UpdateIBUStatus(ctx, u.Client, ibu); updateErr != nil {
 		u.Log.Error(updateErr, "failed to update IBU CR status")
 	}
@@ -213,6 +213,14 @@ func (u *UpgHandler) PrePivot(ctx context.Context, ibu *ibuv1.ImageBasedUpgrade)
 	if err := u.ClusterConfig.FetchLvmConfig(ctx, staterootVarPath); err != nil {
 		return requeueWithError(fmt.Errorf("error while fetching LVM configuration: %w", err))
 	}
+
+	u.Log.Info("Preserving cert-manager configuration into new stateroot")
+	if err := u.ClusterConfig.PreserveCertManagerConfig(ctx, staterootVarPath); err != nil {
+		return requeueWithError(fmt.Errorf("error while preserving cert-manager configuration: %w", err))
+	}
+
+	// Log all manifest files before pivot for debugging
+	u.logManifestFiles(staterootVarPath)
 
 	// Clear any error status that may have been previously set
 	u.resetProgressMessage(ctx, ibu)
@@ -566,4 +574,24 @@ func (u *UpgHandler) HandleRestore(ctx context.Context) (ctrl.Result, error) {
 	u.Log.Info("OADP path removed", "path", backuprestore.OadpPath)
 
 	return doNotRequeue(), nil
+}
+
+// logManifestFiles lists all files in the manifests directory before pivot for debugging.
+func (u *UpgHandler) logManifestFiles(staterootVarPath string) {
+	manifestsDir := filepath.Join(staterootVarPath, common.OptOpenshift, common.ClusterConfigDir, clusterconfig.ManifestDir)
+	entries, err := os.ReadDir(manifestsDir)
+	if err != nil {
+		u.Log.Error(err, "Pre-pivot: failed to read manifests directory", "dir", manifestsDir)
+		return
+	}
+	for _, entry := range entries {
+		info, _ := entry.Info()
+		size := int64(0)
+		if info != nil {
+			size = info.Size()
+		}
+		u.Log.Info("Pre-pivot manifest file", "file", entry.Name(), "size", size)
+	}
+	u.Log.Info("Pre-pivot manifests directory listing complete",
+		"dir", manifestsDir, "totalFiles", len(entries))
 }

--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -353,6 +353,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 		extractAndExportManifestFromPoliciesToDirReturn func() error
 		fetchClusterConfigReturn                        func() error
 		fetchLvmConfigReturn                            func() error
+		fetchCertManagerConfigReturn                    func() error
 		exportIBUCRNew                                  bool
 		exportIBUCROrig                                 bool
 		rebootToNewStateRootReturn                      func() error
@@ -680,7 +681,7 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 					Type:    string(utils.ConditionTypes.UpgradeInProgress),
 					Reason:  string(utils.ConditionReasons.InProgress),
 					Status:  metav1.ConditionTrue,
-					Message: "Exporting Cluster and LVM configuration",
+					Message: "Exporting Cluster, LVM, and cert-manager configuration",
 				},
 			},
 		},
@@ -715,6 +716,9 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 				return nil
 			},
 			fetchLvmConfigReturn: func() error {
+				return nil
+			},
+			fetchCertManagerConfigReturn: func() error {
 				return nil
 			},
 			exportIBUCRNew:  true,
@@ -777,6 +781,9 @@ func TestImageBasedUpgradeReconciler_prePivot(t *testing.T) {
 			}
 			if tt.fetchLvmConfigReturn != nil {
 				mockClusterconfig.EXPECT().FetchLvmConfig(gomock.Any(), gomock.Any()).Return(tt.fetchLvmConfigReturn()).Times(1)
+			}
+			if tt.fetchCertManagerConfigReturn != nil {
+				mockClusterconfig.EXPECT().PreserveCertManagerConfig(gomock.Any(), gomock.Any()).Return(tt.fetchCertManagerConfigReturn()).Times(1)
 			}
 
 			oldHC := CheckHealth

--- a/internal/clusterconfig/certmanagerconfig.go
+++ b/internal/clusterconfig/certmanagerconfig.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterconfig
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	"github.com/openshift-kni/lifecycle-agent/utils"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch
+
+const certManagerCRDName = "certificates.cert-manager.io"
+
+// PreserveCertManagerConfig exports cert-manager TLS Secrets to the new stateroot so they
+// are restored post-pivot via applyManifests. Exported resources:
+//
+//   - Namespaces (01_ prefix) — for non-standard namespaces containing cert-manager resources
+//   - TLS Secrets (03_ prefix) — paired with Certificate CRs
+//
+// Certificate CRs, ClusterIssuers, and Issuers are NOT exported because the
+// cert-manager validating webhook is not yet running when applyManifests executes
+// post-pivot, and any attempt to apply cert-manager custom resources would fail.
+// Recert handles Certificate CR hostname/IP updates via cn_san_replace_rules.
+//
+// The private keys from TLS Secrets are also written to the certmanager-crypto
+// directory and used as recert use_key rules to preserve cert-manager key material
+// through recert's re-keying process (only for certificates with a CommonName).
+func (r *UpgradeClusterConfigGather) PreserveCertManagerConfig(ctx context.Context, ostreeDir string) error {
+	r.Log.Info("Preserving cert-manager configuration", "ostreeDir", ostreeDir)
+
+	// Check if cert-manager is installed by looking for the Certificate CRD
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: certManagerCRDName}, crd); err != nil {
+		if k8serrors.IsNotFound(err) {
+			r.Log.Info("cert-manager CRD not found, skipping cert-manager configuration export",
+				"crdName", certManagerCRDName)
+			return nil
+		}
+		return fmt.Errorf("failed to get cert-manager CRD: %w", err)
+	}
+	r.Log.Info("cert-manager CRD found", "crdName", certManagerCRDName,
+		"crdUID", crd.GetUID(), "versions", len(crd.Spec.Versions))
+
+	manifestsDir := filepath.Join(ostreeDir, common.OptOpenshift, common.ClusterConfigDir, ManifestDir)
+
+	// Ensure the manifests directory exists (defensive — FetchClusterConfig should have created it)
+	if err := os.MkdirAll(manifestsDir, 0o700); err != nil {
+		return fmt.Errorf("failed to create manifests dir %s: %w", manifestsDir, err)
+	}
+
+	secretRefs, err := collectCertManagerSecretRefs(ctx, r.Log, r.Client)
+	if err != nil {
+		return fmt.Errorf("failed to collect cert-manager secret refs: %w", err)
+	}
+
+	secrets, err := fetchCertManagerSecrets(ctx, r.Log, r.Client, secretRefs)
+	if err != nil {
+		return fmt.Errorf("failed to fetch cert-manager secrets: %w", err)
+	}
+
+	if err := writeCertManagerCrypto(r.Log, ostreeDir, secrets); err != nil {
+		return fmt.Errorf("failed to write cert-manager crypto for recert: %w", err)
+	}
+
+	namespacesWritten, err := exportCertManagerNamespaces(r.Log, manifestsDir, secrets)
+	if err != nil {
+		return fmt.Errorf("failed to export cert-manager namespaces: %w", err)
+	}
+
+	secretsWritten, err := exportCertManagerSecrets(r.Log, manifestsDir, secrets)
+	if err != nil {
+		return fmt.Errorf("failed to export cert-manager secrets: %w", err)
+	}
+
+	r.Log.Info("Successfully preserved cert-manager configuration",
+		"namespaces", namespacesWritten,
+		"secrets", secretsWritten,
+		"totalFilesWritten", namespacesWritten+secretsWritten)
+	return nil
+}
+
+// collectCertManagerSecretRefs lists cert-manager Certificate CRs and returns the
+// set of Secret references (namespace/name) they point to, deduplicated.
+func collectCertManagerSecretRefs(
+	ctx context.Context, log logr.Logger, reader client.Reader,
+) (map[types.NamespacedName]bool, error) {
+	log.Info("Listing cert-manager Certificates")
+	certList := &unstructured.UnstructuredList{}
+	certList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cert-manager.io",
+		Kind:    "CertificateList",
+		Version: "v1",
+	})
+	if err := reader.List(ctx, certList); err != nil {
+		return nil, fmt.Errorf("failed to list Certificates: %w", err)
+	}
+	log.Info("Listed cert-manager Certificates", "count", len(certList.Items))
+
+	secretRefs := make(map[types.NamespacedName]bool)
+	for i := range certList.Items {
+		cert := &certList.Items[i]
+		log.Info("Processing Certificate", "name", cert.GetName(), "namespace", cert.GetNamespace())
+		spec, ok := cert.Object["spec"].(map[string]any)
+		if ok {
+			if secretName, exists := spec["secretName"].(string); exists && secretName != "" {
+				log.Info("Certificate references Secret",
+					"certificate", cert.GetName(), "secretName", secretName, "namespace", cert.GetNamespace())
+				secretRefs[types.NamespacedName{
+					Name:      secretName,
+					Namespace: cert.GetNamespace(),
+				}] = true
+			}
+		}
+	}
+	log.Info("Collected secret references from Certificates", "secretRefCount", len(secretRefs))
+	return secretRefs, nil
+}
+
+// fetchCertManagerSecrets fetches each referenced Secret from the API server,
+// skipping any that are not found.
+func fetchCertManagerSecrets(
+	ctx context.Context, log logr.Logger, reader client.Reader,
+	secretRefs map[types.NamespacedName]bool,
+) (map[types.NamespacedName]*unstructured.Unstructured, error) {
+	secrets := make(map[types.NamespacedName]*unstructured.Unstructured, len(secretRefs))
+	for ref := range secretRefs {
+		secret := &unstructured.Unstructured{}
+		secret.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "",
+			Kind:    "Secret",
+			Version: "v1",
+		})
+		if err := reader.Get(ctx, ref, secret); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.Info("Secret referenced by Certificate not found, skipping",
+					"secret", ref.Name, "namespace", ref.Namespace)
+				continue
+			}
+			return nil, fmt.Errorf("failed to get Secret %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+		secrets[ref] = secret
+	}
+	return secrets, nil
+}
+
+// writeCertManagerCrypto extracts private keys from cert-manager TLS Secrets and writes
+// them to the certmanager-crypto directory. These files are used as recert use_key rules
+// to preserve cert-manager key material through recert's re-keying. The CN is extracted
+// from the paired certificate and encoded in the filename for use_key rule construction.
+func writeCertManagerCrypto(
+	log logr.Logger, ostreeDir string, secrets map[types.NamespacedName]*unstructured.Unstructured,
+) error {
+	if len(secrets) == 0 {
+		return nil
+	}
+
+	cryptoDir := filepath.Join(ostreeDir, common.OptOpenshift, common.ClusterConfigDir, common.CertManagerCryptoDir)
+	if err := os.MkdirAll(cryptoDir, 0o700); err != nil {
+		return fmt.Errorf("failed to create certmanager crypto dir %s: %w", cryptoDir, err)
+	}
+
+	for ref, secret := range secrets {
+		data, ok := secret.Object["data"].(map[string]any)
+		if !ok {
+			log.Info("Secret has no data field, skipping crypto extraction",
+				"secret", ref.Name, "namespace", ref.Namespace)
+			continue
+		}
+
+		// Extract CN from the certificate — recert use_key rules require a CN for matching.
+		tlsCrt, crtOk := data["tls.crt"].(string)
+		if !crtOk {
+			log.Info("Secret has no tls.crt field, skipping crypto extraction",
+				"secret", ref.Name, "namespace", ref.Namespace)
+			continue
+		}
+		decodedCrt, err := base64.StdEncoding.DecodeString(tlsCrt)
+		if err != nil {
+			return fmt.Errorf("failed to decode tls.crt for %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+		block, _ := pem.Decode(decodedCrt)
+		if block == nil {
+			log.Info("Could not decode PEM block from tls.crt, skipping crypto extraction",
+				"secret", ref.Name, "namespace", ref.Namespace)
+			continue
+		}
+		parsedCert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			log.Info("Could not parse X.509 certificate, skipping crypto extraction",
+				"secret", ref.Name, "namespace", ref.Namespace, "error", err)
+			continue
+		}
+		if parsedCert.Subject.CommonName == "" {
+			log.Info("Certificate has no CN, skipping recert use_key rule (will be restored via manifest)",
+				"secret", ref.Name, "namespace", ref.Namespace)
+			continue
+		}
+
+		// Write the private key as a PEM file for recert use_key rules.
+		// The CN is encoded in the filename so appendCertManagerCryptoRules can
+		// reconstruct the "CN path/to/key" format that recert expects.
+		tlsKey, keyOk := data["tls.key"].(string)
+		if !keyOk {
+			log.Info("Secret has no tls.key field, skipping crypto extraction",
+				"secret", ref.Name, "namespace", ref.Namespace)
+			continue
+		}
+		decodedKey, err := base64.StdEncoding.DecodeString(tlsKey)
+		if err != nil {
+			return fmt.Errorf("failed to decode tls.key for %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+
+		// Filename format: "CN=<cn>__<namespace>_<name>.key"
+		// The CN= prefix and __ separator allow appendCertManagerCryptoRules to parse the CN.
+		keyFile := filepath.Join(cryptoDir, fmt.Sprintf("CN=%s__%s_%s.key",
+			parsedCert.Subject.CommonName, ref.Namespace, ref.Name))
+		if err := os.WriteFile(keyFile, decodedKey, 0o600); err != nil {
+			return fmt.Errorf("failed to write key file %s: %w", keyFile, err)
+		}
+		log.Info("Wrote cert-manager TLS key for recert preservation",
+			"secret", ref.Name, "namespace", ref.Namespace, "path", keyFile,
+			"cn", parsedCert.Subject.CommonName)
+	}
+
+	log.Info("Wrote cert-manager crypto for recert preservation", "secretCount", len(secrets))
+	return nil
+}
+
+// exportCertManagerNamespaces writes Namespace manifests (01_ prefix) for non-standard
+// namespaces containing cert-manager resources. Well-known namespaces (openshift-*, kube-*,
+// default, openshift) are skipped as they already exist in the seed stateroot.
+func exportCertManagerNamespaces(
+	log logr.Logger, manifestsDir string, secrets map[types.NamespacedName]*unstructured.Unstructured,
+) (int, error) {
+	namespacesWritten := 0
+	exportedNamespaces := make(map[string]bool)
+	for ref := range secrets {
+		ns := ref.Namespace
+		if exportedNamespaces[ns] {
+			continue
+		}
+		exportedNamespaces[ns] = true
+
+		// Skip well-known namespaces that will already exist in the seed stateroot
+		if strings.HasPrefix(ns, "openshift-") || strings.HasPrefix(ns, "kube-") || ns == "default" || ns == "openshift" {
+			log.Info("Skipping well-known namespace for cert-manager resource", "namespace", ns)
+			continue
+		}
+
+		log.Info("Exporting Namespace for cert-manager resource", "namespace", ns)
+		nsObj := &unstructured.Unstructured{}
+		nsObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Kind: "Namespace", Version: "v1"})
+		nsObj.SetName(ns)
+		fileName := fmt.Sprintf("01_certmanager_Namespace_%s.json", ns)
+		filePath := filepath.Join(manifestsDir, fileName)
+		if err := utils.MarshalToFile(nsObj.Object, filePath); err != nil {
+			return 0, fmt.Errorf("failed to write Namespace manifest to %s: %w", filePath, err)
+		}
+		namespacesWritten++
+	}
+	log.Info("Exported cert-manager namespaces", "count", namespacesWritten)
+	return namespacesWritten, nil
+}
+
+// exportCertManagerSecrets cleans and writes TLS Secret manifests (03_ prefix)
+// so they are restored via applyManifests before cert-manager starts.
+func exportCertManagerSecrets(
+	log logr.Logger, manifestsDir string, secrets map[types.NamespacedName]*unstructured.Unstructured,
+) (int, error) {
+	secretsWritten := 0
+	for ref, secret := range secrets {
+		CleanResource(secret)
+		fileName := fmt.Sprintf("03_certmanager_Secret_%s_%s.json", ref.Name, ref.Namespace)
+		filePath := filepath.Join(manifestsDir, fileName)
+		log.Info("Writing cert-manager Secret to file", "path", filePath)
+		if err := utils.MarshalToFile(secret.Object, filePath); err != nil {
+			return 0, fmt.Errorf("failed to write Secret to %s: %w", filePath, err)
+		}
+		secretsWritten++
+	}
+	return secretsWritten, nil
+}
+
+// CleanResource removes transient metadata fields from an unstructured resource
+// so it can be cleanly re-applied post-pivot.
+func CleanResource(obj *unstructured.Unstructured) {
+	obj.SetUID("")
+	obj.SetResourceVersion("")
+	obj.SetManagedFields(nil)
+	obj.SetGeneration(0)
+	obj.SetOwnerReferences(nil)
+	delete(obj.Object, "status")
+
+	if metadata, ok := obj.Object["metadata"].(map[string]any); ok {
+		delete(metadata, "creationTimestamp")
+	}
+}

--- a/internal/clusterconfig/certmanagerconfig_test.go
+++ b/internal/clusterconfig/certmanagerconfig_test.go
@@ -1,0 +1,836 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterconfig
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	"github.com/stretchr/testify/assert"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	certManagerCRD = &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "certificates.cert-manager.io",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "Certificate",
+				ListKind: "CertificateList",
+			},
+		},
+	}
+
+	testCertificate1 = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]any{
+				"name":      "my-cert",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"secretName": "my-cert-tls",
+				"issuerRef": map[string]any{
+					"name": "letsencrypt-prod",
+					"kind": "ClusterIssuer",
+				},
+			},
+		},
+	}
+
+	testCertificate2 = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]any{
+				"name":      "other-cert",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"secretName": "my-cert-tls", // same secret as testCertificate1
+				"issuerRef": map[string]any{
+					"name": "ca-issuer",
+					"kind": "Issuer",
+				},
+			},
+		},
+	}
+
+	testTLSSecret = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "my-cert-tls",
+				"namespace": "default",
+			},
+			"type": "kubernetes.io/tls",
+			"data": map[string]any{
+				"tls.crt": "dGVzdC1jZXJ0",
+				"tls.key": "dGVzdC1rZXk=",
+			},
+		},
+	}
+
+	testCertificateCustomNS = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]any{
+				"name":      "custom-cert",
+				"namespace": "ibu-test-ns",
+			},
+			"spec": map[string]any{
+				"secretName": "custom-cert-tls",
+				"issuerRef": map[string]any{
+					"name": "selfsigned-issuer",
+					"kind": "ClusterIssuer",
+				},
+			},
+		},
+	}
+
+	testTLSSecretCustomNS = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "custom-cert-tls",
+				"namespace": "ibu-test-ns",
+			},
+			"type": "kubernetes.io/tls",
+			"data": map[string]any{
+				"tls.crt": "dGVzdC1jZXJ0",
+				"tls.key": "dGVzdC1rZXk=",
+			},
+		},
+	}
+
+	testClusterIssuerLetsencrypt = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "ClusterIssuer",
+			"metadata": map[string]any{
+				"name": "letsencrypt-prod",
+			},
+			"spec": map[string]any{
+				"acme": map[string]any{
+					"server": "https://acme-v02.api.letsencrypt.org/directory",
+				},
+			},
+		},
+	}
+
+	testClusterIssuerSelfsigned = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "ClusterIssuer",
+			"metadata": map[string]any{
+				"name": "selfsigned-issuer",
+			},
+			"spec": map[string]any{
+				"selfSigned": map[string]any{},
+			},
+		},
+	}
+
+	testIssuerCA = &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Issuer",
+			"metadata": map[string]any{
+				"name":      "ca-issuer",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"ca": map[string]any{
+					"secretName": "ca-key-pair",
+				},
+			},
+		},
+	}
+
+	// testCertB64 and testKeyB64 are populated by init() with a real self-signed certificate.
+	testCertB64 string
+	testKeyB64  string
+)
+
+func init() {
+	// Generate a self-signed certificate with CN so that writeCertManagerCrypto
+	// recognises it as valid for recert use_key rules.
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test.example.com"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		DNSNames:     []string{"test.example.com"},
+	}
+	certDER, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	testCertB64 = base64.StdEncoding.EncodeToString(certPEM)
+	testKeyB64 = base64.StdEncoding.EncodeToString(keyPEM)
+
+	testTLSSecret.Object["data"].(map[string]any)["tls.crt"] = testCertB64
+	testTLSSecret.Object["data"].(map[string]any)["tls.key"] = testKeyB64
+	testTLSSecretCustomNS.Object["data"].(map[string]any)["tls.crt"] = testCertB64
+	testTLSSecretCustomNS.Object["data"].(map[string]any)["tls.key"] = testKeyB64
+}
+
+// TestPreserveCertManagerConfig is the integration test that validates the full
+// orchestration flow end-to-end.
+func TestPreserveCertManagerConfig(t *testing.T) {
+	testcases := []struct {
+		name         string
+		objs         []client.Object
+		validateFunc func(t *testing.T, manifestsDir string)
+	}{
+		{
+			name: "cert-manager CRD not found",
+			objs: []client.Object{},
+			validateFunc: func(t *testing.T, manifestsDir string) {
+				manifests, err := os.ReadDir(manifestsDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				assert.Equal(t, 0, len(manifests))
+			},
+		},
+		{
+			name: "all resources present",
+			objs: []client.Object{certManagerCRD, testCertificate1, testTLSSecret, testClusterIssuerLetsencrypt},
+			validateFunc: func(t *testing.T, manifestsDir string) {
+				manifests, err := os.ReadDir(manifestsDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// Secret (03_) only — Certificate CRs not exported (webhook not ready post-pivot)
+				assert.Equal(t, 1, len(manifests))
+				assert.Contains(t, manifests[0].Name(), "03_certmanager_Secret")
+
+				// Verify cert-manager crypto files for recert use_key rules
+				cryptoDir := filepath.Join(filepath.Dir(manifestsDir), common.CertManagerCryptoDir)
+				cryptoFiles, err := os.ReadDir(cryptoDir)
+				assert.NoError(t, err)
+				assert.Equal(t, 1, len(cryptoFiles), "expected 1 .key file for the TLS Secret")
+				assert.Contains(t, cryptoFiles[0].Name(), "CN=test.example.com__default_my-cert-tls.key")
+
+				// Verify the key file contains valid PEM data
+				keyData, err := os.ReadFile(filepath.Join(cryptoDir, cryptoFiles[0].Name()))
+				assert.NoError(t, err)
+				assert.True(t, strings.HasPrefix(string(keyData), "-----BEGIN EC PRIVATE KEY-----"),
+					"key file should contain PEM-encoded private key")
+			},
+		},
+		{
+			name: "certificate but secret missing",
+			objs: []client.Object{certManagerCRD, testCertificate1, testClusterIssuerLetsencrypt},
+			validateFunc: func(t *testing.T, manifestsDir string) {
+				manifests, err := os.ReadDir(manifestsDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// No manifests — Secret not found and Certificate CRs not exported
+				assert.Equal(t, 0, len(manifests))
+			},
+		},
+		{
+			name: "CRD exists but no resources",
+			objs: []client.Object{certManagerCRD},
+			validateFunc: func(t *testing.T, manifestsDir string) {
+				manifests, err := os.ReadDir(manifestsDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				assert.Equal(t, 0, len(manifests))
+			},
+		},
+		{
+			name: "multiple certificates referencing same secret",
+			objs: []client.Object{certManagerCRD, testCertificate1, testCertificate2, testTLSSecret,
+				testClusterIssuerLetsencrypt, testIssuerCA},
+			validateFunc: func(t *testing.T, manifestsDir string) {
+				manifests, err := os.ReadDir(manifestsDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// Secret (03_, deduplicated) only — Certificate CRs not exported
+				assert.Equal(t, 1, len(manifests))
+				assert.Contains(t, manifests[0].Name(), "03_certmanager_Secret")
+			},
+		},
+		{
+			name: "custom namespace gets exported",
+			objs: []client.Object{certManagerCRD, testCertificateCustomNS, testTLSSecretCustomNS,
+				testClusterIssuerSelfsigned},
+			validateFunc: func(t *testing.T, manifestsDir string) {
+				manifests, err := os.ReadDir(manifestsDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// Namespace (01_) + Secret (03_) — Certificate CRs not exported
+				assert.Equal(t, 2, len(manifests))
+				assert.Contains(t, manifests[0].Name(), "01_certmanager_Namespace_ibu-test-ns")
+				assert.Contains(t, manifests[1].Name(), "03_certmanager_Secret")
+			},
+		},
+		{
+			name: "mixed namespaces: default skipped, custom exported",
+			objs: []client.Object{certManagerCRD, testCertificate1, testTLSSecret,
+				testCertificateCustomNS, testTLSSecretCustomNS,
+				testClusterIssuerLetsencrypt, testClusterIssuerSelfsigned},
+			validateFunc: func(t *testing.T, manifestsDir string) {
+				manifests, err := os.ReadDir(manifestsDir)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// 1 Namespace (ibu-test-ns) + 2 Secrets (default + ibu-test-ns)
+				// Certificate CRs not exported
+				assert.Equal(t, 3, len(manifests))
+				assert.Contains(t, manifests[0].Name(), "01_certmanager_Namespace_ibu-test-ns")
+				assert.Contains(t, manifests[1].Name(), "03_certmanager_Secret")
+				assert.Contains(t, manifests[2].Name(), "03_certmanager_Secret")
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			manifestsDir := filepath.Join(tmpDir, common.OptOpenshift, common.ClusterConfigDir, ManifestDir)
+
+			if err := os.MkdirAll(manifestsDir, 0o700); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			c := fake.NewClientBuilder().WithScheme(testscheme).WithObjects(tc.objs...).Build()
+			ucc := &UpgradeClusterConfigGather{
+				Client: c,
+				Log:    logr.Discard(),
+				Scheme: c.Scheme(),
+			}
+
+			err := ucc.PreserveCertManagerConfig(context.Background(), tmpDir)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			tc.validateFunc(t, manifestsDir)
+		})
+	}
+}
+
+func TestCollectCertManagerSecretRefs(t *testing.T) {
+	testcases := []struct {
+		name         string
+		objs         []client.Object
+		expectedRefs map[types.NamespacedName]bool
+	}{
+		{
+			name:         "no certificates",
+			objs:         []client.Object{certManagerCRD},
+			expectedRefs: map[types.NamespacedName]bool{},
+		},
+		{
+			name: "single certificate",
+			objs: []client.Object{certManagerCRD, testCertificate1},
+			expectedRefs: map[types.NamespacedName]bool{
+				{Name: "my-cert-tls", Namespace: "default"}: true,
+			},
+		},
+		{
+			name: "multiple certificates referencing same secret deduplicates",
+			objs: []client.Object{certManagerCRD, testCertificate1, testCertificate2},
+			expectedRefs: map[types.NamespacedName]bool{
+				{Name: "my-cert-tls", Namespace: "default"}: true,
+			},
+		},
+		{
+			name: "certificates in different namespaces",
+			objs: []client.Object{certManagerCRD, testCertificate1, testCertificateCustomNS},
+			expectedRefs: map[types.NamespacedName]bool{
+				{Name: "my-cert-tls", Namespace: "default"}:         true,
+				{Name: "custom-cert-tls", Namespace: "ibu-test-ns"}: true,
+			},
+		},
+		{
+			name: "certificate without secretName is skipped",
+			objs: []client.Object{certManagerCRD, &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "cert-manager.io/v1",
+					"kind":       "Certificate",
+					"metadata": map[string]any{
+						"name":      "no-secret-cert",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"issuerRef": map[string]any{
+							"name": "some-issuer",
+							"kind": "ClusterIssuer",
+						},
+					},
+				},
+			}},
+			expectedRefs: map[types.NamespacedName]bool{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(testscheme).WithObjects(tc.objs...).Build()
+			refs, err := collectCertManagerSecretRefs(context.Background(), logr.Discard(), c)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedRefs, refs)
+		})
+	}
+}
+
+func TestFetchCertManagerSecrets(t *testing.T) {
+	testcases := []struct {
+		name            string
+		objs            []client.Object
+		secretRefs      map[types.NamespacedName]bool
+		expectedSecrets int
+	}{
+		{
+			name:            "no refs",
+			objs:            []client.Object{},
+			secretRefs:      map[types.NamespacedName]bool{},
+			expectedSecrets: 0,
+		},
+		{
+			name: "secret exists",
+			objs: []client.Object{testTLSSecret},
+			secretRefs: map[types.NamespacedName]bool{
+				{Name: "my-cert-tls", Namespace: "default"}: true,
+			},
+			expectedSecrets: 1,
+		},
+		{
+			name: "secret not found is skipped",
+			objs: []client.Object{},
+			secretRefs: map[types.NamespacedName]bool{
+				{Name: "missing-secret", Namespace: "default"}: true,
+			},
+			expectedSecrets: 0,
+		},
+		{
+			name: "mix of found and missing secrets",
+			objs: []client.Object{testTLSSecret},
+			secretRefs: map[types.NamespacedName]bool{
+				{Name: "my-cert-tls", Namespace: "default"}:    true,
+				{Name: "missing-secret", Namespace: "default"}: true,
+			},
+			expectedSecrets: 1,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(testscheme).WithObjects(tc.objs...).Build()
+			secrets, err := fetchCertManagerSecrets(context.Background(), logr.Discard(), c, tc.secretRefs)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedSecrets, len(secrets))
+		})
+	}
+}
+
+func TestWriteCertManagerCrypto(t *testing.T) {
+	testcases := []struct {
+		name             string
+		secrets          map[types.NamespacedName]*unstructured.Unstructured
+		expectedKeyFiles int
+	}{
+		{
+			name:             "empty secrets",
+			secrets:          map[types.NamespacedName]*unstructured.Unstructured{},
+			expectedKeyFiles: 0,
+		},
+		{
+			name: "valid secret with CN writes key file",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "my-cert-tls", Namespace: "default"}: {
+					Object: map[string]any{
+						"data": map[string]any{
+							"tls.crt": testCertB64,
+							"tls.key": testKeyB64,
+						},
+					},
+				},
+			},
+			expectedKeyFiles: 1,
+		},
+		{
+			name: "secret without data field is skipped",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "no-data", Namespace: "default"}: {
+					Object: map[string]any{},
+				},
+			},
+			expectedKeyFiles: 0,
+		},
+		{
+			name: "secret without tls.crt is skipped",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "no-crt", Namespace: "default"}: {
+					Object: map[string]any{
+						"data": map[string]any{
+							"tls.key": testKeyB64,
+						},
+					},
+				},
+			},
+			expectedKeyFiles: 0,
+		},
+		{
+			name: "secret without tls.key is skipped",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "no-key", Namespace: "default"}: {
+					Object: map[string]any{
+						"data": map[string]any{
+							"tls.crt": testCertB64,
+						},
+					},
+				},
+			},
+			expectedKeyFiles: 0,
+		},
+		{
+			name: "certificate without CN is skipped",
+			secrets: func() map[types.NamespacedName]*unstructured.Unstructured {
+				// Generate a cert with no CN
+				key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				tmpl := &x509.Certificate{
+					SerialNumber: big.NewInt(2),
+					Subject:      pkix.Name{}, // no CN
+					NotBefore:    time.Now(),
+					NotAfter:     time.Now().Add(24 * time.Hour),
+					DNSNames:     []string{"nocn.example.com"},
+				}
+				certDER, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+				certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+				keyDER, _ := x509.MarshalECPrivateKey(key)
+				keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+				return map[types.NamespacedName]*unstructured.Unstructured{
+					{Name: "no-cn", Namespace: "default"}: {
+						Object: map[string]any{
+							"data": map[string]any{
+								"tls.crt": base64.StdEncoding.EncodeToString(certPEM),
+								"tls.key": base64.StdEncoding.EncodeToString(keyPEM),
+							},
+						},
+					},
+				}
+			}(),
+			expectedKeyFiles: 0,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			err := writeCertManagerCrypto(logr.Discard(), tmpDir, tc.secrets)
+			assert.NoError(t, err)
+
+			cryptoDir := filepath.Join(tmpDir, common.OptOpenshift, common.ClusterConfigDir, common.CertManagerCryptoDir)
+			if tc.expectedKeyFiles == 0 {
+				// Directory may or may not exist when no keys are written
+				entries, err := os.ReadDir(cryptoDir)
+				if err != nil {
+					// Directory doesn't exist — that's fine for 0 expected files
+					assert.True(t, os.IsNotExist(err))
+				} else {
+					assert.Equal(t, 0, len(entries))
+				}
+				return
+			}
+
+			entries, err := os.ReadDir(cryptoDir)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedKeyFiles, len(entries))
+
+			for _, entry := range entries {
+				assert.True(t, strings.HasSuffix(entry.Name(), ".key"))
+				assert.True(t, strings.HasPrefix(entry.Name(), "CN="))
+				data, err := os.ReadFile(filepath.Join(cryptoDir, entry.Name()))
+				assert.NoError(t, err)
+				assert.True(t, strings.HasPrefix(string(data), "-----BEGIN EC PRIVATE KEY-----"))
+			}
+		})
+	}
+}
+
+func TestExportCertManagerNamespaces(t *testing.T) {
+	testcases := []struct {
+		name              string
+		secrets           map[types.NamespacedName]*unstructured.Unstructured
+		expectedCount     int
+		expectedFileNames []string
+	}{
+		{
+			name:          "no secrets",
+			secrets:       map[types.NamespacedName]*unstructured.Unstructured{},
+			expectedCount: 0,
+		},
+		{
+			name: "default namespace is skipped",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "s1", Namespace: "default"}: {},
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "openshift- prefix namespace is skipped",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "s1", Namespace: "openshift-cert-manager"}: {},
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "kube- prefix namespace is skipped",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "s1", Namespace: "kube-system"}: {},
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "openshift namespace is skipped",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "s1", Namespace: "openshift"}: {},
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "custom namespace is exported",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "s1", Namespace: "ibu-test-ns"}: {},
+			},
+			expectedCount:     1,
+			expectedFileNames: []string{"01_certmanager_Namespace_ibu-test-ns.json"},
+		},
+		{
+			name: "duplicate namespaces are deduplicated",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "s1", Namespace: "ibu-test-ns"}: {},
+				{Name: "s2", Namespace: "ibu-test-ns"}: {},
+			},
+			expectedCount:     1,
+			expectedFileNames: []string{"01_certmanager_Namespace_ibu-test-ns.json"},
+		},
+		{
+			name: "mix of well-known and custom namespaces",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "s1", Namespace: "default"}:     {},
+				{Name: "s2", Namespace: "my-app-ns"}:   {},
+				{Name: "s3", Namespace: "kube-system"}: {},
+			},
+			expectedCount:     1,
+			expectedFileNames: []string{"01_certmanager_Namespace_my-app-ns.json"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			count, err := exportCertManagerNamespaces(logr.Discard(), tmpDir, tc.secrets)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedCount, count)
+
+			entries, err := os.ReadDir(tmpDir)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedCount, len(entries))
+
+			for _, expectedName := range tc.expectedFileNames {
+				filePath := filepath.Join(tmpDir, expectedName)
+				_, err := os.Stat(filePath)
+				assert.NoError(t, err, "expected file %s to exist", expectedName)
+			}
+		})
+	}
+}
+
+func TestExportCertManagerSecrets(t *testing.T) {
+	testcases := []struct {
+		name          string
+		secrets       map[types.NamespacedName]*unstructured.Unstructured
+		expectedCount int
+	}{
+		{
+			name:          "no secrets",
+			secrets:       map[types.NamespacedName]*unstructured.Unstructured{},
+			expectedCount: 0,
+		},
+		{
+			name: "single secret is exported and cleaned",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "my-cert-tls", Namespace: "default"}: {
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata": map[string]any{
+							"name":              "my-cert-tls",
+							"namespace":         "default",
+							"uid":               "some-uid",
+							"resourceVersion":   "123",
+							"creationTimestamp": "2026-01-01T00:00:00Z",
+						},
+						"data": map[string]any{
+							"tls.crt": testCertB64,
+							"tls.key": testKeyB64,
+						},
+						"status": map[string]any{},
+					},
+				},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "multiple secrets are exported",
+			secrets: map[types.NamespacedName]*unstructured.Unstructured{
+				{Name: "s1", Namespace: "ns1"}: {
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]any{"name": "s1", "namespace": "ns1"},
+					},
+				},
+				{Name: "s2", Namespace: "ns2"}: {
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]any{"name": "s2", "namespace": "ns2"},
+					},
+				},
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			count, err := exportCertManagerSecrets(logr.Discard(), tmpDir, tc.secrets)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedCount, count)
+
+			entries, err := os.ReadDir(tmpDir)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedCount, len(entries))
+
+			for _, entry := range entries {
+				assert.True(t, strings.HasPrefix(entry.Name(), "03_certmanager_Secret_"))
+				assert.True(t, strings.HasSuffix(entry.Name(), ".json"))
+			}
+
+			// Verify CleanResource was applied to exported secrets
+			if tc.expectedCount == 1 {
+				for ref := range tc.secrets {
+					filePath := filepath.Join(tmpDir,
+						"03_certmanager_Secret_"+ref.Name+"_"+ref.Namespace+".json")
+					data, err := os.ReadFile(filePath)
+					assert.NoError(t, err)
+					var obj map[string]any
+					assert.NoError(t, json.Unmarshal(data, &obj))
+					// Verify transient fields were cleaned
+					metadata, _ := obj["metadata"].(map[string]any)
+					assert.Empty(t, metadata["uid"])
+					assert.Empty(t, metadata["resourceVersion"])
+					_, hasStatus := obj["status"]
+					assert.False(t, hasStatus)
+				}
+			}
+		})
+	}
+}
+
+func TestCleanResource(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]any{
+				"name":              "my-cert",
+				"namespace":         "default",
+				"uid":               "12345-abcde",
+				"resourceVersion":   "999",
+				"generation":        int64(3),
+				"creationTimestamp": "2026-01-01T00:00:00Z",
+				"ownerReferences":   []any{map[string]any{"name": "owner"}},
+				"managedFields":     []any{map[string]any{"manager": "test"}},
+			},
+			"spec": map[string]any{
+				"secretName": "my-cert-tls",
+			},
+			"status": map[string]any{
+				"conditions": []any{map[string]any{"type": "Ready"}},
+			},
+		},
+	}
+
+	CleanResource(obj)
+
+	// Verify transient fields are removed
+	assert.Empty(t, obj.GetUID())
+	assert.Empty(t, obj.GetResourceVersion())
+	assert.Equal(t, int64(0), obj.GetGeneration())
+	assert.Nil(t, obj.GetOwnerReferences())
+	assert.Nil(t, obj.GetManagedFields())
+
+	// Verify status is removed
+	_, hasStatus := obj.Object["status"]
+	assert.False(t, hasStatus, "status should be removed")
+
+	// Verify creationTimestamp is removed from metadata
+	metadata := obj.Object["metadata"].(map[string]any)
+	_, hasTimestamp := metadata["creationTimestamp"]
+	assert.False(t, hasTimestamp, "creationTimestamp should be removed")
+
+	// Verify spec content is preserved
+	spec := obj.Object["spec"].(map[string]any)
+	assert.Equal(t, "my-cert-tls", spec["secretName"])
+
+	// Verify the cleaned resource can be marshaled to valid JSON
+	data, err := json.Marshal(obj.Object)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, data)
+}

--- a/internal/clusterconfig/clusterconfig.go
+++ b/internal/clusterconfig/clusterconfig.go
@@ -32,7 +32,8 @@ import (
 // +kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=get;list;watch
 
 const (
-	manifestDir = "manifests"
+	// ManifestDir is the subdirectory name for cluster configuration manifests.
+	ManifestDir = "manifests"
 
 	pullSecretName = "pull-secret"
 
@@ -53,6 +54,7 @@ var (
 type UpgradeClusterConfigGatherer interface {
 	FetchClusterConfig(ctx context.Context, ostreeVarDir string) error
 	FetchLvmConfig(ctx context.Context, ostreeVarDir string) error
+	PreserveCertManagerConfig(ctx context.Context, ostreeVarDir string) error
 }
 
 // UpgradeClusterConfigGather Gather ClusterConfig attributes from the kube-api
@@ -71,7 +73,7 @@ func (r *UpgradeClusterConfigGather) FetchClusterConfig(ctx context.Context, ost
 	if err != nil {
 		return err
 	}
-	manifestsDir := filepath.Join(clusterConfigPath, manifestDir)
+	manifestsDir := filepath.Join(clusterConfigPath, ManifestDir)
 
 	if err := r.fetchIDMS(ctx, manifestsDir); err != nil {
 		return err
@@ -435,8 +437,8 @@ func (r *UpgradeClusterConfigGather) fetchIDMS(ctx context.Context, manifestsDir
 func (r *UpgradeClusterConfigGather) configDir(ostreeVarDir string) (string, error) {
 	filesDir := filepath.Join(ostreeVarDir, common.OptOpenshift, common.ClusterConfigDir)
 	r.Log.Info("Creating cluster configuration folder and subfolder", "folder", filesDir)
-	if err := os.MkdirAll(filepath.Join(filesDir, manifestDir), 0o700); err != nil {
-		return "", fmt.Errorf("failed to create cluster configuration folder and subfolder in %s: %w", manifestDir, err)
+	if err := os.MkdirAll(filepath.Join(filesDir, ManifestDir), 0o700); err != nil {
+		return "", fmt.Errorf("failed to create cluster configuration folder and subfolder in %s: %w", ManifestDir, err)
 	}
 	return filesDir, nil
 }

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -311,7 +311,7 @@ func TestClusterConfig(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				manifestsDir := filepath.Join(clusterConfigPath, manifestDir)
+				manifestsDir := filepath.Join(clusterConfigPath, ManifestDir)
 
 				// validate pull idms
 				idms := &ocpV1.ImageDigestMirrorSetList{}
@@ -359,7 +359,7 @@ func TestClusterConfig(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				manifestsDir := filepath.Join(clusterConfigPath, manifestDir)
+				manifestsDir := filepath.Join(clusterConfigPath, ManifestDir)
 
 				// validate pull idms
 				idms := &ocpV1.ImageDigestMirrorSetList{}
@@ -454,7 +454,7 @@ func TestClusterConfig(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				dir, err := os.ReadDir(filepath.Join(filesDir, manifestDir))
+				dir, err := os.ReadDir(filepath.Join(filesDir, ManifestDir))
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -501,7 +501,7 @@ func TestClusterConfig(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				manifestsDir := filepath.Join(clusterConfigPath, manifestDir)
+				manifestsDir := filepath.Join(clusterConfigPath, ManifestDir)
 
 				// validate pull idms
 				idms := &ocpV1.ImageDigestMirrorSetList{}

--- a/internal/clusterconfig/lvmconfig.go
+++ b/internal/clusterconfig/lvmconfig.go
@@ -48,7 +48,7 @@ func (r *UpgradeClusterConfigGather) FetchLvmConfig(ctx context.Context, ostreeD
 		return err
 	}
 
-	manifestsDir := filepath.Join(ostreeDir, common.OptOpenshift, common.ClusterConfigDir, manifestDir)
+	manifestsDir := filepath.Join(ostreeDir, common.OptOpenshift, common.ClusterConfigDir, ManifestDir)
 	if err := r.fetchLocalVolumes(ctx, manifestsDir); err != nil {
 		return err
 	}
@@ -98,9 +98,7 @@ func (r *UpgradeClusterConfigGather) fetchLocalVolumes(ctx context.Context, mani
 
 	var scNameSet = make(map[string]bool)
 	for _, lv := range lvsList.Items {
-		// Unset uid and resource version
-		lv.SetUID("")
-		lv.SetResourceVersion("")
+		CleanResource(&lv)
 
 		lvFileName := fmt.Sprintf("%s_%s_%s.json", lv.GetKind(), lv.GetName(), lv.GetNamespace())
 		filePath := filepath.Join(manifestsDir, lvFileName)

--- a/internal/clusterconfig/lvmconfig_test.go
+++ b/internal/clusterconfig/lvmconfig_test.go
@@ -161,7 +161,7 @@ func TestFetchLvmConfig(t *testing.T) {
 	for _, tc := range testcases {
 		tmpDir := t.TempDir()
 		lvmConfigDir := filepath.Join(tmpDir, common.OptOpenshift, common.LvmConfigDir)
-		manifestsDir := filepath.Join(tmpDir, common.OptOpenshift, common.ClusterConfigDir, manifestDir)
+		manifestsDir := filepath.Join(tmpDir, common.OptOpenshift, common.ClusterConfigDir, ManifestDir)
 
 		t.Run(tc.name, func(t *testing.T) {
 			// Create the original files

--- a/internal/clusterconfig/mocks/mock_clusterconfig.go
+++ b/internal/clusterconfig/mocks/mock_clusterconfig.go
@@ -67,3 +67,17 @@ func (mr *MockUpgradeClusterConfigGathererMockRecorder) FetchLvmConfig(ctx, ostr
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchLvmConfig", reflect.TypeOf((*MockUpgradeClusterConfigGatherer)(nil).FetchLvmConfig), ctx, ostreeVarDir)
 }
+
+// PreserveCertManagerConfig mocks base method.
+func (m *MockUpgradeClusterConfigGatherer) PreserveCertManagerConfig(ctx context.Context, ostreeVarDir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreserveCertManagerConfig", ctx, ostreeVarDir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PreserveCertManagerConfig indicates an expected call of PreserveCertManagerConfig.
+func (mr *MockUpgradeClusterConfigGathererMockRecorder) PreserveCertManagerConfig(ctx, ostreeVarDir any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreserveCertManagerConfig", reflect.TypeOf((*MockUpgradeClusterConfigGatherer)(nil).PreserveCertManagerConfig), ctx, ostreeVarDir)
+}

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -63,6 +63,7 @@ const (
 	NmstateConfigFileName             = "nmstate.yaml"
 	SeedDataDir                       = "/var/seed_data"
 	KubeconfigCryptoDir               = "kubeconfig-crypto"
+	CertManagerCryptoDir              = "certmanager-crypto"
 	ClusterConfigDir                  = "cluster-configuration"
 	ContainersListFileName            = "containers.list"
 	SeedClusterInfoFileName           = "manifest.json"

--- a/internal/recert/recert.go
+++ b/internal/recert/recert.go
@@ -111,7 +111,7 @@ func SetRecertTrustedCaBundleFromSeedReconfigAdditionaTrustBundle(recertConfig *
 // CreateRecertConfigFile function to create recert config file
 // those params will be provided to an installation script after reboot
 // that will run recert command with them
-func CreateRecertConfigFile(seedReconfig *seedreconfig.SeedReconfiguration, seedClusterInfo *seedclusterinfo.SeedClusterInfo, cryptoDir, recertConfigFolder string) error {
+func CreateRecertConfigFile(seedReconfig *seedreconfig.SeedReconfiguration, seedClusterInfo *seedclusterinfo.SeedClusterInfo, cryptoDir, recertConfigFolder, certManagerCryptoDir string) error {
 	config := createBaseRecertConfig()
 
 	config.ClusterRename = fmt.Sprintf("%s:%s", seedReconfig.ClusterName, seedReconfig.BaseDomain)
@@ -166,6 +166,11 @@ func CreateRecertConfigFile(seedReconfig *seedreconfig.SeedReconfiguration, seed
 			fmt.Sprintf("%s %s/%s", seedClusterInfo.IngressCertificateCN, cryptoDir, ingressKeyFile),
 		}
 		config.UseCertRules = []string{filepath.Join(cryptoDir, "admin-kubeconfig-client-ca.crt")}
+	}
+
+	// Append cert-manager crypto rules if present
+	if err := appendCertManagerCryptoRules(&config, certManagerCryptoDir); err != nil {
+		return fmt.Errorf("failed to append cert-manager crypto rules: %w", err)
 	}
 
 	config.CNSanReplaceRules = []string{
@@ -314,6 +319,44 @@ func CreateRecertConfigFileForIPConfig(
 	}
 
 	return &config, nil
+}
+
+// appendCertManagerCryptoRules scans the certmanager-crypto directory for .key files
+// and appends them as use_key rules to the recert config. This preserves cert-manager-managed
+// key material through recert's re-keying process. The CN is encoded in the filename
+// (format: "CN=<cn>__<namespace>_<name>.key") and used to construct the "CN path" rule
+// format that recert expects.
+func appendCertManagerCryptoRules(config *RecertConfig, certManagerCryptoDir string) error {
+	if certManagerCryptoDir == "" {
+		return nil
+	}
+
+	entries, err := os.ReadDir(certManagerCryptoDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read certmanager crypto dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".key") {
+			continue
+		}
+		// Parse CN from filename format "CN=<cn>__<namespace>_<name>.key"
+		name := entry.Name()
+		if !strings.HasPrefix(name, "CN=") {
+			continue
+		}
+		cn := strings.SplitN(strings.TrimPrefix(name, "CN="), "__", 2)[0]
+		if cn == "" {
+			continue
+		}
+		config.UseKeyRules = append(config.UseKeyRules,
+			fmt.Sprintf("%s %s", cn, filepath.Join(certManagerCryptoDir, name)))
+	}
+
+	return nil
 }
 
 func getIngressKeyPath(certsFolder string) (string, error) {

--- a/internal/recert/recert_test.go
+++ b/internal/recert/recert_test.go
@@ -1,6 +1,8 @@
 package recert
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
@@ -127,6 +129,104 @@ func TestRecertConfig_DualStackFields(t *testing.T) {
 	assert.Equal(t, []string{"192.168.1.0/24", "2001:db8::/64"}, config.MachineNetworkCidr)
 	assert.Equal(t, "test-node", config.Hostname)
 	assert.Equal(t, "test-cluster:example.com", config.ClusterRename)
+}
+
+func TestAppendCertManagerCryptoRules(t *testing.T) {
+	tests := []struct {
+		name              string
+		setupDir          func(t *testing.T) string
+		existingKeyRules  []string
+		expectedRuleCount int
+		validateRules     func(t *testing.T, rules []string)
+	}{
+		{
+			name: "directory does not exist",
+			setupDir: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "nonexistent")
+			},
+			expectedRuleCount: 0,
+		},
+		{
+			name: "empty directory",
+			setupDir: func(t *testing.T) string {
+				dir := filepath.Join(t.TempDir(), "certmanager-crypto")
+				assert.NoError(t, os.MkdirAll(dir, 0o700))
+				return dir
+			},
+			expectedRuleCount: 0,
+		},
+		{
+			name: "directory with key files",
+			setupDir: func(t *testing.T) string {
+				dir := filepath.Join(t.TempDir(), "certmanager-crypto")
+				assert.NoError(t, os.MkdirAll(dir, 0o700))
+				assert.NoError(t, os.WriteFile(filepath.Join(dir, "CN=my-cert.example.com__default_my-cert-tls.key"),
+					[]byte("-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----\n"), 0o600))
+				assert.NoError(t, os.WriteFile(filepath.Join(dir, "CN=api.example.com__openshift-config_api-cert.key"),
+					[]byte("-----BEGIN EC PRIVATE KEY-----\ntest2\n-----END EC PRIVATE KEY-----\n"), 0o600))
+				return dir
+			},
+			expectedRuleCount: 2,
+			validateRules: func(t *testing.T, rules []string) {
+				// ReadDir returns alphabetical order: api... before my-cert...
+				assert.Contains(t, rules[0], "api.example.com ")
+				assert.Contains(t, rules[1], "my-cert.example.com ")
+			},
+		},
+		{
+			name: "non-key files and files without CN= prefix are ignored",
+			setupDir: func(t *testing.T) string {
+				dir := filepath.Join(t.TempDir(), "certmanager-crypto")
+				assert.NoError(t, os.MkdirAll(dir, 0o700))
+				assert.NoError(t, os.WriteFile(filepath.Join(dir, "CN=my-cert.example.com__default_my-cert-tls.key"),
+					[]byte("key"), 0o600))
+				assert.NoError(t, os.WriteFile(filepath.Join(dir, "default_my-cert-tls.crt"),
+					[]byte("cert"), 0o600))
+				assert.NoError(t, os.WriteFile(filepath.Join(dir, "readme.txt"),
+					[]byte("readme"), 0o600))
+				assert.NoError(t, os.WriteFile(filepath.Join(dir, "no-cn-prefix.key"),
+					[]byte("key"), 0o600))
+				return dir
+			},
+			expectedRuleCount: 1,
+		},
+		{
+			name: "appends to existing rules",
+			setupDir: func(t *testing.T) string {
+				dir := filepath.Join(t.TempDir(), "certmanager-crypto")
+				assert.NoError(t, os.MkdirAll(dir, 0o700))
+				assert.NoError(t, os.WriteFile(filepath.Join(dir, "CN=my-cert.example.com__default_my-cert-tls.key"),
+					[]byte("key"), 0o600))
+				return dir
+			},
+			existingKeyRules:  []string{"kube-apiserver-lb-signer /path/loadbalancer-serving-signer.key"},
+			expectedRuleCount: 2,
+		},
+		{
+			name: "empty dir path",
+			setupDir: func(t *testing.T) string {
+				return ""
+			},
+			expectedRuleCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setupDir(t)
+			config := &RecertConfig{}
+			if tt.existingKeyRules != nil {
+				config.UseKeyRules = tt.existingKeyRules
+			}
+
+			err := appendCertManagerCryptoRules(config, dir)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedRuleCount, len(config.UseKeyRules))
+			if tt.validateRules != nil {
+				tt.validateRules(t, config.UseKeyRules)
+			}
+		})
+	}
 }
 
 func TestCreateBaseRecertConfig(t *testing.T) {

--- a/lca-cli/postpivot/postpivot.go
+++ b/lca-cli/postpivot/postpivot.go
@@ -264,8 +264,9 @@ func (p *PostPivot) recert(ctx context.Context, seedReconfiguration *clusterconf
 		return fmt.Errorf("failed to populate crypto dir from seed reconfiguration: %w", err)
 	}
 
+	certManagerCryptoDir := path.Join(p.workingDir, common.ClusterConfigDir, common.CertManagerCryptoDir)
 	if err := recert.CreateRecertConfigFile(seedReconfiguration, seedClusterInfo, kubeconfigCryptoDir,
-		p.workingDir); err != nil {
+		p.workingDir, certManagerCryptoDir); err != nil {
 		return fmt.Errorf("failed to create recert config file: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Backport of #5174 to release-4.21.

- Adds cert-manager awareness to the LCA upgrade pipeline to preserve TLS key material through IBU
- Exports cert-manager Certificate secrets as `use_key` rules for recert, preventing key regeneration
- Companion to recert backport: rh-ecosystem-edge/recert#1516

**Jira**: [CNF-21719](https://issues.redhat.com/browse/CNF-21719)