### PR TITLE
CNF-26342: Upstream catalog-template update — Lifecycle Agent 4.19.5

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-19@sha256:2e4a1e8cc6fe04bd113dc9a4aebed383f02606743234cdb68499abc025ec804f
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-4-19@sha256:9252a0dbe68d9a7d94da8440e8a1bf15d8c2c59503190d15a6e1268de75380c5

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -32,6 +32,10 @@ entries:
       - name: lifecycle-agent.v4.19.5
         replaces: lifecycle-agent.v4.19.4
         skipRange: '>=4.18.0 <4.19.5'
+      # v4.19.6
+      - name: lifecycle-agent.v4.19.6
+        replaces: lifecycle-agent.v4.19.5
+        skipRange: '>=4.18.0 <4.19.6'
     name: stable
     package: lifecycle-agent
     schema: olm.channel
@@ -60,6 +64,10 @@ entries:
       - name: lifecycle-agent.v4.19.5
         replaces: lifecycle-agent.v4.19.4
         skipRange: '>=4.18.0 <4.19.5'
+      # v4.19.6
+      - name: lifecycle-agent.v4.19.6
+        replaces: lifecycle-agent.v4.19.5
+        skipRange: '>=4.18.0 <4.19.6'
     name: "4.19"
     package: lifecycle-agent
     schema: olm.channel
@@ -79,6 +87,9 @@ entries:
   - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:b6ecefc8c9179318d06219bba38f2eed7a993ec2c33626bf97acfcab286cb05f
     schema: olm.bundle
     # v4.19.5 bundle
+  - image: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle@sha256:4cb781345f9a8d0f8b762ddc81ea304d0cf818a2a95464eff418b9abbedace77
+    schema: olm.bundle
+    # v4.19.6 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Lifecycle Agent 4.19.5 → 4.19.6.

Generated by release-automator-konflux.