### PR TITLE
CNF-26342: Upstream release-config version bump — Lifecycle Agent 4.19.5

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -9,9 +9,9 @@ variables:
 
     You can find additional guidance in the upstream repository: https://github.com/openshift-kni/lifecycle-agent
   display_name: "Lifecycle Agent"
-  manager_version: "lifecycle-agent.v4.19.5"
+  manager_version: "lifecycle-agent.v4.19.6"
   # min_kube_version should match ocp
   # https://access.redhat.com/solutions/4870701
   min_kube_version: "1.32.0"
   recert_image: PLACEHOLDER_RECERT_IMAGE
-  version: "4.19.5"
+  version: "4.19.6"


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.19.5 → 4.19.6.

Generated by release-automator-konflux.