### PR TITLE
CNF-24691: Upstream catalog-template update — Lifecycle Agent 4.20.5

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:7fce1abce9f586c9c09e333dc67b658c6ea28a9189ca2257351661f893988cd2
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-20@sha256:620252a13ea64e094b3959195d14090f329f10fb71b536d84a0635a9379a9b76

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -33,6 +33,10 @@ entries:
       - name: lifecycle-agent.v4.20.5
         replaces: lifecycle-agent.v4.20.4
         skipRange: '>=4.18.0 <4.20.5'
+      # v4.20.6
+      - name: lifecycle-agent.v4.20.6
+        replaces: lifecycle-agent.v4.20.5
+        skipRange: '>=4.18.0 <4.20.6'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -61,6 +65,10 @@ entries:
       - name: lifecycle-agent.v4.20.5
         replaces: lifecycle-agent.v4.20.4
         skipRange: '>=4.18.0 <4.20.5'
+      # v4.20.6
+      - name: lifecycle-agent.v4.20.6
+        replaces: lifecycle-agent.v4.20.5
+        skipRange: '>=4.18.0 <4.20.6'
     name: "4.20"
     package: lifecycle-agent
     schema: olm.channel
@@ -80,6 +88,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:f05879638caeb3ca2e064bfa3a7c46d6cecf64e322c8c304806190c24eabba12
     schema: olm.bundle
   # v4.20.5 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:d58fcab5a50f6df010b50ca86346e082ce355f3ac4fa6f8dd1606a0522cbc743
+    schema: olm.bundle
+    # v4.20.6 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.20.5 → 4.20.6.

Generated by release-automator-konflux.