### PR TITLE
CNF-22165: Watch Velero Restore CRs for immediate reconciliation

### DIFF
--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -31,7 +31,9 @@ import (
 	"github.com/openshift-kni/lifecycle-agent/internal/extramanifest"
 	"github.com/openshift-kni/lifecycle-agent/internal/imagemgmt"
 	"github.com/openshift-kni/lifecycle-agent/internal/reboot"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	kbatch "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
 	"github.com/openshift-kni/lifecycle-agent/controllers/utils"
@@ -51,7 +53,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ibuv1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 	ipcv1 "github.com/openshift-kni/lifecycle-agent/api/ipconfig/v1"
@@ -521,6 +525,21 @@ func (r *ImageBasedUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 		})).
 		Owns(&kbatch.Job{}). // note: job resource watched is restricted further using cache.Options during NewManager
+		Watches(&velerov1.Restore{},
+			handler.EnqueueRequestsFromMapFunc(
+				func(ctx context.Context, obj client.Object) []reconcile.Request {
+					return []reconcile.Request{{
+						NamespacedName: types.NamespacedName{Name: utils.IBUName},
+					}}
+				},
+			),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc:  func(e event.CreateEvent) bool { return false },
+				UpdateFunc:  func(e event.UpdateEvent) bool { return true },
+				DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+				GenericFunc: func(e event.GenericEvent) bool { return false },
+			}),
+		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }

--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -533,19 +533,19 @@ func (r *ImageBasedUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					}}
 				},
 			),
-		builder.WithPredicates(predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool { return false },
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				oldRestore, okOld := e.ObjectOld.(*velerov1.Restore)
-				newRestore, okNew := e.ObjectNew.(*velerov1.Restore)
-				if !okOld || !okNew {
-					return false
-				}
-				return oldRestore.Status.Phase != newRestore.Status.Phase
-			},
-			DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-			GenericFunc: func(e event.GenericEvent) bool { return false },
-		}),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(e event.CreateEvent) bool { return false },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldRestore, okOld := e.ObjectOld.(*velerov1.Restore)
+					newRestore, okNew := e.ObjectNew.(*velerov1.Restore)
+					if !okOld || !okNew {
+						return false
+					}
+					return oldRestore.Status.Phase != newRestore.Status.Phase
+				},
+				DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+				GenericFunc: func(e event.GenericEvent) bool { return false },
+			}),
 		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)

--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -533,12 +533,19 @@ func (r *ImageBasedUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					}}
 				},
 			),
-			builder.WithPredicates(predicate.Funcs{
-				CreateFunc:  func(e event.CreateEvent) bool { return false },
-				UpdateFunc:  func(e event.UpdateEvent) bool { return true },
-				DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-				GenericFunc: func(e event.GenericEvent) bool { return false },
-			}),
+		builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool { return false },
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				oldRestore, okOld := e.ObjectOld.(*velerov1.Restore)
+				newRestore, okNew := e.ObjectNew.(*velerov1.Restore)
+				if !okOld || !okNew {
+					return false
+				}
+				return oldRestore.Status.Phase != newRestore.Status.Phase
+			},
+			DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+			GenericFunc: func(e event.GenericEvent) bool { return false },
+		}),
 		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)

--- a/controllers/ibu_controller.go
+++ b/controllers/ibu_controller.go
@@ -87,6 +87,9 @@ type ImageBasedUpgradeReconciler struct {
 
 	// Cluster data retrieved once, during init
 	ContainerStorageMountpointTarget string
+
+	// VeleroAvailable indicates whether Velero CRDs are present in the cluster
+	VeleroAvailable bool
 }
 
 func doNotRequeue() ctrl.Result {
@@ -473,8 +476,7 @@ func validateStageTransition(ibu *ibuv1.ImageBasedUpgrade, isAfterPivot bool) bo
 func (r *ImageBasedUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Recorder = mgr.GetEventRecorder("ImageBasedUpgrade")
 
-	//nolint:wrapcheck
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&ibuv1.ImageBasedUpgrade{}, builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				// Generation is only updated on spec changes (also on deletion),
@@ -524,8 +526,10 @@ func (r *ImageBasedUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return false
 			},
 		})).
-		Owns(&kbatch.Job{}). // note: job resource watched is restricted further using cache.Options during NewManager
-		Watches(&velerov1.Restore{},
+		Owns(&kbatch.Job{}) // note: job resource watched is restricted further using cache.Options during NewManager
+
+	if r.VeleroAvailable {
+		b = b.Watches(&velerov1.Restore{},
 			handler.EnqueueRequestsFromMapFunc(
 				func(ctx context.Context, obj client.Object) []reconcile.Request {
 					return []reconcile.Request{{
@@ -546,7 +550,10 @@ func (r *ImageBasedUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 				GenericFunc: func(e event.GenericEvent) bool { return false },
 			}),
-		).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		)
+	}
+
+	//nolint:wrapcheck
+	return b.WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }

--- a/main/main.go
+++ b/main/main.go
@@ -216,6 +216,10 @@ func main() {
 					Namespaces: map[string]cache.Config{
 						common.OperatorNamespace(): {}},
 				},
+				&velerov1.Restore{}: {
+					Namespaces: map[string]cache.Config{
+						"openshift-adp": {}},
+				},
 			},
 		},
 	})

--- a/main/main.go
+++ b/main/main.go
@@ -216,10 +216,10 @@ func main() {
 					Namespaces: map[string]cache.Config{
 						common.OperatorNamespace(): {}},
 				},
-			&velerov1.Restore{}: {
-				Namespaces: map[string]cache.Config{
-					backuprestore.OadpNs: {}},
-			},
+				&velerov1.Restore{}: {
+					Namespaces: map[string]cache.Config{
+						backuprestore.OadpNs: {}},
+				},
 			},
 		},
 	})

--- a/main/main.go
+++ b/main/main.go
@@ -177,6 +177,13 @@ func main() {
 		setupLog.Info("NetworkPolicies", "msg", msg)
 	}
 
+	veleroAvailable := isVeleroAvailable(k8sClient)
+	if veleroAvailable {
+		setupLog.Info("Velero CRDs detected, enabling Restore watch")
+	} else {
+		setupLog.Info("Velero CRDs not found, Restore watch disabled")
+	}
+
 	// Fetch the TLS profile from the APIServer resource.
 	tlsSecurityProfileSpec, err := utiltls.FetchAPIServerTLSProfile(context.Background(), k8sClient)
 	if err != nil {
@@ -211,16 +218,7 @@ func main() {
 			TLSOpts:        tlsOpts,
 		},
 		Cache: cache.Options{ // https://github.com/kubernetes-sigs/controller-runtime/blob/main/designs/cache_options.md
-			ByObject: map[client.Object]cache.ByObject{
-				&kbatchv1.Job{}: {
-					Namespaces: map[string]cache.Config{
-						common.OperatorNamespace(): {}},
-				},
-				&velerov1.Restore{}: {
-					Namespaces: map[string]cache.Config{
-						backuprestore.OadpNs: {}},
-				},
-			},
+			ByObject: cacheByObject(veleroAvailable),
 		},
 	})
 
@@ -331,6 +329,8 @@ func main() {
 
 		// Cluster data retrieved once during init
 		ContainerStorageMountpointTarget: containerStorageMountpointTarget,
+
+		VeleroAvailable: veleroAvailable,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageBasedUpgrade")
 		os.Exit(1)
@@ -565,4 +565,28 @@ func initSeedGen(ctx context.Context, c client.Client, log *logr.Logger) error {
 
 	log.Info("Restore successful and saved SeedGenerator CR removed")
 	return nil
+}
+
+func isVeleroAvailable(c client.Client) bool {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Name: "restores.velero.io"}, crd); err != nil {
+		return false
+	}
+	return true
+}
+
+func cacheByObject(veleroAvailable bool) map[client.Object]cache.ByObject {
+	objs := map[client.Object]cache.ByObject{
+		&kbatchv1.Job{}: {
+			Namespaces: map[string]cache.Config{
+				common.OperatorNamespace(): {}},
+		},
+	}
+	if veleroAvailable {
+		objs[&velerov1.Restore{}] = cache.ByObject{
+			Namespaces: map[string]cache.Config{
+				backuprestore.OadpNs: {}},
+		}
+	}
+	return objs
 }

--- a/main/main.go
+++ b/main/main.go
@@ -216,10 +216,10 @@ func main() {
 					Namespaces: map[string]cache.Config{
 						common.OperatorNamespace(): {}},
 				},
-				&velerov1.Restore{}: {
-					Namespaces: map[string]cache.Config{
-						"openshift-adp": {}},
-				},
+			&velerov1.Restore{}: {
+				Namespaces: map[string]cache.Config{
+					backuprestore.OadpNs: {}},
+			},
 			},
 		},
 	})


### PR DESCRIPTION
# Background / Context

During an IBU (Image-Based Upgrade), the LCA (Lifecycle Agent) controller manages OADP Velero Restore CRs to bring back workload configurations and state after the stateroot pivot. Currently, the controller monitors Restore CR completion by polling: each reconciliation loop calls `StartOrTrackRestore`, which checks the Restore CR status and re-queues with a fixed delay (up to 20s) if the restore is still in progress. This means there can be up to 20s of idle waiting between a restore completing and the controller noticing it.

The controller already uses `builder.Watches()` for other related CRs (e.g. Jobs), and the manager already restricts cache scope per-namespace for resources like Jobs via `Cache.ByObject`.

Relevant code:
- `SetupWithManager` in `controllers/ibu_controller.go` ([L498-L540](https://github.com/openshift-kni/lifecycle-agent/blob/main/controllers/ibu_controller.go#L498))
- Cache configuration in `main/main.go` ([L206-L225](https://github.com/openshift-kni/lifecycle-agent/blob/main/main/main.go#L206))

# Issue / Requirement / Reason for change

The polling-based restore monitoring introduces unnecessary latency in the OADP restore phase of the IBU upgrade. Each polling cycle can add up to 20s of dead time where the restore has already completed but the controller hasn't reacted yet. This delays workload availability post-upgrade.

# Solution / Feature Overview

Replace the polling-based detection with an event-driven approach using controller-runtime's `builder.Watches()`. The controller now watches Velero Restore CRs and receives immediate reconciliation triggers when their status changes. This eliminates the polling latency without modifying any of the existing restore tracking logic.

# Implementation Details

Two changes:

1. **`controllers/ibu_controller.go`**: Added a `.Watches(&velerov1.Restore{}, ...)` call in `SetupWithManager`. It uses `handler.EnqueueRequestsFromMapFunc` to map any Restore CR update to a reconciliation of the IBU CR. A predicate filter restricts this to `UpdateFunc` events only (no Create/Delete/Generic), since we only care about status transitions on existing Restore CRs.

2. **`main/main.go`**: Added `&velerov1.Restore{}` to the manager's `Cache.ByObject` map, scoped to the `openshift-adp` namespace. This follows the same pattern used for Jobs and ensures the controller only caches Restore CRs from the relevant namespace.

The existing `StartOrTrackRestore` polling logic is left unchanged. The watch simply triggers reconciliation sooner, and the existing code handles the rest.

# Other Information

**Test results**: 5 clean upgrade/rollback cycles on a lab SNO cluster (4.20 -> 4.22) showed a statistically significant workload downtime reduction of 49s vs baseline (p=0.019).

The improvement is at the lower end of the original 0.5-2 min estimate. Its value increases when combined with other IBU optimizations that reduce earlier phases, as the polling latency becomes a proportionally larger share of remaining downtime.

No new tests were added. The change is purely additive wiring in the controller setup and doesn't modify any business logic. Existing unit tests pass.

# Checklist

- [x] I performed a rough self-review of my changes
- [x] I made sure my code passes linting, tests, and builds correctly
- [x] I have ran the code and made sure it works as intended, and doesn't introduce any obvious regressions
- [x] I have not committed any irrelevant changes
- [x] I added tests (or decided that tests aren't really necessary) - No new tests added; the change is additive wiring in `SetupWithManager` that doesn't modify any business logic. Existing unit tests pass.