### PR TITLE
OCPBUGS-94076: normalize cert-manager private keys to PKCS#8 for recert

### DIFF
--- a/internal/clusterconfig/certmanagerconfig.go
+++ b/internal/clusterconfig/certmanagerconfig.go
@@ -225,6 +225,13 @@ func writeCertManagerCrypto(
 				"secret", ref.Name, "namespace", ref.Namespace)
 			continue
 		}
+		if parsedCert.PublicKeyAlgorithm == x509.Ed25519 {
+			log.Info("WARNING: Certificate uses Ed25519 which recert does not yet support, "+
+				"skipping use_key rule (certificate will be re-issued after upgrade)",
+				"secret", ref.Name, "namespace", ref.Namespace,
+				"cn", parsedCert.Subject.CommonName)
+			continue
+		}
 
 		// Write the private key as a PEM file for recert use_key rules.
 		// The CN is encoded in the filename so appendCertManagerCryptoRules can
@@ -240,11 +247,19 @@ func writeCertManagerCrypto(
 			return fmt.Errorf("failed to decode tls.key for %s/%s: %w", ref.Namespace, ref.Name, err)
 		}
 
+		// Normalize the private key to PKCS#8 PEM format. Recert only accepts
+		// PKCS#8 ("BEGIN PRIVATE KEY") but cert-manager produces ECDSA keys in
+		// SEC1 format ("BEGIN EC PRIVATE KEY").
+		pkcs8Key, err := normalizeToPKCS8(decodedKey)
+		if err != nil {
+			return fmt.Errorf("failed to normalize key to PKCS#8 for %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+
 		// Filename format: "CN=<cn>__<namespace>_<name>.key"
 		// The CN= prefix and __ separator allow appendCertManagerCryptoRules to parse the CN.
 		keyFile := filepath.Join(cryptoDir, fmt.Sprintf("CN=%s__%s_%s.key",
 			parsedCert.Subject.CommonName, ref.Namespace, ref.Name))
-		if err := os.WriteFile(keyFile, decodedKey, 0o600); err != nil {
+		if err := os.WriteFile(keyFile, pkcs8Key, 0o600); err != nil {
 			return fmt.Errorf("failed to write key file %s: %w", keyFile, err)
 		}
 		log.Info("Wrote cert-manager TLS key for recert preservation",
@@ -254,6 +269,40 @@ func writeCertManagerCrypto(
 
 	log.Info("Wrote cert-manager crypto for recert preservation", "secretCount", len(secrets))
 	return nil
+}
+
+// normalizeToPKCS8 converts a PEM-encoded private key to PKCS#8 format. Keys already
+// in PKCS#8 are returned unchanged. SEC1 EC keys and PKCS#1 RSA keys are re-encoded.
+func normalizeToPKCS8(pemData []byte) ([]byte, error) {
+	keyBlock, _ := pem.Decode(pemData)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("failed to decode PEM block from private key")
+	}
+
+	if keyBlock.Type == "PRIVATE KEY" {
+		return pemData, nil
+	}
+
+	var parsedKey any
+	var err error
+	switch keyBlock.Type {
+	case "EC PRIVATE KEY":
+		parsedKey, err = x509.ParseECPrivateKey(keyBlock.Bytes)
+	case "RSA PRIVATE KEY":
+		parsedKey, err = x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	default:
+		return nil, fmt.Errorf("unsupported PEM type %q", keyBlock.Type)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s key: %w", keyBlock.Type, err)
+	}
+
+	pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(parsedKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal key to PKCS#8: %w", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8Bytes}), nil
 }
 
 // exportCertManagerNamespaces writes Namespace manifests (01_ prefix) for non-standard

--- a/internal/clusterconfig/certmanagerconfig_test.go
+++ b/internal/clusterconfig/certmanagerconfig_test.go
@@ -19,8 +19,10 @@ package clusterconfig
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
@@ -258,8 +260,8 @@ func TestPreserveCertManagerConfig(t *testing.T) {
 				// Verify the key file contains valid PEM data
 				keyData, err := os.ReadFile(filepath.Join(cryptoDir, cryptoFiles[0].Name()))
 				assert.NoError(t, err)
-				assert.True(t, strings.HasPrefix(string(keyData), "-----BEGIN EC PRIVATE KEY-----"),
-					"key file should contain PEM-encoded private key")
+				assert.True(t, strings.HasPrefix(string(keyData), "-----BEGIN PRIVATE KEY-----"),
+					"key file should contain PKCS#8-encoded private key")
 			},
 		},
 		{
@@ -564,6 +566,60 @@ func TestWriteCertManagerCrypto(t *testing.T) {
 			}(),
 			expectedKeyFiles: 0,
 		},
+		{
+			name: "RSA PKCS#1 key is converted to PKCS#8",
+			secrets: func() map[types.NamespacedName]*unstructured.Unstructured {
+				rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+				tmpl := &x509.Certificate{
+					SerialNumber: big.NewInt(3),
+					Subject:      pkix.Name{CommonName: "rsa.example.com"},
+					NotBefore:    time.Now(),
+					NotAfter:     time.Now().Add(24 * time.Hour),
+				}
+				certDER, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &rsaKey.PublicKey, rsaKey)
+				certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+				rsaDER := x509.MarshalPKCS1PrivateKey(rsaKey)
+				rsaPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: rsaDER})
+				return map[types.NamespacedName]*unstructured.Unstructured{
+					{Name: "rsa-tls", Namespace: "default"}: {
+						Object: map[string]any{
+							"data": map[string]any{
+								"tls.crt": base64.StdEncoding.EncodeToString(certPEM),
+								"tls.key": base64.StdEncoding.EncodeToString(rsaPEM),
+							},
+						},
+					},
+				}
+			}(),
+			expectedKeyFiles: 1,
+		},
+		{
+			name: "Ed25519 certificate is skipped with warning",
+			secrets: func() map[types.NamespacedName]*unstructured.Unstructured {
+				pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+				tmpl := &x509.Certificate{
+					SerialNumber: big.NewInt(4),
+					Subject:      pkix.Name{CommonName: "ed25519.example.com"},
+					NotBefore:    time.Now(),
+					NotAfter:     time.Now().Add(24 * time.Hour),
+				}
+				certDER, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+				certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+				keyDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+				keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+				return map[types.NamespacedName]*unstructured.Unstructured{
+					{Name: "ed25519-tls", Namespace: "default"}: {
+						Object: map[string]any{
+							"data": map[string]any{
+								"tls.crt": base64.StdEncoding.EncodeToString(certPEM),
+								"tls.key": base64.StdEncoding.EncodeToString(keyPEM),
+							},
+						},
+					},
+				}
+			}(),
+			expectedKeyFiles: 0,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -594,10 +650,72 @@ func TestWriteCertManagerCrypto(t *testing.T) {
 				assert.True(t, strings.HasPrefix(entry.Name(), "CN="))
 				data, err := os.ReadFile(filepath.Join(cryptoDir, entry.Name()))
 				assert.NoError(t, err)
-				assert.True(t, strings.HasPrefix(string(data), "-----BEGIN EC PRIVATE KEY-----"))
+				assert.True(t, strings.HasPrefix(string(data), "-----BEGIN PRIVATE KEY-----"))
 			}
 		})
 	}
+}
+
+func TestNormalizeToPKCS8(t *testing.T) {
+	t.Run("EC SEC1 key is converted to PKCS#8", func(t *testing.T) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		assert.NoError(t, err)
+		sec1DER, err := x509.MarshalECPrivateKey(key)
+		assert.NoError(t, err)
+		sec1PEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: sec1DER})
+
+		result, err := normalizeToPKCS8(sec1PEM)
+		assert.NoError(t, err)
+		assert.True(t, strings.HasPrefix(string(result), "-----BEGIN PRIVATE KEY-----"))
+
+		blk, _ := pem.Decode(result)
+		parsed, err := x509.ParsePKCS8PrivateKey(blk.Bytes)
+		assert.NoError(t, err)
+		_, ok := parsed.(*ecdsa.PrivateKey)
+		assert.True(t, ok, "parsed key should be *ecdsa.PrivateKey")
+	})
+
+	t.Run("RSA PKCS#1 key is converted to PKCS#8", func(t *testing.T) {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		pkcs1DER := x509.MarshalPKCS1PrivateKey(key)
+		pkcs1PEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: pkcs1DER})
+
+		result, err := normalizeToPKCS8(pkcs1PEM)
+		assert.NoError(t, err)
+		assert.True(t, strings.HasPrefix(string(result), "-----BEGIN PRIVATE KEY-----"))
+
+		blk, _ := pem.Decode(result)
+		parsed, err := x509.ParsePKCS8PrivateKey(blk.Bytes)
+		assert.NoError(t, err)
+		_, ok := parsed.(*rsa.PrivateKey)
+		assert.True(t, ok, "parsed key should be *rsa.PrivateKey")
+	})
+
+	t.Run("PKCS#8 key passes through unchanged", func(t *testing.T) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		assert.NoError(t, err)
+		pkcs8DER, err := x509.MarshalPKCS8PrivateKey(key)
+		assert.NoError(t, err)
+		pkcs8PEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8DER})
+
+		result, err := normalizeToPKCS8(pkcs8PEM)
+		assert.NoError(t, err)
+		assert.Equal(t, pkcs8PEM, result)
+	})
+
+	t.Run("unsupported PEM type returns error", func(t *testing.T) {
+		badPEM := pem.EncodeToMemory(&pem.Block{Type: "OPENSSH PRIVATE KEY", Bytes: []byte("fake")})
+		_, err := normalizeToPKCS8(badPEM)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported PEM type")
+	})
+
+	t.Run("invalid PEM data returns error", func(t *testing.T) {
+		_, err := normalizeToPKCS8([]byte("not-pem-data"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode PEM block")
+	})
 }
 
 func TestExportCertManagerNamespaces(t *testing.T) {


### PR DESCRIPTION
## Summary

- Recert only supports PKCS#8-encoded private keys (`BEGIN PRIVATE KEY`) but cert-manager produces ECDSA keys in SEC1/PEM format (`BEGIN EC PRIVATE KEY`), causing IBU to fail and auto-rollback when cert-manager certificates use ECDSA.
- Adds a `normalizeToPKCS8` step in `writeCertManagerCrypto` that converts SEC1 EC and PKCS#1 RSA keys to PKCS#8 before writing them to disk for recert `use_key` rules. Keys already in PKCS#8 pass through unchanged.
- Ed25519 certificates are detected and skipped with a warning log, since recert does not yet support Ed25519 (tracked in [CNF-25515](https://redhat.atlassian.net/browse/CNF-25515), recert issue: [rh-ecosystem-edge/recert#1739](https://github.com/rh-ecosystem-edge/recert/issues/1739)).

Fixes: [OCPBUGS-94076](https://issues.redhat.com/browse/OCPBUGS-94076)

## Cert-manager key type compatibility

| Key Algorithm | cert-manager PEM Header | Recert Compatible | This PR |
|---|---|---|---|
| ECDSA (P-256/P-384) | `BEGIN EC PRIVATE KEY` (SEC1) | No | Converted to PKCS#8 |
| RSA | `BEGIN RSA PRIVATE KEY` (PKCS#1) | No | Converted to PKCS#8 |
| ECDSA / RSA | `BEGIN PRIVATE KEY` (PKCS#8) | Yes | Passed through unchanged |
| Ed25519 | `BEGIN PRIVATE KEY` (PKCS#8) | No (unsupported by recert) | Skipped with warning |

## Test plan

- [x] Unit tests for `normalizeToPKCS8` covering EC SEC1, RSA PKCS#1, PKCS#8 passthrough, unsupported PEM types, and invalid PEM data
- [x] Integration tests for `writeCertManagerCrypto` verifying RSA PKCS#1 conversion and Ed25519 skip behavior
- [x] Existing tests updated to assert PKCS#8 output format