### PR TITLE
hack/bundle-run: increase SA wait timeout from 30s to 15m

### DIFF
--- a/hack/bundle-run.sh
+++ b/hack/bundle-run.sh
@@ -35,7 +35,9 @@ PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 : "${BUNDLE_RUN_TIMEOUT:=5m}"
 : "${CATALOGSOURCE_NAME:=lifecycle-agent-catalog}"
 : "${PATCH_TIMEOUT_SECONDS:=120}"
-: "${SA_WAIT_TIMEOUT_SECONDS:=30}"
+# On freshly installed SNO, kube-apiserver revision rollouts can cause
+# intermittent API unavailability for 10+ minutes, blocking SA creation
+: "${SA_WAIT_TIMEOUT_SECONDS:=900}"
 : "${BUNDLE_CLEAN_BEFORE_INSTALL:=false}"
 : "${OPERATOR_SDK:=${PROJECT_DIR}/bin/operator-sdk}"
 


### PR DESCRIPTION
On freshly installed SNO clusters, the kube-apiserver can spend 10+ minutes rolling through revision upgrades after openshift-install declares the cluster installed. During these rollouts the single API server instance is intermittently unavailable, which means namespace creation and the subsequent default ServiceAccount auto-creation can stall or fail silently.

This was observed in a CI failure [1] where bundle-run.sh timed out after 30s waiting for serviceaccount/default in openshift-lifecycle-agent. The must-gather taken 2+ minutes later showed the namespace still didn't exist, and kube-apiserver was still Progressing (revision 5→6, rolling for 6+ minutes with no end in sight at gather time).

Bump the default SA_WAIT_TIMEOUT_SECONDS from 30 to 900 (15 minutes) to ride out these post-install apiserver rollouts. The loop still exits immediately once the SA appears, so happy-path timing is unchanged. The value remains overridable via environment variable.

[1] https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_recert/970/pull-ci-rh-ecosystem-edge-recert-main-ipc-e2e-flow/2069332829723955200

Assisted-by: Claude <noreply@anthropic.com>
