### PR TITLE
CNF-26037: Add unit tests for recert config generation, certificate utilities, and controller conditions

### DIFF
--- a/controllers/utils/conditions_test.go
+++ b/controllers/utils/conditions_test.go
@@ -1,0 +1,925 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
+	ipcv1 "github.com/openshift-kni/lifecycle-agent/api/ipconfig/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func newIBU(stage ibuv1.ImageBasedUpgradeStage, conditions ...metav1.Condition) *ibuv1.ImageBasedUpgrade {
+	return &ibuv1.ImageBasedUpgrade{
+		ObjectMeta: metav1.ObjectMeta{Name: "upgrade", Generation: 1},
+		Spec:       ibuv1.ImageBasedUpgradeSpec{Stage: stage},
+		Status:     ibuv1.ImageBasedUpgradeStatus{Conditions: conditions},
+	}
+}
+
+func newIPC(stage ipcv1.IPConfigStage, conditions ...metav1.Condition) *ipcv1.IPConfig {
+	return &ipcv1.IPConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ipconfig", Generation: 1},
+		Spec:       ipcv1.IPConfigSpec{Stage: stage},
+		Status:     ipcv1.IPConfigStatus{Conditions: conditions},
+	}
+}
+
+func cond(typ ConditionType, status metav1.ConditionStatus, reason ConditionReason) metav1.Condition {
+	return metav1.Condition{
+		Type:   string(typ),
+		Status: status,
+		Reason: string(reason),
+	}
+}
+
+func newFailStatusClient() client.Client {
+	return fake.NewClientBuilder().WithScheme(testscheme).WithInterceptorFuncs(interceptor.Funcs{
+		SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+			return fmt.Errorf("injected error")
+		},
+	}).Build()
+}
+
+func TestGetInProgressConditionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		stage    ibuv1.ImageBasedUpgradeStage
+		expected ConditionType
+	}{
+		{"Idle", ibuv1.Stages.Idle, ConditionTypes.Idle},
+		{"Prep", ibuv1.Stages.Prep, ConditionTypes.PrepInProgress},
+		{"Upgrade", ibuv1.Stages.Upgrade, ConditionTypes.UpgradeInProgress},
+		{"Rollback", ibuv1.Stages.Rollback, ConditionTypes.RollbackInProgress},
+		{"unknown stage", "Unknown", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetInProgressConditionType(tt.stage))
+		})
+	}
+}
+
+func TestGetCompletedConditionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		stage    ibuv1.ImageBasedUpgradeStage
+		expected ConditionType
+	}{
+		{"Idle", ibuv1.Stages.Idle, ConditionTypes.Idle},
+		{"Prep", ibuv1.Stages.Prep, ConditionTypes.PrepCompleted},
+		{"Upgrade", ibuv1.Stages.Upgrade, ConditionTypes.UpgradeCompleted},
+		{"Rollback", ibuv1.Stages.Rollback, ConditionTypes.RollbackCompleted},
+		{"unknown stage", "Unknown", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetCompletedConditionType(tt.stage))
+		})
+	}
+}
+
+func TestGetIPInProgressConditionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		stage    ipcv1.IPConfigStage
+		expected ConditionType
+	}{
+		{"Idle", ipcv1.IPStages.Idle, ConditionTypes.Idle},
+		{"Config", ipcv1.IPStages.Config, ConditionTypes.ConfigInProgress},
+		{"Rollback", ipcv1.IPStages.Rollback, ConditionTypes.RollbackInProgress},
+		{"unknown stage", "Unknown", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetIPInProgressConditionType(tt.stage))
+		})
+	}
+}
+
+func TestGetIPCompletedConditionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		stage    ipcv1.IPConfigStage
+		expected ConditionType
+	}{
+		{"Idle", ipcv1.IPStages.Idle, ConditionTypes.Idle},
+		{"Config", ipcv1.IPStages.Config, ConditionTypes.ConfigCompleted},
+		{"Rollback", ipcv1.IPStages.Rollback, ConditionTypes.RollbackCompleted},
+		{"unknown stage", "Unknown", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetIPCompletedConditionType(tt.stage))
+		})
+	}
+}
+
+func TestSetStatusCondition(t *testing.T) {
+	tests := []struct {
+		name       string
+		initial    []metav1.Condition
+		typ        ConditionType
+		reason     ConditionReason
+		status     metav1.ConditionStatus
+		message    string
+		assertFunc func(t *testing.T, conditions []metav1.Condition)
+	}{
+		{
+			name:    "adds new condition to empty slice",
+			initial: []metav1.Condition{},
+			typ:     ConditionTypes.PrepInProgress,
+			reason:  ConditionReasons.InProgress,
+			status:  metav1.ConditionTrue,
+			message: "prep started",
+			assertFunc: func(t *testing.T, conditions []metav1.Condition) {
+				assert.Len(t, conditions, 1)
+				assert.Equal(t, string(ConditionTypes.PrepInProgress), conditions[0].Type)
+				assert.Equal(t, metav1.ConditionTrue, conditions[0].Status)
+				assert.Equal(t, string(ConditionReasons.InProgress), conditions[0].Reason)
+				assert.Equal(t, "prep started", conditions[0].Message)
+			},
+		},
+		{
+			name: "updates existing condition status",
+			initial: []metav1.Condition{
+				cond(ConditionTypes.PrepInProgress, metav1.ConditionTrue, ConditionReasons.InProgress),
+			},
+			typ:     ConditionTypes.PrepInProgress,
+			reason:  ConditionReasons.Completed,
+			status:  metav1.ConditionFalse,
+			message: "prep done",
+			assertFunc: func(t *testing.T, conditions []metav1.Condition) {
+				assert.Len(t, conditions, 1)
+				assert.Equal(t, metav1.ConditionFalse, conditions[0].Status)
+				assert.Equal(t, string(ConditionReasons.Completed), conditions[0].Reason)
+			},
+		},
+		{
+			name: "Idle condition reorder when status changes and not last",
+			initial: []metav1.Condition{
+				cond(ConditionTypes.Idle, metav1.ConditionTrue, ConditionReasons.Idle),
+				cond(ConditionTypes.PrepInProgress, metav1.ConditionTrue, ConditionReasons.InProgress),
+			},
+			typ:     ConditionTypes.Idle,
+			reason:  ConditionReasons.InProgress,
+			status:  metav1.ConditionFalse,
+			message: "becoming not idle",
+			assertFunc: func(t *testing.T, conditions []metav1.Condition) {
+				assert.Equal(t, metav1.ConditionFalse, conditions[len(conditions)-1].Status)
+				assert.Equal(t, string(ConditionTypes.Idle), conditions[len(conditions)-1].Type)
+			},
+		},
+		{
+			name: "Idle condition no reorder when already last",
+			initial: []metav1.Condition{
+				cond(ConditionTypes.PrepInProgress, metav1.ConditionTrue, ConditionReasons.InProgress),
+				cond(ConditionTypes.Idle, metav1.ConditionTrue, ConditionReasons.Idle),
+			},
+			typ:     ConditionTypes.Idle,
+			reason:  ConditionReasons.InProgress,
+			status:  metav1.ConditionFalse,
+			message: "still last",
+			assertFunc: func(t *testing.T, conditions []metav1.Condition) {
+				assert.Equal(t, string(ConditionTypes.Idle), conditions[len(conditions)-1].Type)
+				assert.Equal(t, metav1.ConditionFalse, conditions[len(conditions)-1].Status)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conditions := make([]metav1.Condition, len(tt.initial))
+			copy(conditions, tt.initial)
+			SetStatusCondition(&conditions, tt.typ, tt.reason, tt.status, tt.message, 1)
+			tt.assertFunc(t, conditions)
+		})
+	}
+}
+
+func TestResetStatusConditions(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial []metav1.Condition
+	}{
+		{
+			name:    "empty conditions",
+			initial: []metav1.Condition{},
+		},
+		{
+			name: "removes non-Idle conditions and sets Idle true",
+			initial: []metav1.Condition{
+				cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InProgress),
+				cond(ConditionTypes.PrepInProgress, metav1.ConditionTrue, ConditionReasons.InProgress),
+				cond(ConditionTypes.PrepCompleted, metav1.ConditionTrue, ConditionReasons.Completed),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conditions := make([]metav1.Condition, len(tt.initial))
+			copy(conditions, tt.initial)
+			ResetStatusConditions(&conditions, 1)
+			assert.Len(t, conditions, 1)
+			assert.Equal(t, string(ConditionTypes.Idle), conditions[0].Type)
+			assert.Equal(t, metav1.ConditionTrue, conditions[0].Status)
+			assert.Equal(t, string(ConditionReasons.Idle), conditions[0].Reason)
+		})
+	}
+}
+
+func TestIsIdleConditionTrue(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		expected   bool
+	}{
+		{"empty conditions", nil, false},
+		{"no Idle condition", []metav1.Condition{cond(ConditionTypes.PrepInProgress, metav1.ConditionTrue, ConditionReasons.InProgress)}, false},
+		{"Idle true", []metav1.Condition{cond(ConditionTypes.Idle, metav1.ConditionTrue, ConditionReasons.Idle)}, true},
+		{"Idle false", []metav1.Condition{cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InProgress)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsIdleConditionTrue(tt.conditions))
+		})
+	}
+}
+
+func TestIsStageCompleted(t *testing.T) {
+	tests := []struct {
+		name     string
+		ibu      *ibuv1.ImageBasedUpgrade
+		stage    ibuv1.ImageBasedUpgradeStage
+		expected bool
+	}{
+		{
+			"completed true",
+			newIBU(ibuv1.Stages.Upgrade, cond(ConditionTypes.UpgradeCompleted, metav1.ConditionTrue, ConditionReasons.Completed)),
+			ibuv1.Stages.Upgrade,
+			true,
+		},
+		{
+			"completed false (failed)",
+			newIBU(ibuv1.Stages.Upgrade, cond(ConditionTypes.UpgradeCompleted, metav1.ConditionFalse, ConditionReasons.Failed)),
+			ibuv1.Stages.Upgrade,
+			false,
+		},
+		{
+			"no completed condition",
+			newIBU(ibuv1.Stages.Upgrade),
+			ibuv1.Stages.Upgrade,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsStageCompleted(tt.ibu, tt.stage))
+		})
+	}
+}
+
+func TestIsStageFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		ibu      *ibuv1.ImageBasedUpgrade
+		stage    ibuv1.ImageBasedUpgradeStage
+		expected bool
+	}{
+		{
+			"completed false means failed",
+			newIBU(ibuv1.Stages.Prep, cond(ConditionTypes.PrepCompleted, metav1.ConditionFalse, ConditionReasons.Failed)),
+			ibuv1.Stages.Prep,
+			true,
+		},
+		{
+			"completed true means not failed",
+			newIBU(ibuv1.Stages.Prep, cond(ConditionTypes.PrepCompleted, metav1.ConditionTrue, ConditionReasons.Completed)),
+			ibuv1.Stages.Prep,
+			false,
+		},
+		{
+			"no condition",
+			newIBU(ibuv1.Stages.Prep),
+			ibuv1.Stages.Prep,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsStageFailed(tt.ibu, tt.stage))
+		})
+	}
+}
+
+func TestIsStageCompletedOrFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		ibu      *ibuv1.ImageBasedUpgrade
+		stage    ibuv1.ImageBasedUpgradeStage
+		expected bool
+	}{
+		{"completed", newIBU(ibuv1.Stages.Upgrade, cond(ConditionTypes.UpgradeCompleted, metav1.ConditionTrue, ConditionReasons.Completed)), ibuv1.Stages.Upgrade, true},
+		{"failed", newIBU(ibuv1.Stages.Upgrade, cond(ConditionTypes.UpgradeCompleted, metav1.ConditionFalse, ConditionReasons.Failed)), ibuv1.Stages.Upgrade, true},
+		{"no condition", newIBU(ibuv1.Stages.Upgrade), ibuv1.Stages.Upgrade, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsStageCompletedOrFailed(tt.ibu, tt.stage))
+		})
+	}
+}
+
+func TestIsStageInProgress(t *testing.T) {
+	tests := []struct {
+		name     string
+		ibu      *ibuv1.ImageBasedUpgrade
+		stage    ibuv1.ImageBasedUpgradeStage
+		expected bool
+	}{
+		{
+			"non-Idle stage in progress",
+			newIBU(ibuv1.Stages.Prep, cond(ConditionTypes.PrepInProgress, metav1.ConditionTrue, ConditionReasons.InProgress)),
+			ibuv1.Stages.Prep,
+			true,
+		},
+		{
+			"non-Idle stage not in progress",
+			newIBU(ibuv1.Stages.Prep, cond(ConditionTypes.PrepInProgress, metav1.ConditionFalse, ConditionReasons.Completed)),
+			ibuv1.Stages.Prep,
+			false,
+		},
+		{
+			"non-Idle stage no condition",
+			newIBU(ibuv1.Stages.Prep),
+			ibuv1.Stages.Prep,
+			false,
+		},
+		{
+			"Idle stage with True status is not in progress",
+			newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionTrue, ConditionReasons.Idle)),
+			ibuv1.Stages.Idle,
+			false,
+		},
+		{
+			"Idle stage nil condition is not in progress",
+			newIBU(ibuv1.Stages.Idle),
+			ibuv1.Stages.Idle,
+			false,
+		},
+		{
+			"Idle stage Aborting is in progress",
+			newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.Aborting)),
+			ibuv1.Stages.Idle,
+			true,
+		},
+		{
+			"Idle stage Finalizing is in progress",
+			newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.Finalizing)),
+			ibuv1.Stages.Idle,
+			true,
+		},
+		{
+			"Idle stage AbortFailed is in progress",
+			newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.AbortFailed)),
+			ibuv1.Stages.Idle,
+			true,
+		},
+		{
+			"Idle stage FinalizeFailed is in progress",
+			newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.FinalizeFailed)),
+			ibuv1.Stages.Idle,
+			true,
+		},
+		{
+			"Idle stage InProgress reason is not in progress",
+			newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InProgress)),
+			ibuv1.Stages.Idle,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsStageInProgress(tt.ibu, tt.stage))
+		})
+	}
+}
+
+func TestGetInProgressStage(t *testing.T) {
+	tests := []struct {
+		name     string
+		ibu      *ibuv1.ImageBasedUpgrade
+		expected ibuv1.ImageBasedUpgradeStage
+	}{
+		{"Prep in progress", newIBU(ibuv1.Stages.Prep, cond(ConditionTypes.PrepInProgress, metav1.ConditionTrue, ConditionReasons.InProgress)), ibuv1.Stages.Prep},
+		{"Idle aborting", newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.Aborting)), ibuv1.Stages.Idle},
+		{"none in progress", newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionTrue, ConditionReasons.Idle)), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetInProgressStage(tt.ibu))
+		})
+	}
+}
+
+func TestGetInProgressCondition(t *testing.T) {
+	ibu := newIBU(ibuv1.Stages.Upgrade, cond(ConditionTypes.UpgradeInProgress, metav1.ConditionTrue, ConditionReasons.InProgress))
+	c := GetInProgressCondition(ibu, ibuv1.Stages.Upgrade)
+	assert.NotNil(t, c)
+	assert.Equal(t, string(ConditionTypes.UpgradeInProgress), c.Type)
+
+	assert.Nil(t, GetInProgressCondition(ibu, ibuv1.Stages.Prep))
+	assert.Nil(t, GetInProgressCondition(ibu, "Unknown"))
+}
+
+func TestGetCompletedCondition(t *testing.T) {
+	ibu := newIBU(ibuv1.Stages.Upgrade, cond(ConditionTypes.UpgradeCompleted, metav1.ConditionTrue, ConditionReasons.Completed))
+	c := GetCompletedCondition(ibu, ibuv1.Stages.Upgrade)
+	assert.NotNil(t, c)
+	assert.Equal(t, string(ConditionTypes.UpgradeCompleted), c.Type)
+
+	assert.Nil(t, GetCompletedCondition(ibu, ibuv1.Stages.Prep))
+	assert.Nil(t, GetCompletedCondition(ibu, "Unknown"))
+}
+
+func TestIBUSetStatusInProgress(t *testing.T) {
+	tests := []struct {
+		name   string
+		stage  ibuv1.ImageBasedUpgradeStage
+		setter func(*ibuv1.ImageBasedUpgrade, string)
+	}{
+		{"Prep", ibuv1.Stages.Prep, SetPrepStatusInProgress},
+		{"Upgrade", ibuv1.Stages.Upgrade, SetUpgradeStatusInProgress},
+		{"Rollback", ibuv1.Stages.Rollback, SetRollbackStatusInProgress},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ibu := newIBU(tt.stage)
+			tt.setter(ibu, "in progress")
+			c := GetInProgressCondition(ibu, tt.stage)
+			assert.NotNil(t, c)
+			assert.Equal(t, metav1.ConditionTrue, c.Status)
+			assert.Equal(t, string(ConditionReasons.InProgress), c.Reason)
+			assert.Equal(t, "in progress", c.Message)
+		})
+	}
+}
+
+func TestIBUSetStatusFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		stage  ibuv1.ImageBasedUpgradeStage
+		setter func(*ibuv1.ImageBasedUpgrade, string)
+	}{
+		{"Prep", ibuv1.Stages.Prep, SetPrepStatusFailed},
+		{"Upgrade", ibuv1.Stages.Upgrade, SetUpgradeStatusFailed},
+		{"Rollback", ibuv1.Stages.Rollback, SetRollbackStatusFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ibu := newIBU(tt.stage)
+			tt.setter(ibu, "something broke")
+
+			completed := GetCompletedCondition(ibu, tt.stage)
+			assert.NotNil(t, completed)
+			assert.Equal(t, metav1.ConditionFalse, completed.Status)
+			assert.Equal(t, string(ConditionReasons.Failed), completed.Reason)
+
+			inProgress := GetInProgressCondition(ibu, tt.stage)
+			assert.NotNil(t, inProgress)
+			assert.Equal(t, metav1.ConditionFalse, inProgress.Status)
+			assert.Equal(t, string(ConditionReasons.Failed), inProgress.Reason)
+			assert.Equal(t, "something broke", inProgress.Message)
+		})
+	}
+}
+
+func TestIBUSetStatusCompleted(t *testing.T) {
+	tests := []struct {
+		name   string
+		stage  ibuv1.ImageBasedUpgradeStage
+		setter func(*ibuv1.ImageBasedUpgrade)
+	}{
+		{"Upgrade", ibuv1.Stages.Upgrade, SetUpgradeStatusCompleted},
+		{"Rollback", ibuv1.Stages.Rollback, SetRollbackStatusCompleted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ibu := newIBU(tt.stage)
+			tt.setter(ibu)
+
+			inProgress := GetInProgressCondition(ibu, tt.stage)
+			assert.NotNil(t, inProgress)
+			assert.Equal(t, metav1.ConditionFalse, inProgress.Status)
+			assert.Equal(t, string(ConditionReasons.Completed), inProgress.Reason)
+
+			completed := GetCompletedCondition(ibu, tt.stage)
+			assert.NotNil(t, completed)
+			assert.Equal(t, metav1.ConditionTrue, completed.Status)
+			assert.Equal(t, string(ConditionReasons.Completed), completed.Reason)
+		})
+	}
+}
+
+func TestSetPrepStatusCompleted(t *testing.T) {
+	ibu := newIBU(ibuv1.Stages.Prep)
+	SetPrepStatusCompleted(ibu, "done")
+
+	inProgress := GetInProgressCondition(ibu, ibuv1.Stages.Prep)
+	assert.NotNil(t, inProgress)
+	assert.Equal(t, metav1.ConditionFalse, inProgress.Status)
+
+	completed := GetCompletedCondition(ibu, ibuv1.Stages.Prep)
+	assert.NotNil(t, completed)
+	assert.Equal(t, metav1.ConditionTrue, completed.Status)
+}
+
+func TestSetUpgradeStatusRollbackRequested(t *testing.T) {
+	ibu := newIBU(ibuv1.Stages.Upgrade)
+	SetUpgradeStatusRollbackRequested(ibu)
+
+	completed := GetCompletedCondition(ibu, ibuv1.Stages.Upgrade)
+	assert.NotNil(t, completed)
+	assert.Equal(t, metav1.ConditionFalse, completed.Status)
+	assert.Equal(t, RollbackRequested, completed.Message)
+
+	inProgress := GetInProgressCondition(ibu, ibuv1.Stages.Upgrade)
+	assert.NotNil(t, inProgress)
+	assert.Equal(t, metav1.ConditionFalse, inProgress.Status)
+	assert.Equal(t, RollbackRequested, inProgress.Message)
+}
+
+func TestSetIdleStatusInProgress(t *testing.T) {
+	ibu := newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionTrue, ConditionReasons.Idle))
+	SetIdleStatusInProgress(ibu, ConditionReasons.Aborting, Aborting)
+	idle := GetInProgressCondition(ibu, ibuv1.Stages.Idle)
+	assert.NotNil(t, idle)
+	assert.Equal(t, metav1.ConditionFalse, idle.Status)
+	assert.Equal(t, string(ConditionReasons.Aborting), idle.Reason)
+	assert.Equal(t, Aborting, idle.Message)
+}
+
+func TestSetStatusInvalidTransition(t *testing.T) {
+	ibu := newIBU(ibuv1.Stages.Prep)
+	SetStatusInvalidTransition(ibu, "cannot go there")
+	c := GetInProgressCondition(ibu, ibuv1.Stages.Prep)
+	assert.NotNil(t, c)
+	assert.Equal(t, string(ConditionReasons.InvalidTransition), c.Reason)
+	assert.Equal(t, metav1.ConditionFalse, c.Status)
+	assert.Equal(t, "cannot go there", c.Message)
+}
+
+func TestClearInvalidTransitionStatusConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		ibu        *ibuv1.ImageBasedUpgrade
+		assertFunc func(t *testing.T, ibu *ibuv1.ImageBasedUpgrade)
+	}{
+		{
+			name: "Idle with InvalidTransition reverts to InProgress",
+			ibu:  newIBU(ibuv1.Stages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InvalidTransition)),
+			assertFunc: func(t *testing.T, ibu *ibuv1.ImageBasedUpgrade) {
+				c := GetInProgressCondition(ibu, ibuv1.Stages.Idle)
+				assert.NotNil(t, c)
+				assert.Equal(t, string(ConditionReasons.InProgress), c.Reason)
+			},
+		},
+		{
+			name: "PrepInProgress with InvalidTransition is removed",
+			ibu:  newIBU(ibuv1.Stages.Prep, cond(ConditionTypes.PrepInProgress, metav1.ConditionFalse, ConditionReasons.InvalidTransition)),
+			assertFunc: func(t *testing.T, ibu *ibuv1.ImageBasedUpgrade) {
+				assert.Nil(t, GetInProgressCondition(ibu, ibuv1.Stages.Prep))
+			},
+		},
+		{
+			name: "no invalid transitions is no-op",
+			ibu:  newIBU(ibuv1.Stages.Prep, cond(ConditionTypes.PrepInProgress, metav1.ConditionTrue, ConditionReasons.InProgress)),
+			assertFunc: func(t *testing.T, ibu *ibuv1.ImageBasedUpgrade) {
+				c := GetInProgressCondition(ibu, ibuv1.Stages.Prep)
+				assert.NotNil(t, c)
+				assert.Equal(t, string(ConditionReasons.InProgress), c.Reason)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ClearInvalidTransitionStatusConditions(tt.ibu)
+			tt.assertFunc(t, tt.ibu)
+		})
+	}
+}
+
+func TestUpdateIBUStatus(t *testing.T) {
+	t.Run("nil client returns nil", func(t *testing.T) {
+		ibu := newIBU(ibuv1.Stages.Upgrade)
+		assert.NoError(t, UpdateIBUStatus(context.Background(), nil, ibu))
+	})
+
+	t.Run("sets ObservedGeneration on matching conditions", func(t *testing.T) {
+		ibu := newIBU(ibuv1.Stages.Upgrade,
+			cond(ConditionTypes.UpgradeInProgress, metav1.ConditionTrue, ConditionReasons.InProgress),
+			cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InProgress),
+		)
+		ibu.Generation = 5
+		testscheme.AddKnownTypes(ibuv1.GroupVersion, &ibuv1.ImageBasedUpgrade{})
+		c := fake.NewClientBuilder().WithScheme(testscheme).WithObjects(ibu).WithStatusSubresource(ibu).Build()
+		err := UpdateIBUStatus(context.Background(), c, ibu)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(5), ibu.Status.ObservedGeneration)
+		for _, cond := range ibu.Status.Conditions {
+			if cond.Type == string(ConditionTypes.UpgradeInProgress) {
+				assert.Equal(t, int64(5), cond.ObservedGeneration)
+			}
+		}
+	})
+
+	t.Run("returns error when status update fails", func(t *testing.T) {
+		ibu := newIBU(ibuv1.Stages.Upgrade)
+		err := UpdateIBUStatus(context.Background(), newFailStatusClient(), ibu)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update IBU status")
+	})
+}
+
+func TestUpdateIPCStatus(t *testing.T) {
+	t.Run("nil client returns error", func(t *testing.T) {
+		ipc := newIPC(ipcv1.IPStages.Config)
+		err := UpdateIPCStatus(context.Background(), nil, ipc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client is nil")
+	})
+
+	t.Run("sets ObservedGeneration on matching conditions", func(t *testing.T) {
+		ipc := newIPC(ipcv1.IPStages.Config,
+			cond(ConditionTypes.ConfigInProgress, metav1.ConditionTrue, ConditionReasons.InProgress),
+			cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InProgress),
+		)
+		ipc.Generation = 3
+		testscheme.AddKnownTypes(ipcv1.GroupVersion, &ipcv1.IPConfig{})
+		c := fake.NewClientBuilder().WithScheme(testscheme).WithObjects(ipc).WithStatusSubresource(ipc).Build()
+		err := UpdateIPCStatus(context.Background(), c, ipc)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(3), ipc.Status.ObservedGeneration)
+	})
+
+	t.Run("returns error when status update fails", func(t *testing.T) {
+		ipc := newIPC(ipcv1.IPStages.Config)
+		err := UpdateIPCStatus(context.Background(), newFailStatusClient(), ipc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update IPConfig status")
+	})
+}
+
+func TestIsIPStageCompleted(t *testing.T) {
+	tests := []struct {
+		name     string
+		ipc      *ipcv1.IPConfig
+		stage    ipcv1.IPConfigStage
+		expected bool
+	}{
+		{"completed true", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigCompleted, metav1.ConditionTrue, ConditionReasons.Completed)), ipcv1.IPStages.Config, true},
+		{"completed false", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigCompleted, metav1.ConditionFalse, ConditionReasons.Failed)), ipcv1.IPStages.Config, false},
+		{"no condition", newIPC(ipcv1.IPStages.Config), ipcv1.IPStages.Config, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsIPStageCompleted(tt.ipc, tt.stage))
+		})
+	}
+}
+
+func TestIsIPStageFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		ipc      *ipcv1.IPConfig
+		stage    ipcv1.IPConfigStage
+		expected bool
+	}{
+		{"completed false is failed", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigCompleted, metav1.ConditionFalse, ConditionReasons.Failed)), ipcv1.IPStages.Config, true},
+		{"completed true is not failed", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigCompleted, metav1.ConditionTrue, ConditionReasons.Completed)), ipcv1.IPStages.Config, false},
+		{"no condition", newIPC(ipcv1.IPStages.Config), ipcv1.IPStages.Config, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsIPStageFailed(tt.ipc, tt.stage))
+		})
+	}
+}
+
+func TestIsIPStageCompletedOrFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		ipc      *ipcv1.IPConfig
+		stage    ipcv1.IPConfigStage
+		expected bool
+	}{
+		{"completed", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigCompleted, metav1.ConditionTrue, ConditionReasons.Completed)), ipcv1.IPStages.Config, true},
+		{"failed", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigCompleted, metav1.ConditionFalse, ConditionReasons.Failed)), ipcv1.IPStages.Config, true},
+		{"no condition", newIPC(ipcv1.IPStages.Config), ipcv1.IPStages.Config, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsIPStageCompletedOrFailed(tt.ipc, tt.stage))
+		})
+	}
+}
+
+func TestIsIPStageInProgress(t *testing.T) {
+	tests := []struct {
+		name     string
+		ipc      *ipcv1.IPConfig
+		stage    ipcv1.IPConfigStage
+		expected bool
+	}{
+		{"Config in progress", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigInProgress, metav1.ConditionTrue, ConditionReasons.InProgress)), ipcv1.IPStages.Config, true},
+		{"Config not in progress", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigInProgress, metav1.ConditionFalse, ConditionReasons.Completed)), ipcv1.IPStages.Config, false},
+		{"Idle with ConditionFalse and InProgress reason is in progress", newIPC(ipcv1.IPStages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InProgress)), ipcv1.IPStages.Idle, true},
+		{"Idle with ConditionTrue is not in progress", newIPC(ipcv1.IPStages.Idle, cond(ConditionTypes.Idle, metav1.ConditionTrue, ConditionReasons.Idle)), ipcv1.IPStages.Idle, false},
+		{"no condition", newIPC(ipcv1.IPStages.Config), ipcv1.IPStages.Config, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsIPStageInProgress(tt.ipc, tt.stage))
+		})
+	}
+}
+
+func TestGetIPInProgressStage(t *testing.T) {
+	tests := []struct {
+		name     string
+		ipc      *ipcv1.IPConfig
+		expected ipcv1.IPConfigStage
+	}{
+		{"Config in progress", newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigInProgress, metav1.ConditionTrue, ConditionReasons.InProgress)), ipcv1.IPStages.Config},
+		{"Idle in progress", newIPC(ipcv1.IPStages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InProgress)), ipcv1.IPStages.Idle},
+		{"none in progress", newIPC(ipcv1.IPStages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.Idle)), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetIPInProgressStage(tt.ipc))
+		})
+	}
+}
+
+func TestGetIPInProgressCondition(t *testing.T) {
+	ipc := newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigInProgress, metav1.ConditionTrue, ConditionReasons.InProgress))
+	c := GetIPInProgressCondition(ipc, ipcv1.IPStages.Config)
+	assert.NotNil(t, c)
+	assert.Equal(t, string(ConditionTypes.ConfigInProgress), c.Type)
+
+	assert.Nil(t, GetIPInProgressCondition(ipc, ipcv1.IPStages.Rollback))
+	assert.Nil(t, GetIPInProgressCondition(ipc, "Unknown"))
+}
+
+func TestGetIPCompletedCondition(t *testing.T) {
+	ipc := newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigCompleted, metav1.ConditionTrue, ConditionReasons.Completed))
+	c := GetIPCompletedCondition(ipc, ipcv1.IPStages.Config)
+	assert.NotNil(t, c)
+	assert.Equal(t, string(ConditionTypes.ConfigCompleted), c.Type)
+
+	assert.Nil(t, GetIPCompletedCondition(ipc, ipcv1.IPStages.Rollback))
+	assert.Nil(t, GetIPCompletedCondition(ipc, "Unknown"))
+}
+
+func TestIPSetStatusInProgress(t *testing.T) {
+	tests := []struct {
+		name   string
+		stage  ipcv1.IPConfigStage
+		setter func(*ipcv1.IPConfig, string)
+	}{
+		{"Config", ipcv1.IPStages.Config, SetIPConfigStatusInProgress},
+		{"Rollback", ipcv1.IPStages.Rollback, SetIPRollbackStatusInProgress},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipc := newIPC(tt.stage)
+			tt.setter(ipc, "in progress")
+			c := GetIPInProgressCondition(ipc, tt.stage)
+			assert.NotNil(t, c)
+			assert.Equal(t, metav1.ConditionTrue, c.Status)
+			assert.Equal(t, string(ConditionReasons.InProgress), c.Reason)
+		})
+	}
+}
+
+func TestIPSetStatusFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		stage  ipcv1.IPConfigStage
+		setter func(*ipcv1.IPConfig, string)
+	}{
+		{"Config", ipcv1.IPStages.Config, SetIPConfigStatusFailed},
+		{"Rollback", ipcv1.IPStages.Rollback, SetIPRollbackStatusFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipc := newIPC(tt.stage)
+			tt.setter(ipc, "something broke")
+
+			completed := GetIPCompletedCondition(ipc, tt.stage)
+			assert.NotNil(t, completed)
+			assert.Equal(t, metav1.ConditionFalse, completed.Status)
+			assert.Equal(t, string(ConditionReasons.Failed), completed.Reason)
+
+			inProgress := GetIPInProgressCondition(ipc, tt.stage)
+			assert.NotNil(t, inProgress)
+			assert.Equal(t, metav1.ConditionFalse, inProgress.Status)
+			assert.Equal(t, string(ConditionReasons.Failed), inProgress.Reason)
+		})
+	}
+}
+
+func TestIPSetStatusCompleted(t *testing.T) {
+	tests := []struct {
+		name   string
+		stage  ipcv1.IPConfigStage
+		setter func(*ipcv1.IPConfig, string)
+	}{
+		{"Config", ipcv1.IPStages.Config, SetIPConfigStatusCompleted},
+		{"Rollback", ipcv1.IPStages.Rollback, SetIPRollbackStatusCompleted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipc := newIPC(tt.stage)
+			tt.setter(ipc, "done")
+
+			inProgress := GetIPInProgressCondition(ipc, tt.stage)
+			assert.NotNil(t, inProgress)
+			assert.Equal(t, metav1.ConditionFalse, inProgress.Status)
+
+			completed := GetIPCompletedCondition(ipc, tt.stage)
+			assert.NotNil(t, completed)
+			assert.Equal(t, metav1.ConditionTrue, completed.Status)
+		})
+	}
+}
+
+func TestSetIPIdleStatusFalse(t *testing.T) {
+	ipc := newIPC(ipcv1.IPStages.Idle, cond(ConditionTypes.Idle, metav1.ConditionTrue, ConditionReasons.Idle))
+	SetIPIdleStatusFalse(ipc, ConditionReasons.InProgress, InProgress)
+	c := GetIPInProgressCondition(ipc, ipcv1.IPStages.Idle)
+	assert.NotNil(t, c)
+	assert.Equal(t, metav1.ConditionFalse, c.Status)
+	assert.Equal(t, string(ConditionReasons.InProgress), c.Reason)
+}
+
+func TestSetIPStatusInvalidTransition(t *testing.T) {
+	t.Run("sets InvalidTransition on known stage", func(t *testing.T) {
+		ipc := newIPC(ipcv1.IPStages.Config)
+		SetIPStatusInvalidTransition(ipc, "not allowed")
+		c := GetIPInProgressCondition(ipc, ipcv1.IPStages.Config)
+		assert.NotNil(t, c)
+		assert.Equal(t, string(ConditionReasons.InvalidTransition), c.Reason)
+		assert.Equal(t, metav1.ConditionFalse, c.Status)
+	})
+
+	t.Run("no-op on unknown stage", func(t *testing.T) {
+		ipc := newIPC("Unknown")
+		SetIPStatusInvalidTransition(ipc, "msg")
+		assert.Empty(t, ipc.Status.Conditions)
+	})
+}
+
+func TestClearIPInvalidTransitionStatusConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		ipc        *ipcv1.IPConfig
+		assertFunc func(t *testing.T, ipc *ipcv1.IPConfig)
+	}{
+		{
+			name: "Idle with InvalidTransition is replaced with ConfigurationInProgress",
+			ipc:  newIPC(ipcv1.IPStages.Idle, cond(ConditionTypes.Idle, metav1.ConditionFalse, ConditionReasons.InvalidTransition)),
+			assertFunc: func(t *testing.T, ipc *ipcv1.IPConfig) {
+				c := GetIPInProgressCondition(ipc, ipcv1.IPStages.Idle)
+				assert.NotNil(t, c)
+				assert.Equal(t, string(ConditionReasons.ConfigurationInProgress), c.Reason)
+			},
+		},
+		{
+			name: "ConfigInProgress with InvalidTransition is removed",
+			ipc:  newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigInProgress, metav1.ConditionFalse, ConditionReasons.InvalidTransition)),
+			assertFunc: func(t *testing.T, ipc *ipcv1.IPConfig) {
+				assert.Nil(t, GetIPInProgressCondition(ipc, ipcv1.IPStages.Config))
+			},
+		},
+		{
+			name: "no invalid transitions is no-op",
+			ipc:  newIPC(ipcv1.IPStages.Config, cond(ConditionTypes.ConfigInProgress, metav1.ConditionTrue, ConditionReasons.InProgress)),
+			assertFunc: func(t *testing.T, ipc *ipcv1.IPConfig) {
+				c := GetIPInProgressCondition(ipc, ipcv1.IPStages.Config)
+				assert.NotNil(t, c)
+				assert.Equal(t, string(ConditionReasons.InProgress), c.Reason)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ClearIPInvalidTransitionStatusConditions(tt.ipc)
+			tt.assertFunc(t, tt.ipc)
+		})
+	}
+}

--- a/internal/healthcheck/healthcheck_test.go
+++ b/internal/healthcheck/healthcheck_test.go
@@ -1244,6 +1244,54 @@ func TestAreCertificateSigningRequestsReady(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "certificateSigningRequest (csr) test-csr not yet approved",
 		},
+		{
+			name: "Fail with no conditions at all",
+			objects: []runtime.Object{
+				&k8sv1.CertificateSigningRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pending-csr",
+					},
+					Status: k8sv1.CertificateSigningRequestStatus{
+						Conditions: []k8sv1.CertificateSigningRequestCondition{},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "certificateSigningRequest (csr) pending-csr not yet approved",
+		},
+		{
+			name:    "Success with empty CSR list",
+			objects: []runtime.Object{},
+			wantErr: false,
+		},
+		{
+			name: "Fail when one of multiple CSRs is not approved",
+			objects: []runtime.Object{
+				&k8sv1.CertificateSigningRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "approved-csr",
+					},
+					Status: k8sv1.CertificateSigningRequestStatus{
+						Conditions: []k8sv1.CertificateSigningRequestCondition{
+							{
+								Type:   k8sv1.CertificateApproved,
+								Status: v1.ConditionStatus(metav1.ConditionTrue),
+							},
+						},
+					},
+				},
+				&k8sv1.CertificateSigningRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "unapproved-csr",
+					},
+					Status: k8sv1.CertificateSigningRequestStatus{
+						Conditions: []k8sv1.CertificateSigningRequestCondition{},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "certificateSigningRequest (csr) unapproved-csr not yet approved",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/recert/recert_test.go
+++ b/internal/recert/recert_test.go
@@ -1,11 +1,14 @@
 package recert
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
+	"github.com/openshift-kni/lifecycle-agent/internal/common"
+	"github.com/openshift-kni/lifecycle-agent/lca-cli/seedclusterinfo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -95,6 +98,26 @@ func TestSetRecertTrustedCaBundleFromSeedReconfigAdditionaTrustBundle(t *testing
 				ProxyConfigmapBundle: "-----BEGIN CERTIFICATE-----\ncustom-ca\n-----END CERTIFICATE-----",
 			},
 			expectedError: true,
+		},
+		{
+			name: "cluster trust bundle name sets name-only proxy bundle",
+			additionalTrustBundle: seedreconfig.AdditionalTrustBundle{
+				ProxyConfigmapName:   "user-ca-bundle",
+				ProxyConfigmapBundle: "-----BEGIN CERTIFICATE-----\nbundle\n-----END CERTIFICATE-----",
+			},
+			expectedError:        false,
+			expectedUserCaBundle: "",
+			expectedProxyBundle:  "user-ca-bundle:",
+		},
+		{
+			name: "custom configmap name sets name:bundle proxy bundle",
+			additionalTrustBundle: seedreconfig.AdditionalTrustBundle{
+				ProxyConfigmapName:   "custom-proxy-ca",
+				ProxyConfigmapBundle: "custom-bundle-content",
+			},
+			expectedError:        false,
+			expectedUserCaBundle: "",
+			expectedProxyBundle:  "custom-proxy-ca:custom-bundle-content",
 		},
 	}
 
@@ -240,4 +263,670 @@ func TestCreateBaseRecertConfig(t *testing.T) {
 	assert.Equal(t, cryptoFiles, config.CryptoFiles)
 	assert.Equal(t, clusterCustomizationDirs, config.ClusterCustomizationDirs)
 	assert.Equal(t, clusterCustomizationFiles, config.ClusterCustomizationFiles)
+}
+
+func TestGetIngressKeyPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       []string
+		expected    string
+		expectedErr string
+	}{
+		{
+			name:     "finds ingress key among other files",
+			files:    []string{"loadbalancer-serving-signer.key", "ingresskey-ingress-operator.key", "admin-kubeconfig-client-ca.crt"},
+			expected: "ingresskey-ingress-operator.key",
+		},
+		{
+			name:     "finds first ingresskey- prefixed file",
+			files:    []string{"ingresskey-first.key", "ingresskey-second.key"},
+			expected: "ingresskey-first.key",
+		},
+		{
+			name:        "no matching files",
+			files:       []string{"loadbalancer-serving-signer.key", "localhost-serving-signer.key"},
+			expectedErr: "failed to find ingress key file",
+		},
+		{
+			name:        "empty directory",
+			files:       []string{},
+			expectedErr: "failed to find ingress key file",
+		},
+		{
+			name:        "near-miss name without dash",
+			files:       []string{"ingresskey.key"},
+			expectedErr: "failed to find ingress key file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tt.files {
+				assert.NoError(t, os.WriteFile(filepath.Join(dir, f), []byte("dummy"), 0o600))
+			}
+
+			result, err := getIngressKeyPath(dir)
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetIngressKeyPath_NonexistentDir(t *testing.T) {
+	_, err := getIngressKeyPath("/nonexistent/path")
+	assert.ErrorContains(t, err, "failed to list files")
+}
+
+func setupCryptoDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	files := []string{
+		"loadbalancer-serving-signer.key",
+		"localhost-serving-signer.key",
+		"service-network-serving-signer.key",
+		"ingresskey-ingress-operator.key",
+		"admin-kubeconfig-client-ca.crt",
+	}
+	for _, f := range files {
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, f), []byte("dummy-key"), 0o600))
+	}
+	return dir
+}
+
+func readRecertConfig(t *testing.T, configFolder string) RecertConfig {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(configFolder, RecertConfigFile))
+	assert.NoError(t, err)
+	var config RecertConfig
+	assert.NoError(t, json.Unmarshal(data, &config))
+	return config
+}
+
+func TestCreateRecertConfigFile(t *testing.T) {
+	tests := []struct {
+		name            string
+		seedReconfig    *seedreconfig.SeedReconfiguration
+		seedClusterInfo *seedclusterinfo.SeedClusterInfo
+		hasCryptoDir    bool
+		validate        func(t *testing.T, config RecertConfig)
+	}{
+		{
+			name: "hostname changed",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "target-cluster",
+				BaseDomain:  "target.example.com",
+				Hostname:    "target-node",
+				NodeIPs:     []string{"10.0.0.1"},
+				PullSecret:  "pull-secret",
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName:          "seed-cluster",
+				BaseDomain:           "seed.example.com",
+				SNOHostname:          "seed-node",
+				NodeIPs:              []string{"10.0.0.1"},
+				IngressCertificateCN: "ingress-operator@1234",
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Equal(t, "target-node", config.Hostname)
+				assert.Equal(t, "target-cluster:target.example.com", config.ClusterRename)
+				assert.Contains(t, config.CNSanReplaceRules, "system:node:seed-node,system:node:target-node")
+				assert.Contains(t, config.CNSanReplaceRules, "seed-node,target-node")
+				assert.Contains(t, config.CNSanReplaceRules, "api.seed-cluster.seed.example.com,api.target-cluster.target.example.com")
+				assert.Contains(t, config.CNSanReplaceRules, "api-int.seed-cluster.seed.example.com,api-int.target-cluster.target.example.com")
+				assert.Contains(t, config.CNSanReplaceRules, "*.apps.seed-cluster.seed.example.com,*.apps.target-cluster.target.example.com")
+			},
+		},
+		{
+			name: "hostname unchanged is omitted",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "same-host",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "same-host",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Empty(t, config.Hostname)
+			},
+		},
+		{
+			name: "IPs changed single stack",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.2"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Equal(t, []string{"10.0.0.2"}, config.IP)
+				assert.Contains(t, config.CNSanReplaceRules, "10.0.0.1,10.0.0.2")
+			},
+		},
+		{
+			name: "IPs changed dual stack",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.2", "2001:db8::2"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1", "2001:db8::1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Equal(t, []string{"10.0.0.2", "2001:db8::2"}, config.IP)
+				assert.Contains(t, config.CNSanReplaceRules, "10.0.0.1,10.0.0.2")
+				assert.Contains(t, config.CNSanReplaceRules, "2001:db8::1,2001:db8::2")
+			},
+		},
+		{
+			name: "IPs unchanged is omitted",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Nil(t, config.IP)
+			},
+		},
+		{
+			name: "IP count mismatch skips IP replacement rules",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.2", "2001:db8::2"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Equal(t, []string{"10.0.0.2", "2001:db8::2"}, config.IP)
+				for _, rule := range config.CNSanReplaceRules {
+					assert.NotContains(t, rule, "10.0.0.1,")
+				}
+			},
+		},
+		{
+			name: "InfraID present adds three-segment ClusterRename",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				InfraID:     "cluster-abc12",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Equal(t, "cluster:example.com:cluster-abc12", config.ClusterRename)
+			},
+		},
+		{
+			name: "InfraID absent gives two-segment ClusterRename",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Equal(t, "cluster:example.com", config.ClusterRename)
+			},
+		},
+		{
+			name: "crypto dir present populates UseKeyRules and UseCertRules",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName:          "seed",
+				BaseDomain:           "seed.example.com",
+				SNOHostname:          "seed-node",
+				NodeIPs:              []string{"10.0.0.1"},
+				IngressCertificateCN: "ingress-operator@1234",
+			},
+			hasCryptoDir: true,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Len(t, config.UseKeyRules, 4)
+				assert.Contains(t, config.UseKeyRules[0], "kube-apiserver-lb-signer")
+				assert.Contains(t, config.UseKeyRules[1], "kube-apiserver-localhost-signer")
+				assert.Contains(t, config.UseKeyRules[2], "kube-apiserver-service-network-signer")
+				assert.Contains(t, config.UseKeyRules[3], "ingress-operator@1234")
+				assert.Contains(t, config.UseKeyRules[3], "ingresskey-ingress-operator.key")
+				assert.Len(t, config.UseCertRules, 1)
+				assert.Contains(t, config.UseCertRules[0], "admin-kubeconfig-client-ca.crt")
+			},
+		},
+		{
+			name: "crypto dir absent leaves UseKeyRules and UseCertRules nil",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Nil(t, config.UseKeyRules)
+				assert.Nil(t, config.UseCertRules)
+			},
+		},
+		{
+			name: "ingress CN retention appends CN replace rule",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.1"},
+				KubeconfigCryptoRetention: seedreconfig.KubeConfigCryptoRetention{
+					IngresssCrypto: seedreconfig.IngresssCrypto{
+						IngressCertificateCN: "ingress-operator@9999",
+					},
+				},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName:          "seed",
+				BaseDomain:           "seed.example.com",
+				SNOHostname:          "seed-node",
+				NodeIPs:              []string{"10.0.0.1"},
+				IngressCertificateCN: "ingress-operator@1234",
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Contains(t, config.CNSanReplaceRules, "ingress-operator@1234,ingress-operator@9999")
+			},
+		},
+		{
+			name: "machine networks changed",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName:     "cluster",
+				BaseDomain:      "example.com",
+				Hostname:        "node",
+				NodeIPs:         []string{"10.0.0.1"},
+				MachineNetworks: []string{"10.0.0.0/24"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName:     "seed",
+				BaseDomain:      "seed.example.com",
+				SNOHostname:     "seed-node",
+				NodeIPs:         []string{"10.0.0.1"},
+				MachineNetworks: []string{"192.168.1.0/24"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Equal(t, []string{"10.0.0.0/24"}, config.MachineNetworkCidr)
+			},
+		},
+		{
+			name: "machine networks unchanged is nil",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName:     "cluster",
+				BaseDomain:      "example.com",
+				Hostname:        "node",
+				NodeIPs:         []string{"10.0.0.1"},
+				MachineNetworks: []string{"10.0.0.0/24"},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName:     "seed",
+				BaseDomain:      "seed.example.com",
+				SNOHostname:     "seed-node",
+				NodeIPs:         []string{"10.0.0.1"},
+				MachineNetworks: []string{"10.0.0.0/24"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Nil(t, config.MachineNetworkCidr)
+			},
+		},
+		{
+			name: "IBI case with empty ServerSSHKeys sets RegenerateServerSSHKeys",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName:   "cluster",
+				BaseDomain:    "example.com",
+				Hostname:      "node",
+				NodeIPs:       []string{"10.0.0.1"},
+				ServerSSHKeys: nil,
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Equal(t, EtcSSHMount, config.RegenerateServerSSHKeys)
+			},
+		},
+		{
+			name: "IBU case with non-empty ServerSSHKeys leaves RegenerateServerSSHKeys empty",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName: "cluster",
+				BaseDomain:  "example.com",
+				Hostname:    "node",
+				NodeIPs:     []string{"10.0.0.1"},
+				ServerSSHKeys: []seedreconfig.ServerSSHKey{
+					{FileName: "ssh_host_rsa_key", FileContent: "key-content"},
+				},
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.Empty(t, config.RegenerateServerSSHKeys)
+			},
+		},
+		{
+			name: "common fields are set correctly",
+			seedReconfig: &seedreconfig.SeedReconfiguration{
+				ClusterName:           "cluster",
+				BaseDomain:            "example.com",
+				Hostname:              "node",
+				NodeIPs:               []string{"10.0.0.1"},
+				KubeadminPasswordHash: "$2a$10$hash",
+				PullSecret:            `{"auths":{}}`,
+				ChronyConfig:          "server ntp.example.com iburst",
+			},
+			seedClusterInfo: &seedclusterinfo.SeedClusterInfo{
+				ClusterName: "seed",
+				BaseDomain:  "seed.example.com",
+				SNOHostname: "seed-node",
+				NodeIPs:     []string{"10.0.0.1"},
+			},
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config RecertConfig) {
+				assert.True(t, config.ExtendExpiration)
+				assert.Equal(t, "$2a$10$hash", config.KubeadminPasswordHash)
+				assert.Equal(t, `{"auths":{}}`, config.PullSecret)
+				assert.Equal(t, "server ntp.example.com iburst", config.ChronyConfig)
+				assert.Equal(t, SummaryFile, config.SummaryFileClean)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cryptoDir := "/nonexistent/crypto"
+			if tt.hasCryptoDir {
+				cryptoDir = setupCryptoDir(t)
+			}
+			configFolder := t.TempDir()
+
+			err := CreateRecertConfigFile(tt.seedReconfig, tt.seedClusterInfo, cryptoDir, configFolder, "")
+			assert.NoError(t, err)
+
+			config := readRecertConfig(t, configFolder)
+			tt.validate(t, config)
+		})
+	}
+}
+
+func TestCreateRecertConfigFile_TrustBundleError(t *testing.T) {
+	seedReconfig := &seedreconfig.SeedReconfiguration{
+		ClusterName: "cluster",
+		BaseDomain:  "example.com",
+		Hostname:    "node",
+		NodeIPs:     []string{"10.0.0.1"},
+		AdditionalTrustBundle: seedreconfig.AdditionalTrustBundle{
+			ProxyConfigmapName: "has-name-but-no-bundle",
+		},
+	}
+	seedClusterInfo := &seedclusterinfo.SeedClusterInfo{
+		ClusterName: "seed",
+		BaseDomain:  "seed.example.com",
+		SNOHostname: "seed-node",
+		NodeIPs:     []string{"10.0.0.1"},
+	}
+
+	err := CreateRecertConfigFile(seedReconfig, seedClusterInfo, "/nonexistent", t.TempDir(), "")
+	assert.ErrorContains(t, err, "failed to set recert trusted ca bundle")
+}
+
+func TestCreateRecertConfigFile_MissingIngressKeyInCryptoDir(t *testing.T) {
+	cryptoDir := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(cryptoDir, "loadbalancer-serving-signer.key"), []byte("key"), 0o600))
+
+	seedReconfig := &seedreconfig.SeedReconfiguration{
+		ClusterName: "cluster",
+		BaseDomain:  "example.com",
+		Hostname:    "node",
+		NodeIPs:     []string{"10.0.0.1"},
+	}
+	seedClusterInfo := &seedclusterinfo.SeedClusterInfo{
+		ClusterName:          "seed",
+		BaseDomain:           "seed.example.com",
+		SNOHostname:          "seed-node",
+		NodeIPs:              []string{"10.0.0.1"},
+		IngressCertificateCN: "ingress-operator@1234",
+	}
+
+	err := CreateRecertConfigFile(seedReconfig, seedClusterInfo, cryptoDir, t.TempDir(), "")
+	assert.ErrorContains(t, err, "failed to find ingress key file")
+}
+
+func TestCreateRecertConfigFileForIPConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldIPs             []string
+		newIPs             []string
+		newMachineNetworks []string
+		installConfig      string
+		hasCryptoDir       bool
+		ingressCN          string
+		expectedErr        string
+		validate           func(t *testing.T, config *RecertConfig)
+	}{
+		{
+			name:               "single stack IP change",
+			oldIPs:             []string{"10.0.0.1"},
+			newIPs:             []string{"10.0.0.2"},
+			newMachineNetworks: []string{"10.0.0.0/24"},
+			installConfig:      "install-config-yaml",
+			ingressCN:          "ingress-operator@1234",
+			hasCryptoDir:       false,
+			validate: func(t *testing.T, config *RecertConfig) {
+				assert.Equal(t, []string{"10.0.0.2"}, config.IP)
+				assert.Contains(t, config.CNSanReplaceRules, "10.0.0.1,10.0.0.2")
+				assert.Equal(t, []string{"10.0.0.0/24"}, config.MachineNetworkCidr)
+				assert.False(t, config.ExtendExpiration)
+				assert.True(t, config.IPChangeOnly)
+			},
+		},
+		{
+			name:               "dual stack IP change",
+			oldIPs:             []string{"10.0.0.1", "2001:db8::1"},
+			newIPs:             []string{"10.0.0.2", "2001:db8::2"},
+			newMachineNetworks: []string{"10.0.0.0/24", "2001:db8::/64"},
+			ingressCN:          "ingress-operator@1234",
+			hasCryptoDir:       false,
+			validate: func(t *testing.T, config *RecertConfig) {
+				assert.Equal(t, []string{"10.0.0.2", "2001:db8::2"}, config.IP)
+				assert.Contains(t, config.CNSanReplaceRules, "10.0.0.1,10.0.0.2")
+				assert.Contains(t, config.CNSanReplaceRules, "2001:db8::1,2001:db8::2")
+			},
+		},
+		{
+			name:        "mismatched IP counts returns error",
+			oldIPs:      []string{"10.0.0.1"},
+			newIPs:      []string{"10.0.0.2", "2001:db8::2"},
+			ingressCN:   "ingress-operator@1234",
+			expectedErr: "oldIPs and newIPs must have the same length",
+		},
+		{
+			name:         "with crypto dir populates UseKeyRules",
+			oldIPs:       []string{"10.0.0.1"},
+			newIPs:       []string{"10.0.0.2"},
+			ingressCN:    "ingress-operator@1234",
+			hasCryptoDir: true,
+			validate: func(t *testing.T, config *RecertConfig) {
+				assert.Len(t, config.UseKeyRules, 4)
+				assert.Contains(t, config.UseKeyRules[3], "ingress-operator@1234")
+				assert.Len(t, config.UseCertRules, 1)
+			},
+		},
+		{
+			name:         "without crypto dir leaves key rules nil",
+			oldIPs:       []string{"10.0.0.1"},
+			newIPs:       []string{"10.0.0.2"},
+			ingressCN:    "ingress-operator@1234",
+			hasCryptoDir: false,
+			validate: func(t *testing.T, config *RecertConfig) {
+				assert.Nil(t, config.UseKeyRules)
+				assert.Nil(t, config.UseCertRules)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cryptoDir := "/nonexistent/crypto"
+			if tt.hasCryptoDir {
+				cryptoDir = setupCryptoDir(t)
+			}
+
+			config, err := CreateRecertConfigFileForIPConfig(
+				tt.oldIPs, tt.newIPs, tt.newMachineNetworks,
+				tt.installConfig, cryptoDir, tt.ingressCN,
+			)
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+			tt.validate(t, config)
+		})
+	}
+}
+
+func TestCreateRecertConfigFileForIPConfig_MissingIngressKey(t *testing.T) {
+	cryptoDir := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(cryptoDir, "some-other-file.key"), []byte("key"), 0o600))
+
+	_, err := CreateRecertConfigFileForIPConfig(
+		[]string{"10.0.0.1"}, []string{"10.0.0.2"}, nil,
+		"", cryptoDir, "ingress-operator@1234",
+	)
+	assert.ErrorContains(t, err, "failed to find ingress key file")
+}
+
+func TestCreateRecertConfigFileForSeedCreation(t *testing.T) {
+	t.Run("with password generates bcrypt hash", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), RecertConfigFile)
+		err := CreateRecertConfigFileForSeedCreation(configPath, true)
+		assert.NoError(t, err)
+
+		data, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+		var config RecertConfig
+		assert.NoError(t, json.Unmarshal(data, &config))
+
+		assert.True(t, config.ForceExpire)
+		assert.True(t, config.EtcdDefrag)
+		assert.NotEmpty(t, config.KubeadminPasswordHash)
+		assert.Contains(t, config.KubeadminPasswordHash, "$2a$")
+		assert.Equal(t, "/kubernetes/recert-seed-creation-summary.yaml", config.SummaryFileClean)
+	})
+
+	t.Run("without password sets empty hash", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), RecertConfigFile)
+		err := CreateRecertConfigFileForSeedCreation(configPath, false)
+		assert.NoError(t, err)
+
+		data, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+		var config RecertConfig
+		assert.NoError(t, json.Unmarshal(data, &config))
+
+		assert.True(t, config.ForceExpire)
+		assert.Empty(t, config.KubeadminPasswordHash)
+	})
+}
+
+func TestCreateRecertConfigFileForSeedRestoration(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), RecertConfigFile)
+	originalHash := "$2a$10$original-password-hash"
+
+	err := CreateRecertConfigFileForSeedRestoration(configPath, originalHash)
+	assert.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	assert.NoError(t, err)
+	var config RecertConfig
+	assert.NoError(t, json.Unmarshal(data, &config))
+
+	assert.True(t, config.ExtendExpiration)
+	assert.False(t, config.ForceExpire)
+	assert.Equal(t, originalHash, config.KubeadminPasswordHash)
+	assert.Equal(t, "/kubernetes/recert-seed-restoration-summary.yaml", config.SummaryFileClean)
+
+	assert.Len(t, config.UseKeyRules, 4)
+	for _, rule := range config.UseKeyRules {
+		assert.Contains(t, rule, common.BackupCertsDir)
+	}
+	assert.Contains(t, config.UseKeyRules[3], "ingresskey-ingress-operator")
+
+	assert.Len(t, config.UseCertRules, 1)
+	assert.Contains(t, config.UseCertRules[0], "admin-kubeconfig-client-ca.crt")
 }

--- a/utils/client_helper_test.go
+++ b/utils/client_helper_test.go
@@ -2,7 +2,15 @@ package utils
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -311,4 +319,82 @@ func TestGetMachineNetworks_InvalidYAML(t *testing.T) {
 	nets, err := GetMachineNetworks(ctx, cl)
 	assert.Error(t, err)
 	assert.Nil(t, nets)
+}
+
+func mustGenerateCertPEM(t *testing.T, cn string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	assert.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func mustGenerateKeyPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	assert.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+func TestGetCommonNameFromCertificate(t *testing.T) {
+	tests := []struct {
+		name        string
+		certPEM     []byte
+		expectedCN  string
+		expectedErr string
+	}{
+		{
+			name:       "valid certificate with known CN",
+			certPEM:    mustGenerateCertPEM(t, "ingress-operator@1234567890"),
+			expectedCN: "ingress-operator@1234567890",
+		},
+		{
+			name:       "certificate with empty CN",
+			certPEM:    mustGenerateCertPEM(t, ""),
+			expectedCN: "",
+		},
+		{
+			name:        "malformed PEM data",
+			certPEM:     []byte("not-a-pem-block"),
+			expectedErr: "failed to decode PEM block",
+		},
+		{
+			name:        "private key PEM instead of certificate",
+			certPEM:     mustGenerateKeyPEM(t),
+			expectedErr: "failed to parse certificate",
+		},
+		{
+			name: "uses first PEM block when multiple are present",
+			certPEM: append(
+				mustGenerateCertPEM(t, "first-cn"),
+				mustGenerateCertPEM(t, "second-cn")...,
+			),
+			expectedCN: "first-cn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cn, err := getCommonNameFromCertificate(tt.certPEM)
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedCN, cn)
+			}
+		})
+	}
 }

--- a/utils/crypto_dir_test.go
+++ b/utils/crypto_dir_test.go
@@ -1,0 +1,193 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
+)
+
+func TestBackupKubeadminPasswordHash(t *testing.T) {
+	tests := []struct {
+		name           string
+		secret         *corev1.Secret
+		expectedFound  bool
+		expectedErr    bool
+		expectedErrMsg string
+	}{
+		{
+			name: "secret exists",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubeadmin",
+					Namespace: "kube-system",
+				},
+				Data: map[string][]byte{
+					"kubeadmin": []byte("$2a$10$hashed-password"),
+				},
+			},
+			expectedFound: true,
+		},
+		{
+			name:          "secret not found returns false with no error",
+			secret:        nil,
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			if tt.secret != nil {
+				builder = builder.WithObjects(tt.secret)
+			}
+			cl := builder.Build()
+
+			found, err := BackupKubeadminPasswordHash(context.Background(), cl, dir)
+			if tt.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedFound, found)
+
+			hashFile := path.Join(dir, pwHashFile)
+			if tt.expectedFound {
+				content, readErr := os.ReadFile(hashFile)
+				assert.NoError(t, readErr)
+				assert.Equal(t, string(tt.secret.Data["kubeadmin"]), string(content))
+			} else {
+				_, statErr := os.Stat(hashFile)
+				assert.True(t, os.IsNotExist(statErr))
+			}
+		})
+	}
+}
+
+func TestLoadKubeadminPasswordHash(t *testing.T) {
+	tests := []struct {
+		name         string
+		writeContent string
+		writeFile    bool
+		expectedHash string
+		expectedErr  bool
+	}{
+		{
+			name:         "file exists with content",
+			writeFile:    true,
+			writeContent: "$2a$10$hashed-password",
+			expectedHash: "$2a$10$hashed-password",
+		},
+		{
+			name:         "file does not exist returns empty string",
+			writeFile:    false,
+			expectedHash: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.writeFile {
+				assert.NoError(t, os.WriteFile(path.Join(dir, pwHashFile), []byte(tt.writeContent), 0o600))
+			}
+
+			hash, err := LoadKubeadminPasswordHash(dir)
+			if tt.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHash, hash)
+		})
+	}
+}
+
+func TestKubeadminPasswordHash_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	expectedHash := "$2a$10$round-trip-test-hash"
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubeadmin",
+			Namespace: "kube-system",
+		},
+		Data: map[string][]byte{
+			"kubeadmin": []byte(expectedHash),
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(secret).Build()
+
+	found, err := BackupKubeadminPasswordHash(context.Background(), cl, dir)
+	assert.NoError(t, err)
+	assert.True(t, found)
+
+	loaded, err := LoadKubeadminPasswordHash(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHash, loaded)
+}
+
+func TestSeedReconfigurationKubeconfigRetentionToCryptoDir(t *testing.T) {
+	dir := t.TempDir()
+	cryptoDir := path.Join(dir, "kubeconfig-crypto")
+
+	retention := &seedreconfig.KubeConfigCryptoRetention{
+		KubeAPICrypto: seedreconfig.KubeAPICrypto{
+			ServingCrypto: seedreconfig.ServingCrypto{
+				LoadbalancerSignerPrivateKey:   "lb-key-pem",
+				LocalhostSignerPrivateKey:      "localhost-key-pem",
+				ServiceNetworkSignerPrivateKey: "svc-net-key-pem",
+			},
+			ClientAuthCrypto: seedreconfig.ClientAuthCrypto{
+				AdminCACertificate: "admin-ca-cert-pem",
+			},
+		},
+		IngresssCrypto: seedreconfig.IngresssCrypto{
+			IngressCAPrivateKey: "ingress-key-pem",
+		},
+	}
+
+	err := SeedReconfigurationKubeconfigRetentionToCryptoDir(cryptoDir, retention)
+	assert.NoError(t, err)
+
+	expectedFiles := map[string]string{
+		"admin-kubeconfig-client-ca.crt":     "admin-ca-cert-pem",
+		"loadbalancer-serving-signer.key":    "lb-key-pem",
+		"localhost-serving-signer.key":       "localhost-key-pem",
+		"service-network-serving-signer.key": "svc-net-key-pem",
+		"ingresskey-ingress-operator.key":    "ingress-key-pem",
+	}
+
+	for filename, expectedContent := range expectedFiles {
+		filepath := path.Join(cryptoDir, filename)
+		content, readErr := os.ReadFile(filepath)
+		assert.NoError(t, readErr, "failed to read %s", filename)
+		assert.Equal(t, expectedContent, string(content), "content mismatch for %s", filename)
+
+		info, statErr := os.Stat(filepath)
+		assert.NoError(t, statErr)
+		assert.Equal(t, os.FileMode(cryptoDirMode), info.Mode().Perm(), "wrong permissions for %s", filename)
+	}
+}
+
+func TestSeedReconfigurationKubeconfigRetentionToCryptoDir_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cryptoDir := path.Join(dir, "nested", "crypto")
+
+	retention := &seedreconfig.KubeConfigCryptoRetention{}
+	err := SeedReconfigurationKubeconfigRetentionToCryptoDir(cryptoDir, retention)
+	assert.NoError(t, err)
+
+	info, err := os.Stat(cryptoDir)
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+}


### PR DESCRIPTION
## [CNF-26037](https://redhat.atlassian.net/browse/CNF-26037)

## Summary

Adds 85 new unit test cases across 5 test files (1,941 lines), covering previously untested recert configuration assembly, certificate utilities, controller condition helpers, and health checks.

**Recert config generation** (30 test cases in `internal/recert/recert_test.go`):
- `CreateRecertConfigFile`: 16 table-driven scenarios covering hostname/IP/proxy/crypto/CN-SAN rule generation across single-stack, dual-stack, IBI, and IBU paths
- `CreateRecertConfigFileForIPConfig`: 5 scenarios for IP-change-only recert configs plus error paths
- `CreateRecertConfigFileForSeedCreation` and `CreateRecertConfigFileForSeedRestoration`: password hash handling, cert expiry flags, backup dir paths
- `getIngressKeyPath`: 5 scenarios for prefix matching including near-miss names and empty dirs
- 2 new trust bundle scenarios added to existing test

**Certificate utilities** (10 test cases):
- `getCommonNameFromCertificate`: 5 scenarios (valid cert, empty CN, malformed PEM, wrong PEM type, multiple blocks) in `utils/client_helper_test.go`
- `BackupKubeadminPasswordHash`/`LoadKubeadminPasswordHash`/round-trip + `SeedReconfigurationKubeconfigRetentionToCryptoDir`: 5 scenarios in `utils/crypto_dir_test.go`

**Controller condition helpers** (42 test cases in `controllers/utils/conditions_test.go`):
- IBU and IPC stage transition functions, status setters, condition queries, invalid transition handling, and client interaction via `UpdateIBUStatus`/`UpdateIPCStatus`

**Health checks** (3 test cases in `internal/healthcheck/healthcheck_test.go`):
- CSR approval edge cases: no conditions, empty CSR list, mixed approved/unapproved CSRs

## Test plan
- [x] `make unittest` passes locally (319 tests in affected packages, full suite clean)
- [x] `make golangci-lint` passes with zero issues
- [x] No production code changes — all files are `_test.go` only