### PR TITLE
[release-4.19] CNF-25262: Fix for CI failing on missing service account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,8 +294,8 @@ bundle-check: bundle
 
 .PHONY: bundle-run
 bundle-run: # Install bundle on cluster using operator sdk.
-	oc create ns openshift-lifecycle-agent
-	$(OPERATOR_SDK) --security-context-config restricted -n openshift-lifecycle-agent run bundle $(BUNDLE_IMG)
+	OPERATOR_SDK="$(OPERATOR_SDK)" BUNDLE_IMG="$(BUNDLE_IMG)" \
+		bash $(PROJECT_DIR)/hack/bundle-run.sh
 
 .PHONY: bundle-upgrade
 bundle-upgrade: # Upgrade bundle on cluster using operator sdk.

--- a/hack/bundle-run.sh
+++ b/hack/bundle-run.sh
@@ -11,9 +11,11 @@
 #
 # Optional env vars:
 #   BUNDLE_NAMESPACE: namespace used for operator-sdk run bundle (default: openshift-lifecycle-agent)
-#   BUNDLE_RUN_TIMEOUT: how long to wait for the CSV to install (default: 5m)
+#   BUNDLE_RUN_TIMEOUT: how long to wait for the CSV to install (default: 15m)
 #   CATALOGSOURCE_NAME: CatalogSource name created by operator-sdk (default: lifecycle-agent-catalog)
 #   PATCH_TIMEOUT_SECONDS: how long to wait for CatalogSource/address to appear (default: 120)
+#   SA_WAIT_TIMEOUT_SECONDS: how long to wait for default serviceaccount (default: 900)
+#   SA_WAIT_POLL_INTERVAL_SECONDS: poll interval while waiting for serviceaccount (default: 30)
 
 set -euo pipefail
 if [[ "${TRACE:-0}" == "1" ]]; then
@@ -21,10 +23,11 @@ if [[ "${TRACE:-0}" == "1" ]]; then
 fi
 
 : "${BUNDLE_NAMESPACE:=openshift-lifecycle-agent}"
-: "${BUNDLE_RUN_TIMEOUT:=5m}"
+: "${BUNDLE_RUN_TIMEOUT:=15m}"
 : "${CATALOGSOURCE_NAME:=lifecycle-agent-catalog}"
 : "${PATCH_TIMEOUT_SECONDS:=120}"
-: "${SA_WAIT_TIMEOUT_SECONDS:=30}"
+: "${SA_WAIT_TIMEOUT_SECONDS:=900}"
+: "${SA_WAIT_POLL_INTERVAL_SECONDS:=30}"
 : "${OPERATOR_SDK:=${PROJECT_DIR}/bin/operator-sdk}"
 
 if [[ -z "${OPERATOR_SDK:-}" ]]; then
@@ -39,12 +42,13 @@ fi
 
 oc create ns "${BUNDLE_NAMESPACE}" 2>/dev/null || true
 
-echo "Waiting for default serviceaccount in ${BUNDLE_NAMESPACE} (timeout=${SA_WAIT_TIMEOUT_SECONDS}s)"
-for _i in $(seq 1 "${SA_WAIT_TIMEOUT_SECONDS}"); do
+SA_WAIT_MAX_ATTEMPTS=$(( (SA_WAIT_TIMEOUT_SECONDS + SA_WAIT_POLL_INTERVAL_SECONDS - 1) / SA_WAIT_POLL_INTERVAL_SECONDS ))
+echo "Waiting for default serviceaccount in ${BUNDLE_NAMESPACE} (timeout=${SA_WAIT_TIMEOUT_SECONDS}s, poll=${SA_WAIT_POLL_INTERVAL_SECONDS}s)"
+for _i in $(seq 1 "${SA_WAIT_MAX_ATTEMPTS}"); do
     if oc get serviceaccount default -n "${BUNDLE_NAMESPACE}" >/dev/null 2>&1; then
         break
     fi
-    sleep 1
+    sleep "${SA_WAIT_POLL_INTERVAL_SECONDS}"
 done
 if ! oc get serviceaccount default -n "${BUNDLE_NAMESPACE}" >/dev/null 2>&1; then
     echo "ERROR: timed out waiting for serviceaccount/default in ${BUNDLE_NAMESPACE}"

--- a/hack/bundle-run.sh
+++ b/hack/bundle-run.sh
@@ -42,6 +42,15 @@ fi
 
 oc create ns "${BUNDLE_NAMESPACE}" 2>/dev/null || true
 
+if [[ ! "${SA_WAIT_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: SA_WAIT_TIMEOUT_SECONDS must be a positive integer, got: ${SA_WAIT_TIMEOUT_SECONDS}"
+    exit 2
+fi
+if [[ ! "${SA_WAIT_POLL_INTERVAL_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: SA_WAIT_POLL_INTERVAL_SECONDS must be a positive integer, got: ${SA_WAIT_POLL_INTERVAL_SECONDS}"
+    exit 2
+fi
+
 SA_WAIT_MAX_ATTEMPTS=$(( (SA_WAIT_TIMEOUT_SECONDS + SA_WAIT_POLL_INTERVAL_SECONDS - 1) / SA_WAIT_POLL_INTERVAL_SECONDS ))
 echo "Waiting for default serviceaccount in ${BUNDLE_NAMESPACE} (timeout=${SA_WAIT_TIMEOUT_SECONDS}s, poll=${SA_WAIT_POLL_INTERVAL_SECONDS}s)"
 for _i in $(seq 1 "${SA_WAIT_MAX_ATTEMPTS}"); do
@@ -58,6 +67,11 @@ fi
 "${OPERATOR_SDK}" --security-context-config restricted -n "${BUNDLE_NAMESPACE}" \
     run bundle --timeout="${BUNDLE_RUN_TIMEOUT}" "${BUNDLE_IMG}" &
 sdk_pid=$!
+
+if [[ ! "${PATCH_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: PATCH_TIMEOUT_SECONDS must be a positive integer, got: ${PATCH_TIMEOUT_SECONDS}"
+    exit 2
+fi
 
 for _i in $(seq 1 "${PATCH_TIMEOUT_SECONDS}"); do
     if ! oc get "catalogsource/${CATALOGSOURCE_NAME}" -n "${BUNDLE_NAMESPACE}" >/dev/null 2>&1; then

--- a/hack/bundle-run.sh
+++ b/hack/bundle-run.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# bundle-run.sh installs the operator bundle using operator-sdk and works around
+# an operator-sdk/OLM issue on IPv6 clusters where CatalogSource.spec.address
+# may be rendered without brackets (e.g. "fd00::1:50051" instead of "[fd00::1]:50051"),
+# which causes OLM resolution errors.
+#
+# Usage (typically via make):
+#   OPERATOR_SDK=/path/to/operator-sdk BUNDLE_IMG=quay.io/... \
+#     bash hack/bundle-run.sh
+#
+# Optional env vars:
+#   BUNDLE_NAMESPACE: namespace used for operator-sdk run bundle (default: openshift-lifecycle-agent)
+#   CATALOGSOURCE_NAME: CatalogSource name created by operator-sdk (default: lifecycle-agent-catalog)
+#   PATCH_TIMEOUT_SECONDS: how long to wait for CatalogSource/address to appear (default: 120)
+
+set -euo pipefail
+if [[ "${TRACE:-0}" == "1" ]]; then
+    set -x
+fi
+
+: "${BUNDLE_NAMESPACE:=openshift-lifecycle-agent}"
+: "${CATALOGSOURCE_NAME:=lifecycle-agent-catalog}"
+: "${PATCH_TIMEOUT_SECONDS:=120}"
+: "${SA_WAIT_TIMEOUT_SECONDS:=30}"
+: "${OPERATOR_SDK:=${PROJECT_DIR}/bin/operator-sdk}"
+
+if [[ -z "${OPERATOR_SDK:-}" ]]; then
+    echo "ERROR: OPERATOR_SDK is not set"
+    exit 2
+fi
+
+if [[ -z "${BUNDLE_IMG:-}" ]]; then
+    echo "ERROR: BUNDLE_IMG is not set"
+    exit 2
+fi
+
+oc create ns "${BUNDLE_NAMESPACE}" 2>/dev/null || true
+
+echo "Waiting for default serviceaccount in ${BUNDLE_NAMESPACE} (timeout=${SA_WAIT_TIMEOUT_SECONDS}s)"
+for _i in $(seq 1 "${SA_WAIT_TIMEOUT_SECONDS}"); do
+    if oc get serviceaccount default -n "${BUNDLE_NAMESPACE}" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+if ! oc get serviceaccount default -n "${BUNDLE_NAMESPACE}" >/dev/null 2>&1; then
+    echo "ERROR: timed out waiting for serviceaccount/default in ${BUNDLE_NAMESPACE}"
+    exit 1
+fi
+
+"${OPERATOR_SDK}" --security-context-config restricted -n "${BUNDLE_NAMESPACE}" run bundle "${BUNDLE_IMG}" &
+sdk_pid=$!
+
+for _i in $(seq 1 "${PATCH_TIMEOUT_SECONDS}"); do
+    if ! oc get "catalogsource/${CATALOGSOURCE_NAME}" -n "${BUNDLE_NAMESPACE}" >/dev/null 2>&1; then
+        sleep 1
+        continue
+    fi
+
+    addr="$(oc get "catalogsource/${CATALOGSOURCE_NAME}" -n "${BUNDLE_NAMESPACE}" -o jsonpath='{.spec.address}' 2>/dev/null || true)"
+    if [[ -z "${addr}" ]]; then
+        # CatalogSource can exist briefly before spec.address is populated.
+        sleep 1
+        continue
+    fi
+
+    # Already bracketed -> nothing to do.
+    case "${addr}" in
+        \[*\]*) break ;;
+    esac
+
+    # Patch unbracketed IPv6 "host:port" (port must be numeric).
+    if [[ "${addr}" =~ ^([0-9A-Fa-f:]+):([0-9]+)$ ]]; then
+        host="${BASH_REMATCH[1]}"
+        port="${BASH_REMATCH[2]}"
+        newaddr="[${host}]:${port}"
+        echo "Patching catalogsource/${CATALOGSOURCE_NAME} in ${BUNDLE_NAMESPACE} spec.address: ${addr} -> ${newaddr}"
+        patch="$(printf '{"spec":{"address":"%s"}}' "${newaddr}")"
+        oc patch "catalogsource/${CATALOGSOURCE_NAME}" -n "${BUNDLE_NAMESPACE}" --type=merge -p "${patch}"
+    fi
+    break
+done
+
+wait "${sdk_pid}"

--- a/hack/bundle-run.sh
+++ b/hack/bundle-run.sh
@@ -11,6 +11,7 @@
 #
 # Optional env vars:
 #   BUNDLE_NAMESPACE: namespace used for operator-sdk run bundle (default: openshift-lifecycle-agent)
+#   BUNDLE_RUN_TIMEOUT: how long to wait for the CSV to install (default: 5m)
 #   CATALOGSOURCE_NAME: CatalogSource name created by operator-sdk (default: lifecycle-agent-catalog)
 #   PATCH_TIMEOUT_SECONDS: how long to wait for CatalogSource/address to appear (default: 120)
 
@@ -20,6 +21,7 @@ if [[ "${TRACE:-0}" == "1" ]]; then
 fi
 
 : "${BUNDLE_NAMESPACE:=openshift-lifecycle-agent}"
+: "${BUNDLE_RUN_TIMEOUT:=5m}"
 : "${CATALOGSOURCE_NAME:=lifecycle-agent-catalog}"
 : "${PATCH_TIMEOUT_SECONDS:=120}"
 : "${SA_WAIT_TIMEOUT_SECONDS:=30}"
@@ -49,7 +51,8 @@ if ! oc get serviceaccount default -n "${BUNDLE_NAMESPACE}" >/dev/null 2>&1; the
     exit 1
 fi
 
-"${OPERATOR_SDK}" --security-context-config restricted -n "${BUNDLE_NAMESPACE}" run bundle "${BUNDLE_IMG}" &
+"${OPERATOR_SDK}" --security-context-config restricted -n "${BUNDLE_NAMESPACE}" \
+    run bundle --timeout="${BUNDLE_RUN_TIMEOUT}" "${BUNDLE_IMG}" &
 sdk_pid=$!
 
 for _i in $(seq 1 "${PATCH_TIMEOUT_SECONDS}"); do


### PR DESCRIPTION
Manual backport of https://github.com/openshift-kni/lifecycle-agent/pull/7358

Cherry pick bot is not signing commits so we cannot use it atm

Additional change: Use hack/bundle-run.sh for the make bundle-run target
