### PR TITLE
CNF-24248: Upstream catalog-template update — Lifecycle Agent 4.22.0

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-22@sha256:0fb9fe40cff820fcbab5c925bafc1270ddbf3c552ae8fed648642bdd53bd716c
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-22@sha256:ffa7de3fe3577f576eb3beaa98d0e693ce61df402f3625177a9019e1f50b8f57

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -13,6 +13,10 @@ entries:
       # v4.22.0
       - name: lifecycle-agent.v4.22.0
         skipRange: '>=4.20.0 <4.22.0'
+      # v4.22.1
+      - name: lifecycle-agent.v4.22.1
+        replaces: lifecycle-agent.v4.22.0
+        skipRange: '>=4.20.0 <4.22.1'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -21,6 +25,10 @@ entries:
       # v4.22.0
       - name: lifecycle-agent.v4.22.0
         skipRange: '>=4.20.0 <4.22.0'
+      # v4.22.1
+      - name: lifecycle-agent.v4.22.1
+        replaces: lifecycle-agent.v4.22.0
+        skipRange: '>=4.20.0 <4.22.1'
     name: "4.22"
     package: lifecycle-agent
     schema: olm.channel


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.22.0 → 4.22.1.

Generated by release-automator-konflux.