### PR TITLE
CNF-25102: Upstream catalog-template update — Lifecycle Agent 4.16.7

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-16@sha256:6ec64c770abe8f8b1a2798088ad63c0e6c06a5d6c7732006aac9bf2198c64933
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-16@sha256:8756ca175109444d9490b063220f5779ef2e3569a099d92d9d8b0ae5bbbba070

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -40,6 +40,10 @@ entries:
       - name: lifecycle-agent.v4.16.7
         replaces: lifecycle-agent.v4.16.6
         skipRange: '>=4.14.0 <4.16.7'
+      # v4.16.8
+      - name: lifecycle-agent.v4.16.8
+        replaces: lifecycle-agent.v4.16.7
+        skipRange: '>=4.14.0 <4.16.8'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -76,6 +80,10 @@ entries:
       - name: lifecycle-agent.v4.16.7
         replaces: lifecycle-agent.v4.16.6
         skipRange: '>=4.14.0 <4.16.7'
+      # v4.16.8
+      - name: lifecycle-agent.v4.16.8
+        replaces: lifecycle-agent.v4.16.7
+        skipRange: '>=4.14.0 <4.16.8'
     name: "4.16"
     package: lifecycle-agent
     schema: olm.channel
@@ -101,6 +109,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:593146284f98f9daf051b5d18953e618788b95982e9be72ffdc96f0831b19545
     schema: olm.bundle
   # v4.16.7 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:655b183ab9f42a9448d9c3cf5f696db876a5a5b784b97744fc2f7d8dd4aeaa89
+    schema: olm.bundle
+    # v4.16.8 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.16.7 → 4.16.8.

Generated by release-automator-konflux.