### PR TITLE
CNF-26059: Upstream catalog-template update — Lifecycle Agent 4.22.1

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-22@sha256:a3620d8f7ea0ab06f92f590a75d940d2adadb49fcf141924d31b65c461d944da
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-22@sha256:2d5f47f059d04a9ea77da7300de65ec974ea0a0fc00f20258ecc8ba62e60e9d9

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -17,6 +17,10 @@ entries:
       - name: lifecycle-agent.v4.22.1
         replaces: lifecycle-agent.v4.22.0
         skipRange: '>=4.20.0 <4.22.1'
+      # v4.22.2
+      - name: lifecycle-agent.v4.22.2
+        replaces: lifecycle-agent.v4.22.1
+        skipRange: '>=4.20.0 <4.22.2'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -29,6 +33,10 @@ entries:
       - name: lifecycle-agent.v4.22.1
         replaces: lifecycle-agent.v4.22.0
         skipRange: '>=4.20.0 <4.22.1'
+      # v4.22.2
+      - name: lifecycle-agent.v4.22.2
+        replaces: lifecycle-agent.v4.22.1
+        skipRange: '>=4.20.0 <4.22.2'
     name: "4.22"
     package: lifecycle-agent
     schema: olm.channel
@@ -36,6 +44,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:0fb9fe40cff820fcbab5c925bafc1270ddbf3c552ae8fed648642bdd53bd716c
     schema: olm.bundle
     # v4.22.1 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:1d40848dd3fd0819b6e008d0345229c82a5af997e1096dc9851a5f664d206d7b
+    schema: olm.bundle
+    # v4.22.2 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.22.1 → 4.22.2.

Generated by release-automator-konflux.