### PR TITLE
CNF-22168: Implement tiered health checks for PostPivot

### DIFF
--- a/controllers/upgrade_handlers.go
+++ b/controllers/upgrade_handlers.go
@@ -346,8 +346,14 @@ var getStaterootVarPath = func(stateroot string) string {
 	return common.PathOutsideChroot(filepath.Join(common.GetStaterootPath(stateroot), "/var"))
 }
 
-// CheckHealth helper func to call HealthChecks
+// CheckHealth helper func to call HealthChecks (used by PrePivot)
 var CheckHealth = healthcheck.HealthChecks
+
+// CheckMandatoryHealth runs pre-restore mandatory checks (COs, MCP, SRIOV, OADP)
+var CheckMandatoryHealth = healthcheck.MandatoryHealthChecks
+
+// CheckDeferredHealth runs post-restore deferred checks (Node, CSVs, CSRs)
+var CheckDeferredHealth = healthcheck.DeferredHealthChecks
 
 func (u *UpgHandler) autoRollbackIfEnabled(ibu *ibuv1.ImageBasedUpgrade, msg string) {
 	// Check whether auto-rollback is disabled using annotation
@@ -376,8 +382,8 @@ func (u *UpgHandler) PostPivot(ctx context.Context, ibu *ibuv1.ImageBasedUpgrade
 	// start post-pivot phase timer
 	utils.StartPhase(u.Client, u.Log, ibu, UpgradePhasePostpivot)
 
-	u.Log.Info("Starting health check for different components")
-	if err := CheckHealth(ctx, u.NoncachedClient, u.Log); err != nil {
+	u.Log.Info("Running mandatory health checks (pre-restore)")
+	if err := CheckMandatoryHealth(ctx, u.NoncachedClient, u.Log); err != nil {
 		utils.SetUpgradeStatusInProgress(ibu, fmt.Sprintf("Waiting for system to stabilize: %s", err.Error()))
 		return requeueWithHealthCheckInterval(), nil
 	}
@@ -451,6 +457,12 @@ func (u *UpgHandler) PostPivot(ctx context.Context, ibu *ibuv1.ImageBasedUpgrade
 		// The restore process has not been completed yet, requeue
 		utils.SetUpgradeStatusInProgress(ibu, "Restore of Application Data is in progress")
 		return result, nil
+	}
+
+	u.Log.Info("Running deferred health checks (post-restore)")
+	if err := CheckDeferredHealth(ctx, u.NoncachedClient, u.Log); err != nil {
+		utils.SetUpgradeStatusInProgress(ibu, fmt.Sprintf("Waiting for system to fully stabilize: %s", err.Error()))
+		return requeueWithHealthCheckInterval(), nil
 	}
 
 	if err := u.RebootClient.DisableInitMonitor(); err != nil {

--- a/controllers/upgrade_handlers_test.go
+++ b/controllers/upgrade_handlers_test.go
@@ -916,6 +916,7 @@ func TestImageBasedUpgradeReconciler_postPivot(t *testing.T) {
 		want                              controllerruntime.Result
 		wantErr                           assert.ErrorAssertionFunc
 		checkHealthReturn                 func(ctx context.Context, c client.Reader, l logr.Logger) error
+		checkDeferredHealthReturn         func(ctx context.Context, c client.Reader, l logr.Logger) error
 		applyExtraManifestsReturn         func() error
 		applyPolicyManifestsReturn        func() error
 		ensureOadpConfigurationReturn     func() error
@@ -1046,6 +1047,38 @@ func TestImageBasedUpgradeReconciler_postPivot(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "deferred healthchecks return error after restore",
+			args: args{ibu: &ibuv1.ImageBasedUpgrade{}},
+			checkHealthReturn: func(ctx context.Context, c client.Reader, l logr.Logger) error {
+				return nil
+			},
+			checkDeferredHealthReturn: func(ctx context.Context, c client.Reader, l logr.Logger) error {
+				return fmt.Errorf("node is not yet ready: cnfdf40")
+			},
+			applyPolicyManifestsReturn: func() error {
+				return nil
+			},
+			applyExtraManifestsReturn: func() error {
+				return nil
+			},
+			ensureOadpConfigurationReturn: func() error {
+				return nil
+			},
+			loadRestoresFromOadpRestoreReturn: func() ([][]*velerov1.Restore, error) {
+				return nil, nil
+			},
+			wantConditions: []metav1.Condition{
+				{
+					Type:    string(utils.ConditionTypes.UpgradeInProgress),
+					Reason:  string(utils.ConditionReasons.InProgress),
+					Status:  metav1.ConditionTrue,
+					Message: "Waiting for system to fully stabilize: node is not yet ready: cnfdf40",
+				},
+			},
+			want:    requeueWithHealthCheckInterval(),
+			wantErr: assert.NoError,
+		},
+		{
 			name: "upgrade completed",
 			args: args{ibu: &ibuv1.ImageBasedUpgrade{}},
 			checkHealthReturn: func(ctx context.Context, c client.Reader, l logr.Logger) error {
@@ -1095,12 +1128,21 @@ func TestImageBasedUpgradeReconciler_postPivot(t *testing.T) {
 				RebootClient:    mockRebootClient,
 			}
 
-			oldHC := CheckHealth
+			oldMandatory := CheckMandatoryHealth
+			oldDeferred := CheckDeferredHealth
 			defer func() {
-				CheckHealth = oldHC
+				CheckMandatoryHealth = oldMandatory
+				CheckDeferredHealth = oldDeferred
 			}()
 
-			CheckHealth = tt.checkHealthReturn
+			CheckMandatoryHealth = tt.checkHealthReturn
+			if tt.checkDeferredHealthReturn != nil {
+				CheckDeferredHealth = tt.checkDeferredHealthReturn
+			} else {
+				CheckDeferredHealth = func(ctx context.Context, c client.Reader, l logr.Logger) error {
+					return nil
+				}
+			}
 
 			if tt.applyPolicyManifestsReturn != nil {
 				mockExtramanifest.EXPECT().ApplyExtraManifests(gomock.Any(), common.PathOutsideChroot(extramanifest.PolicyManifestPath)).Return(tt.applyPolicyManifestsReturn()).Times(1)

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -26,7 +26,6 @@ import (
 // +kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigpools,verbs=list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=list;watch
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=list;watch
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=sriovnetworknodestates,verbs=get;list;watch
@@ -41,11 +40,12 @@ const (
 	SriovNetworkNodeStateNotPresentMsg = "no SriovNetworkNodeStates present"
 )
 
-func HealthChecks(ctx context.Context, c client.Reader, l logr.Logger) error {
+// MandatoryHealthChecks runs the checks required before OADP restore can begin:
+// ClusterOperators, MachineConfigPools, SRIOV, and OADP (DPA + BSL).
+func MandatoryHealthChecks(ctx context.Context, c client.Reader, l logr.Logger) error {
 	var failures []string
 
 	clusterOperatorsReady := false
-	clusterServiceVersionsReady := false
 
 	if err := AreClusterOperatorsReady(ctx, c, l); err != nil {
 		l.Info("co health check failure", "error", err.Error())
@@ -59,36 +59,12 @@ func HealthChecks(ctx context.Context, c client.Reader, l logr.Logger) error {
 		failures = append(failures, err.Error())
 	}
 
-	if err := IsNodeReady(ctx, c, l); err != nil {
-		l.Info("node health check failure", "error", err.Error())
-		failures = append(failures, err.Error())
-	}
-
-	if err := AreClusterServiceVersionsReady(ctx, c, l); err != nil {
-		l.Info("csv health check failure", "error", err.Error())
-		failures = append(failures, err.Error())
-	} else {
-		clusterServiceVersionsReady = true
-	}
-
-	if err := IsClusterVersionReady(ctx, c, l); err != nil {
-		l.Info("clusterVersion health check failure", "error", err.Error())
-		failures = append(failures, err.Error())
-	}
-
-	if err := AreCertificateSigningRequestsReady(ctx, c, l); err != nil {
-		l.Info("certificateSigningRequest (csr) health check failure", "error", err.Error())
-		failures = append(failures, err.Error())
-	}
-
-	if clusterOperatorsReady && clusterServiceVersionsReady {
-		// Only check SriovNetworkNodeState once cluster operators and CSVs are stable
+	if clusterOperatorsReady {
 		if err := IsSriovNetworkNodeReady(ctx, c, l); err != nil {
 			l.Info("sriovNetworkNodeState health check failure", "error", err.Error())
 			failures = append(failures, err.Error())
 		}
 
-		// Check oadp storage backend connection when DPA exists and is reconciled
 		if ok, err := IsDataProtectionApplicationReconciled(ctx, c, l); err != nil {
 			l.Info("dataProtentionApplication health check failure", "error", err.Error())
 			failures = append(failures, err.Error())
@@ -101,13 +77,52 @@ func HealthChecks(ctx context.Context, c client.Reader, l logr.Logger) error {
 	}
 
 	if len(failures) > 0 {
-		l.Info("One or more health checks failed")
+		l.Info("One or more mandatory health checks failed")
 		// nolint: staticcheck
 		return fmt.Errorf("one or more health checks failed: %s", strings.Join(failures, "\n  - "))
 	}
 
-	l.Info("Health checks done")
+	l.Info("Mandatory health checks done")
 	return nil
+}
+
+// DeferredHealthChecks runs checks that are only required after OADP restore completes,
+// before declaring the upgrade finished: Node readiness, CSVs, and CSRs.
+func DeferredHealthChecks(ctx context.Context, c client.Reader, l logr.Logger) error {
+	var failures []string
+
+	if err := IsNodeReady(ctx, c, l); err != nil {
+		l.Info("node health check failure", "error", err.Error())
+		failures = append(failures, err.Error())
+	}
+
+	if err := AreClusterServiceVersionsReady(ctx, c, l); err != nil {
+		l.Info("csv health check failure", "error", err.Error())
+		failures = append(failures, err.Error())
+	}
+
+	if err := AreCertificateSigningRequestsReady(ctx, c, l); err != nil {
+		l.Info("certificateSigningRequest (csr) health check failure", "error", err.Error())
+		failures = append(failures, err.Error())
+	}
+
+	if len(failures) > 0 {
+		l.Info("One or more deferred health checks failed")
+		// nolint: staticcheck
+		return fmt.Errorf("one or more health checks failed: %s", strings.Join(failures, "\n  - "))
+	}
+
+	l.Info("Deferred health checks done")
+	return nil
+}
+
+// HealthChecks runs all health checks (mandatory + deferred). Used by PrePivot
+// and other callers that need the full check set in a single call.
+func HealthChecks(ctx context.Context, c client.Reader, l logr.Logger) error {
+	if err := MandatoryHealthChecks(ctx, c, l); err != nil {
+		return err
+	}
+	return DeferredHealthChecks(ctx, c, l)
 }
 
 func IsDataProtectionApplicationReconciled(ctx context.Context, c client.Reader, l logr.Logger) (bool, error) {
@@ -195,28 +210,6 @@ func AreClusterServiceVersionsReady(ctx context.Context, c client.Reader, l logr
 	}
 
 	l.Info("All CSVs are ready")
-	return nil
-}
-
-func IsClusterVersionReady(ctx context.Context, c client.Reader, l logr.Logger) error {
-	clusterVersionList := configv1.ClusterVersionList{}
-	err := c.List(ctx, &clusterVersionList)
-	if err != nil {
-		return fmt.Errorf("failed to get cv list: %w", err)
-	}
-
-	// As we would only have one ClusterVersion currently, we don't need to build a list of not-ready CVs.
-	// Instead, we can return on first error.
-	for _, co := range clusterVersionList.Items {
-		if !getClusterOperatorStatusCondition(co.Status.Conditions, configv1.OperatorAvailable) {
-			msg := fmt.Sprintf("clusterVersion %s not ready", co.Name)
-			l.Info(msg)
-			// nolint: staticcheck
-			return fmt.Errorf("clusterVersion %s not ready", co.Name)
-		}
-	}
-
-	l.Info("Cluster version is ready")
 	return nil
 }
 

--- a/internal/healthcheck/healthcheck_test.go
+++ b/internal/healthcheck/healthcheck_test.go
@@ -28,8 +28,6 @@ var s = scheme.Scheme
 
 // let fakeclient know about all the possible types of CRs used by HCs
 func init() {
-	s.AddKnownTypes(configv1.GroupVersion, &configv1.ClusterVersion{})
-	s.AddKnownTypes(configv1.GroupVersion, &configv1.ClusterVersionList{})
 	s.AddKnownTypes(mcv1.GroupVersion, &mcv1.MachineConfigPoolList{})
 	s.AddKnownTypes(mcv1.GroupVersion, &mcv1.MachineConfigPool{})
 	s.AddKnownTypes(configv1.GroupVersion, &configv1.ClusterOperatorList{})
@@ -430,59 +428,6 @@ func Test_machineConfigPoolReady(t *testing.T) {
 	}
 }
 
-func Test_clusterVersionReady(t *testing.T) {
-	type args struct {
-		c client.Reader
-		l logr.Logger
-	}
-	tests := []struct {
-		name    string
-		args    args
-		objects []runtime.Object
-		wantErr bool
-	}{
-		{
-			name: "happy path clusterVersion Ready",
-			objects: []runtime.Object{
-				&configv1.ClusterVersion{
-					Status: configv1.ClusterVersionStatus{
-						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{
-								Type:   configv1.OperatorAvailable,
-								Status: configv1.ConditionTrue,
-							},
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "clusterVersion condition false",
-			objects: []runtime.Object{
-				&configv1.ClusterVersion{
-					Status: configv1.ClusterVersionStatus{
-						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{
-								Type:   configv1.OperatorAvailable,
-								Status: configv1.ConditionFalse,
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.args.c = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tt.objects...).Build()
-			if err := IsClusterVersionReady(context.TODO(), tt.args.c, tt.args.l); (err != nil) != tt.wantErr {
-				t.Errorf("IsClusterVersionReady() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
 
 func Test_sriovNetworkNodeStateReady(t *testing.T) {
 	type args struct {
@@ -825,24 +770,14 @@ func TestHealthChecks(t *testing.T) {
 						},
 					},
 				},
-				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
-					MachineCount:      1,
-					ReadyMachineCount: 12,
-				}},
-				&configv1.ClusterVersion{
-					Status: configv1.ClusterVersionStatus{
-						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{
-								Type:   configv1.OperatorAvailable,
-								Status: configv1.ConditionFalse,
-							},
-						},
-					},
-				},
-			},
+			&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+				MachineCount:      1,
+				ReadyMachineCount: 12,
+			}},
 		},
-		{
-			name:    "happy path",
+	},
+	{
+		name:    "happy path",
 			wantErr: false,
 			objects: []runtime.Object{
 				&configv1.Infrastructure{
@@ -891,21 +826,11 @@ func TestHealthChecks(t *testing.T) {
 						},
 					},
 				},
-				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
-					MachineCount:      1,
-					ReadyMachineCount: 1,
-				}},
-				&configv1.ClusterVersion{
-					Status: configv1.ClusterVersionStatus{
-						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{
-								Type:   configv1.OperatorAvailable,
-								Status: configv1.ConditionTrue,
-							},
-						},
-					},
-				},
-				crd,
+			&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+				MachineCount:      1,
+				ReadyMachineCount: 1,
+			}},
+			crd,
 				&sriovv1.SriovNetworkNodeStateList{
 					Items: []sriovv1.SriovNetworkNodeState{*successSriovNetworkNodeState},
 				},
@@ -959,6 +884,319 @@ func TestHealthChecks(t *testing.T) {
 			err := HealthChecks(context.TODO(), tt.args.c, tt.args.l)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("HealthChecks() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMandatoryHealthChecks(t *testing.T) {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sriovnetworknodestates.sriovnetwork.openshift.io",
+		},
+	}
+
+	dpaCrd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dataprotectionapplications.oadp.openshift.io",
+		},
+	}
+
+	successDpa := &unstructured.Unstructured{
+		Object: map[string]any{
+			"kind":       backuprestore.DpaGvk.Kind,
+			"apiVersion": backuprestore.DpaGvk.Group + "/" + backuprestore.DpaGvk.Version,
+			"metadata": map[string]any{
+				"name":      "oadp",
+				"namespace": backuprestore.OadpNs,
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":   "Reconciled",
+						"status": "True",
+						"reason": "Complete",
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		wantErr bool
+	}{
+		{
+			name: "all mandatory checks pass",
+			objects: []runtime.Object{
+				&configv1.ClusterOperator{
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Status: configv1.ConditionTrue, Type: configv1.OperatorAvailable},
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+					MachineCount: 1, ReadyMachineCount: 1,
+				}},
+				crd,
+				&sriovv1.SriovNetworkNodeStateList{
+					Items: []sriovv1.SriovNetworkNodeState{
+						{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Status: sriovv1.SriovNetworkNodeStateStatus{SyncStatus: "Succeeded"}},
+					},
+				},
+				dpaCrd,
+				&unstructured.UnstructuredList{Items: []unstructured.Unstructured{*successDpa}},
+				&velerov1.BackupStorageLocationList{
+					Items: []velerov1.BackupStorageLocation{
+						{ObjectMeta: metav1.ObjectMeta{Name: "dpa-1", Namespace: backuprestore.OadpNs}, Status: velerov1.BackupStorageLocationStatus{Phase: velerov1.BackupStorageLocationPhaseAvailable}},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "CO not ready fails",
+			objects: []runtime.Object{
+				&configv1.ClusterOperator{
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Status: configv1.ConditionFalse, Type: configv1.OperatorAvailable},
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+					MachineCount: 1, ReadyMachineCount: 1,
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "MCP not ready fails",
+			objects: []runtime.Object{
+				&configv1.ClusterOperator{
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Status: configv1.ConditionTrue, Type: configv1.OperatorAvailable},
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+					MachineCount: 1, ReadyMachineCount: 0,
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "SRIOV not ready fails",
+			objects: []runtime.Object{
+				&configv1.ClusterOperator{
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Status: configv1.ConditionTrue, Type: configv1.OperatorAvailable},
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+					MachineCount: 1, ReadyMachineCount: 1,
+				}},
+				crd,
+				&sriovv1.SriovNetworkNodeStateList{
+					Items: []sriovv1.SriovNetworkNodeState{
+						{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Status: sriovv1.SriovNetworkNodeStateStatus{SyncStatus: ""}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "DPA not reconciled fails",
+			objects: []runtime.Object{
+				&configv1.ClusterOperator{
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Status: configv1.ConditionTrue, Type: configv1.OperatorAvailable},
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+					MachineCount: 1, ReadyMachineCount: 1,
+				}},
+				dpaCrd,
+				&unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{Object: map[string]any{
+							"kind":       backuprestore.DpaGvk.Kind,
+							"apiVersion": backuprestore.DpaGvk.Group + "/" + backuprestore.DpaGvk.Version,
+							"metadata":   map[string]any{"name": "oadp", "namespace": backuprestore.OadpNs},
+							"status": map[string]any{"conditions": []any{
+								map[string]any{"type": "Reconciled", "status": "False", "reason": "Error"},
+							}},
+						}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "BSL unavailable fails",
+			objects: []runtime.Object{
+				&configv1.ClusterOperator{
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Status: configv1.ConditionTrue, Type: configv1.OperatorAvailable},
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+					MachineCount: 1, ReadyMachineCount: 1,
+				}},
+				dpaCrd,
+				&unstructured.UnstructuredList{Items: []unstructured.Unstructured{*successDpa}},
+				&velerov1.BackupStorageLocationList{
+					Items: []velerov1.BackupStorageLocation{
+						{ObjectMeta: metav1.ObjectMeta{Name: "dpa-1", Namespace: backuprestore.OadpNs}, Status: velerov1.BackupStorageLocationStatus{Phase: velerov1.BackupStorageLocationPhaseUnavailable}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tt.objects...).Build()
+			err := MandatoryHealthChecks(context.TODO(), c, logr.Logger{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MandatoryHealthChecks() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeferredHealthChecks(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		wantErr bool
+	}{
+		{
+			name: "all deferred checks pass",
+			objects: []runtime.Object{
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     configv1.InfrastructureStatus{InfrastructureTopology: configv1.SingleReplicaTopologyMode},
+				},
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+						NodeRoleControlPlane: "", NodeRoleMaster: "", NodeRoleWorker: "",
+					}},
+					Status: v1.NodeStatus{Conditions: []v1.NodeCondition{
+						{Type: v1.NodeReady, Status: v1.ConditionTrue},
+						{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
+					}},
+				},
+				&operatorsv1alpha1.ClusterServiceVersion{
+					Status: operatorsv1alpha1.ClusterServiceVersionStatus{
+						Phase: operatorsv1alpha1.CSVPhaseSucceeded, Reason: operatorsv1alpha1.CSVReasonInstallSuccessful,
+					},
+				},
+				&k8sv1.CertificateSigningRequest{
+					Status: k8sv1.CertificateSigningRequestStatus{
+						Conditions: []k8sv1.CertificateSigningRequestCondition{
+							{Type: k8sv1.CertificateApproved, Status: v1.ConditionStatus(metav1.ConditionTrue)},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "node not ready fails",
+			objects: []runtime.Object{
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     configv1.InfrastructureStatus{InfrastructureTopology: configv1.SingleReplicaTopologyMode},
+				},
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+						NodeRoleControlPlane: "", NodeRoleMaster: "", NodeRoleWorker: "",
+					}},
+					Status: v1.NodeStatus{Conditions: []v1.NodeCondition{
+						{Type: v1.NodeReady, Status: v1.ConditionFalse},
+					}},
+				},
+				&operatorsv1alpha1.ClusterServiceVersion{
+					Status: operatorsv1alpha1.ClusterServiceVersionStatus{
+						Phase: operatorsv1alpha1.CSVPhaseSucceeded, Reason: operatorsv1alpha1.CSVReasonInstallSuccessful,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "CSV not ready fails",
+			objects: []runtime.Object{
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     configv1.InfrastructureStatus{InfrastructureTopology: configv1.SingleReplicaTopologyMode},
+				},
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+						NodeRoleControlPlane: "", NodeRoleMaster: "", NodeRoleWorker: "",
+					}},
+					Status: v1.NodeStatus{Conditions: []v1.NodeCondition{
+						{Type: v1.NodeReady, Status: v1.ConditionTrue},
+						{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
+					}},
+				},
+				&operatorsv1alpha1.ClusterServiceVersion{
+					Status: operatorsv1alpha1.ClusterServiceVersionStatus{
+						Phase: operatorsv1alpha1.CSVPhasePending,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "CSR not approved fails",
+			objects: []runtime.Object{
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     configv1.InfrastructureStatus{InfrastructureTopology: configv1.SingleReplicaTopologyMode},
+				},
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+						NodeRoleControlPlane: "", NodeRoleMaster: "", NodeRoleWorker: "",
+					}},
+					Status: v1.NodeStatus{Conditions: []v1.NodeCondition{
+						{Type: v1.NodeReady, Status: v1.ConditionTrue},
+						{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
+					}},
+				},
+				&operatorsv1alpha1.ClusterServiceVersion{
+					Status: operatorsv1alpha1.ClusterServiceVersionStatus{
+						Phase: operatorsv1alpha1.CSVPhaseSucceeded, Reason: operatorsv1alpha1.CSVReasonInstallSuccessful,
+					},
+				},
+				&k8sv1.CertificateSigningRequest{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-csr"},
+					Status: k8sv1.CertificateSigningRequestStatus{
+						Conditions: []k8sv1.CertificateSigningRequestCondition{
+							{Type: k8sv1.CertificateApproved, Status: v1.ConditionStatus(metav1.ConditionFalse)},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tt.objects...).Build()
+			err := DeferredHealthChecks(context.TODO(), c, logr.Logger{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeferredHealthChecks() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/healthcheck/healthcheck_test.go
+++ b/internal/healthcheck/healthcheck_test.go
@@ -428,7 +428,6 @@ func Test_machineConfigPoolReady(t *testing.T) {
 	}
 }
 
-
 func Test_sriovNetworkNodeStateReady(t *testing.T) {
 	type args struct {
 		c client.Reader
@@ -770,14 +769,14 @@ func TestHealthChecks(t *testing.T) {
 						},
 					},
 				},
-			&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
-				MachineCount:      1,
-				ReadyMachineCount: 12,
-			}},
+				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+					MachineCount:      1,
+					ReadyMachineCount: 12,
+				}},
+			},
 		},
-	},
-	{
-		name:    "happy path",
+		{
+			name:    "happy path",
 			wantErr: false,
 			objects: []runtime.Object{
 				&configv1.Infrastructure{
@@ -826,11 +825,11 @@ func TestHealthChecks(t *testing.T) {
 						},
 					},
 				},
-			&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
-				MachineCount:      1,
-				ReadyMachineCount: 1,
-			}},
-			crd,
+				&mcv1.MachineConfigPool{Status: mcv1.MachineConfigPoolStatus{
+					MachineCount:      1,
+					ReadyMachineCount: 1,
+				}},
+				crd,
 				&sriovv1.SriovNetworkNodeStateList{
 					Items: []sriovv1.SriovNetworkNodeState{*successSriovNetworkNodeState},
 				},


### PR DESCRIPTION
# Background / Context

During an IBU (Image-Based Upgrade) on SNO clusters, the LCA's `PostPivot()` function runs after the node reboots into the new stateroot. It performs health checks to validate the cluster is stable, then triggers OADP restore to bring back workload configurations, and finally declares the upgrade complete.

Currently, all health checks run as a single block before OADP restore begins. This means checks that are not strictly required for a successful restore (Node readiness, CSVs, CSRs) still gate the restore operation, delaying workload recovery unnecessarily.

The health check set currently includes: ClusterOperators, MachineConfigPools, Node readiness, ClusterServiceVersions, CertificateSigningRequests, ClusterVersion, SRIOV, DPA, and BSL.

# Issue / Requirement / Reason for change

[CNF-22168](https://redhat.atlassian.net/browse/CNF-22168) requires implementing a two-tier health check model where only the checks that are genuinely required for a successful OADP restore gate the restore operation, while remaining checks run after restore completes before declaring the upgrade finished.

The mandatory pre-restore checks (as specified in the Jira) are: Control plane (ClusterOperators), MCP, SRIOV, and OADP readiness. Everything else can be deferred.

Additionally, [CNF-22164](https://redhat.atlassian.net/browse/CNF-22164) requests removing the `IsClusterVersionReady` check entirely, as it is redundant with `AreClusterOperatorsReady`. Empirical testing (9 clean runs) confirmed it has no measurable impact on any downtime metric.

# Solution / Feature Overview

Split the health checks into two tiers:

1. `MandatoryHealthChecks` (pre-restore gate): ClusterOperators, MachineConfigPools, SRIOV (gated on COs), and OADP (DPA + BSL, gated on COs). These must pass before OADP restore can begin.

2. `DeferredHealthChecks` (post-restore): Node readiness, CSVs, and CSRs. These run only after OADP restore completes successfully, before declaring the upgrade finished.

The existing `HealthChecks()` function is preserved as a wrapper calling both (used by PrePivot and other callers that need the full set in a single call).

`IsClusterVersionReady` is removed entirely ([CNF-22164](https://redhat.atlassian.net/browse/CNF-22164)).

# Implementation Details

- `internal/healthcheck/healthcheck.go`: Added `MandatoryHealthChecks()` and `DeferredHealthChecks()` as new exported functions. Removed `IsClusterVersionReady()` and its RBAC marker. `HealthChecks()` now calls Mandatory then Deferred sequentially.

- `controllers/upgrade_handlers.go`: Added `CheckMandatoryHealth` and `CheckDeferredHealth` package-level vars (for test mockability). Modified `PostPivot()` to call `CheckMandatoryHealth` before restore, and `CheckDeferredHealth` after restore completes successfully.

- SRIOV and OADP checks within `MandatoryHealthChecks` are gated on ClusterOperators passing first (same pattern as the original code, which gated them on both COs and CSVs). Since CSVs are now deferred, gating on COs alone is sufficient -- if the SRIOV/OADP operators are healthy as ClusterOperators, their CSVs will be in a ready state.

# Other Information

- Lab tested with 15 clean upgrade cycles (16 total, 1 excluded for hardware boot hang). Results show a statistically significant workload downtime improvement of -1m21s (p<0.001) compared to the custom baseline.
- No check runs in both tiers. The split is clean with no overlap.

# Checklist

- [x] I performed a rough self-review of my changes
- [x] I explained non-trivial motivation for my code using code-comments
- [x] I made sure my code passes linting, tests, and builds correctly
- [x] I have ran the code and made sure it works as intended, and doesn't introduce any obvious regressions
- [x] I have not committed any irrelevant changes
- [x] I added tests
