### PR TITLE
CNF-22163: embed graceful service shutdown in systemd-run reboot command

### DIFF
--- a/internal/reboot/reboot.go
+++ b/internal/reboot/reboot.go
@@ -177,11 +177,18 @@ func (c *IBURebootClient) RebootToNewStateRoot(rationale string) error {
 }
 
 func (c *IBURebootClient) Reboot(rationale string) error {
+	// Stop cluster services before reboot to avoid messy shutdown cascades.
+	// Runs as a host-level systemd unit so it survives the LCA pod being killed
+	// when kubelet/CRI-O stop.
 	_, err := c.hostCommandsExecutor.Execute("systemd-run", "--unit", "lifecycle-agent-reboot",
 		"--description", fmt.Sprintf("\"lifecycle-agent: %s\"", rationale),
-		"systemctl", "--message=\"Image Based Upgrade\"", "reboot")
+		"bash", "-c",
+		"systemctl stop kubelet.service 2>/dev/null; "+
+			"crictl ps -q 2>/dev/null | xargs --no-run-if-empty --max-args 1 --max-procs 10 crictl stop --timeout 5 2>/dev/null; "+
+			"systemctl stop crio.service 2>/dev/null; "+
+			"systemctl --message='Image Based Upgrade' reboot")
 	if err != nil {
-		return fmt.Errorf("failed to reboot with systemd :%w", err)
+		return fmt.Errorf("failed to reboot with systemd: %w", err)
 	}
 
 	c.log.Info(fmt.Sprintf("Wait for %s to be killed via SIGTERM", defaultRebootTimeout.String()))


### PR DESCRIPTION
# Background / Context
During an IBU (Image Based Upgrade), LCA's `Reboot()` function in `internal/reboot/reboot.go` triggers a system reboot via `systemd-run systemctl reboot`. This causes systemd to tear down services in its default dependency order. Because kubelet, CRI-O, and application containers are all stopped concurrently by systemd, pods lose their dependencies unpredictably — kubelet may die before containers finish, or CRI-O may stop while containers are still draining. This results in a 2-3 minute messy shutdown with cascading failures.
# Issue / Requirement / Reason for change
The ungraceful shutdown adds unnecessary time to the hard downtime window (API unavailable) during IBU upgrades and rollbacks. Empirical testing shows the shutdown phase contributes significantly to the total API downtime measured on SNO clusters.

# Solution / Feature Overview
Replace the direct `systemctl reboot` with an ordered shutdown sequence that explicitly stops cluster services before rebooting:
1. Stop kubelet (prevents new pod scheduling, sends SIGTERM to pods)
2. Stop all remaining containers via `crictl stop` (5s grace period, 10 in parallel)
3. Stop CRI-O (clean exit after all containers are gone)
4. Reboot

The sequence runs as a host-level transient systemd unit (`systemd-run`), so it survives the LCA pod being killed when kubelet/CRI-O stop.
Testing across 25 clean upgrade cycles on a SNO cluster showed a statistically significant API downtime reduction of 1m25s (p<0.001) compared to the baseline.
# Implementation Details
The change is entirely within `Reboot()` in `internal/reboot/reboot.go`. The `systemd-run` command now executes `bash -c` with the ordered shutdown sequence instead of calling `systemctl reboot` directly. All intermediate commands suppress stderr (`2>/dev/null`) to avoid failures if a service is already stopped.
Also fixed a minor typo in the error message format string (misplaced space before colon).
# Other Information
**Deployment consideration**: During an IBU upgrade, `Reboot()` is called by the LCA on the **target** cluster (pre-pivot, running the older OCP version), not by the LCA in the seed image. For this optimization to take effect on upgrades, it must be present in the LCA version running on the target cluster.
- [x] I performed a rough self-review of my changes
- [x] I explained non-trivial motivation for my code using code-comments
- [x] I made sure my code passes linting, tests, and builds correctly
- [x] I have ran the code and made sure it works as intended, and doesn't introduce any obvious regressions
- [x] I have not committed any irrelevant changes
- [x] I added tests (or decided that tests aren't really necessary) — `Reboot()` was untested before this change; the function is a thin executor wrapper best validated by integration testing (25 upgrade cycles performed).