### PR TITLE
OCPBUGS-98688: order config service after coreos-update-ca-trust

### DIFF
--- a/lca-cli/installation_configuration_files/services/installation-configuration.service
+++ b/lca-cli/installation_configuration_files/services/installation-configuration.service
@@ -1,5 +1,12 @@
 [Unit]
 Description=Image base SNO configuration script
+# update-ca-trust is not concurrency-safe. Both this service and
+# coreos-update-ca-trust.service call it at boot; without this
+# ordering they race and update-ca-trust fails. The race exists on
+# RHEL 9 too but the collision window is ~100ms; RHEL 10 widened it
+# to several seconds (more hash symlinks in /etc/pki/tls/certs/),
+# making it hit reliably.
+After=coreos-update-ca-trust.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
# Background

update-ca-trust is not concurrency-safe — concurrent invocations fail with "ln: failed to create symbolic link ... File exists" and a nonzero exit code. Both `installation-configuration.service` (LCA postpivot) and `coreos-update-ca-trust.service` call `update-ca-trust` during boot, and without explicit ordering they race.

The race exists on RHEL 9 too, but the collision window there is only ~100ms (hard to hit in practice). RHEL 10 added ~292 hash symlink operations in `/etc/pki/tls/certs/`, which grew `update-ca-trust`'s runtime from around 1.3s to 5.9s, widening the collision window to several seconds and making it hit reliably.

# Issue

OCPBUGS-98688

On a real RHEL 10 node doing an IBU (OCP `5.0.0-ec.2` to `5.0.0-ec.4`), the two services started ~600ms apart — well outside RHEL 9's window, but guaranteed to collide on RHEL 10. The nonzero exit code from `update-ca-trust` caused the entire IBU upgrade to roll back.

# Solution

Adding `After=coreos-update-ca-trust.service` ensures LCA's postpivot waits for the boot-time `update-ca-trust` to finish before calling it again. `After=` is ordering-only — if `coreos-update-ca-trust.service` is removed or not started, systemd ignores it and we run normally.

# Other info

Analysis produced through agent collaboration with more details:

https://github.com/omertuc/update-ca-trust-race/blob/main/repro.md