### PR TITLE
CNF-24048: Upstream catalog-template update — Lifecycle Agent 4.18.4

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-18@sha256:a30aaea2149c93964ac23d99ce8f98743313e8ab8d33432d122c010b1e339a5a
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-18@sha256:7493c8b8df7ef0438191c0d6cb2c58fffc01b255d95da4ad1e5f614007b4c896

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -28,6 +28,10 @@ entries:
       - name: lifecycle-agent.v4.18.4
         replaces: lifecycle-agent.v4.18.3
         skipRange: '>=4.16.0 <4.18.4'
+      # v4.18.5
+      - name: lifecycle-agent.v4.18.5
+        replaces: lifecycle-agent.v4.18.4
+        skipRange: '>=4.16.0 <4.18.5'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -52,6 +56,10 @@ entries:
       - name: lifecycle-agent.v4.18.4
         replaces: lifecycle-agent.v4.18.3
         skipRange: '>=4.16.0 <4.18.4'
+      # v4.18.5
+      - name: lifecycle-agent.v4.18.5
+        replaces: lifecycle-agent.v4.18.4
+        skipRange: '>=4.16.0 <4.18.5'
     name: "4.18"
     package: lifecycle-agent
     schema: olm.channel
@@ -68,6 +76,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:9bfbd0c5cb782da6e28389c2ae5ccfe93de07b645c5901abdc6ac7d8d3e39997
     schema: olm.bundle
   # v4.18.4 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:6d209a21180dd0665fc8fd2f5a6d01524e2bcd2ec71fcb62966e4e8e54d3bde0
+    schema: olm.bundle
+    # v4.18.5 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.18.4 → 4.18.5.

Generated by release-automator-konflux.