### PR TITLE
CNF-24061: Upstream catalog-template update — Lifecycle Agent 4.19.4

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-19@sha256:9f5ea89c83c726a790b8c87e8b9bef061a4c19c4536c4f40ec4274a07ec353b3
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-19@sha256:5bd4f1b25cfded845df38d8d1cd0566971f51390fe5b1bb9502270ce5a80f2b7

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -28,6 +28,10 @@ entries:
       - name: lifecycle-agent.v4.19.4
         replaces: lifecycle-agent.v4.19.3
         skipRange: '>=4.18.0 <4.19.4'
+      # v4.19.5
+      - name: lifecycle-agent.v4.19.5
+        replaces: lifecycle-agent.v4.19.4
+        skipRange: '>=4.18.0 <4.19.5'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -52,6 +56,10 @@ entries:
       - name: lifecycle-agent.v4.19.4
         replaces: lifecycle-agent.v4.19.3
         skipRange: '>=4.18.0 <4.19.4'
+      # v4.19.5
+      - name: lifecycle-agent.v4.19.5
+        replaces: lifecycle-agent.v4.19.4
+        skipRange: '>=4.18.0 <4.19.5'
     name: "4.19"
     package: lifecycle-agent
     schema: olm.channel
@@ -68,6 +76,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:7abb5108b6a730fbb0605618081ca4f8cc9f371451476dbf132fa74833f6eca5
     schema: olm.bundle
   # v4.19.4 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:b6ecefc8c9179318d06219bba38f2eed7a993ec2c33626bf97acfcab286cb05f
+    schema: olm.bundle
+    # v4.19.5 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.19.4 → 4.19.5.

Generated by release-automator-konflux.