### PR TITLE
CNF-22981: add allow-automatic-merge label for rpm-lockfile manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,14 @@
             ]
         },
         {
+            "addLabels": [
+                "allow-automatic-merge"
+            ],
+            "matchManagers": [
+                "rpm-lockfile"
+            ]
+        },
+        {
             "enabled": false,
             "matchUpdateTypes": [
                 "minor"


### PR DESCRIPTION
## Summary

- Add a `packageRule` to label PRs generated by the `rpm-lockfile` manager with `allow-automatic-merge`
- This enables auto-merge of `rpms.lock.yaml` refresh PRs created by the mintmaker preset (`github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles`)

## Motivation

PRs like [rh-ecosystem-edge/recert#1441](https://github.com/rh-ecosystem-edge/recert/pull/1441) (chore(deps): refresh rpm lockfiles) are generated automatically by `red-hat-konflux[bot]` and only update RPM lock file checksums/versions. They should be auto-merged without manual intervention.


Made with [Cursor](https://cursor.com)