### PR TITLE
CNF-26059: Upstream release-config version bump — Lifecycle Agent 4.22.1

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -9,9 +9,9 @@ variables:
 
       You can find additional guidance in the upstream repository: https://github.com/openshift-kni/lifecycle-agent
   display_name: "Lifecycle Agent"
-  manager_version: "lifecycle-agent.v4.22.1"
+  manager_version: "lifecycle-agent.v4.22.2"
   # min_kube_version should match ocp
   # https://access.redhat.com/solutions/4870701
   min_kube_version: "1.35.0"
   recert_image: PLACEHOLDER_RECERT_IMAGE
-  version: "4.22.1"
+  version: "4.22.2"


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.22.1 → 4.22.2.

Generated by release-automator-konflux.