### PR TITLE
Update catalog skipRange from 4.20.0 to 4.22.0

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -12,7 +12,7 @@ entries:
   - entries:
       # v5.0.0
       - name: lifecycle-agent.v5.0.0
-        skipRange: '>=4.20.0 <5.0.0'
+        skipRange: '>=4.22.0 <5.0.0'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -20,7 +20,7 @@ entries:
   - entries:
       # v5.0.0
       - name: lifecycle-agent.v5.0.0
-        skipRange: '>=4.20.0 <5.0.0'
+        skipRange: '>=4.22.0 <5.0.0'
     name: "5.0"
     package: lifecycle-agent
     schema: olm.channel


### PR DESCRIPTION
## Summary
- Update `skipRange` in `.konflux/catalog/catalog-template.in.yaml` from `>=4.20.0 <5.0.0` to `>=4.22.0 <5.0.0` for both `stable` and `5.0` channels.


Made with [Cursor](https://cursor.com)