### PR TITLE
CNF-25347: Upstream catalog-template update — Lifecycle Agent 4.14.8

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-14@sha256:1b325ea9340e9f0292ddd18908b3cd7c3c6d285cfe2e072c3a50bb4556446524
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-14@sha256:31270c3f45c347f72375b0fec172687a1b63547b43f5e24eee0cfab27bccba0c

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -43,6 +43,10 @@ entries:
       - name: lifecycle-agent.v4.14.8
         replaces: lifecycle-agent.v4.14.7
         skipRange: '>=4.14.0 <4.14.8'
+      # v4.14.9
+      - name: lifecycle-agent.v4.14.9
+        replaces: lifecycle-agent.v4.14.8
+        skipRange: '>=4.14.0 <4.14.9'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -82,6 +86,10 @@ entries:
       - name: lifecycle-agent.v4.14.8
         replaces: lifecycle-agent.v4.14.7
         skipRange: '>=4.14.0 <4.14.8'
+      # v4.14.9
+      - name: lifecycle-agent.v4.14.9
+        replaces: lifecycle-agent.v4.14.8
+        skipRange: '>=4.14.0 <4.14.9'
     name: "4.14"
     package: lifecycle-agent
     schema: olm.channel
@@ -110,6 +118,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:25d1dd9cf063d2c89c9cb2ada934ae77825f74e5fffd3db69e72197b69ccb7b9
     schema: olm.bundle
   # v4.14.8 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:98606e9ce5fef04849f36b650d444fef1d4e3d745f57a20dce4f48adfc91b710
+    schema: olm.bundle
+    # v4.14.9 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.14.8 → 4.14.9.

Generated by release-automator-konflux.