### PR TITLE
CNF-26435: Switch runtime base image to ubi9-minimal-pqc

### DIFF
--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -20,7 +20,7 @@ OPENSHIFT_CLI_IMAGE=registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:cbe
 # The runtime image is used to run the binaries
 # This should match the dummy file Dockerfile.mintmaker in the lock-runtime directory
 # Mintmaker should keep these in sync automatically when it performs updates
-RUNTIME_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+RUNTIME_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest@sha256:e7f7720259142a68a8087fb4df9d21a91189863aa083e9b27c2c2801878ef5c4
 #
 
 # The yq image is used at build time to manipulate yaml

--- a/.konflux/lock-runtime/Dockerfile.mintmaker
+++ b/.konflux/lock-runtime/Dockerfile.mintmaker
@@ -1,5 +1,5 @@
 # Due to a limitation in Mintmaker, we need to create a dummy Dockerfile that does not use ARGs
 # This should match the RUNTIME_IMAGE in container_build_args.conf
 # Mintmaker should keep these in sync automatically when it performs updates
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest@sha256:e7f7720259142a68a8087fb4df9d21a91189863aa083e9b27c2c2801878ef5c4
 #

--- a/Makefile
+++ b/Makefile
@@ -581,7 +581,7 @@ konflux-update-rpm-lock-runtime: sync-git-submodules ## Update the rpm lock file
 	@echo "Updating rpm lock file for the runtime..."
 	$(MAKE) -C $(PROJECT_DIR)/telco5g-konflux/scripts/rpm-lock generate-rhel9-locks \
 		LOCK_SCRIPT_TARGET_DIR=$(PROJECT_DIR)/.konflux/lock-runtime/tmp/ \
-		RHEL9_EXECUTION_IMAGE=$$(awk -F'=' '/^RUNTIME_IMAGE=/ {print $$2}' $(PROJECT_DIR)/.konflux/container_build_args.conf | sed 's|ubi-minimal|ubi|g' | sed 's|@.*||') \
+		RHEL9_EXECUTION_IMAGE=$$(awk -F'=' '/^RUNTIME_IMAGE=/ {print $$2}' $(PROJECT_DIR)/.konflux/container_build_args.conf | sed 's|ubi-minimal[^:]*|ubi|' | sed 's|@.*||') \
 		RHEL9_IMAGE_TO_LOCK=$$(awk -F'=' '/^RUNTIME_IMAGE=/ {print $$2}' $(PROJECT_DIR)/.konflux/container_build_args.conf)
 	@echo "Update rpms.lock.yaml with new contents..."
 	cp $(PROJECT_DIR)/.konflux/lock-runtime/tmp/rpms.lock.yaml $(PROJECT_DIR)/.konflux/lock-runtime/rpms.lock.yaml


### PR DESCRIPTION
## Summary

Switch the Konflux runtime base image from `ubi9/ubi-minimal` to `ubi9/ubi-minimal-pqc` to enable the `DEFAULT:PQ` crypto-policy in the container, as required by [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113) for platform-wide PQC consistency.

The PQC base images use the `DEFAULT:PQ` crypto-policy instead of `DEFAULT`, enabling post-quantum algorithms (ML-KEM, ML-DSA) in OpenSSL.

## Changes

- **`.konflux/container_build_args.conf`**: Update `RUNTIME_IMAGE` from `ubi9/ubi-minimal` to `ubi9/ubi-minimal-pqc` with pinned digest.
- **`.konflux/lock-runtime/Dockerfile.mintmaker`**: Update `FROM` image to match the new `RUNTIME_IMAGE` (required for Mintmaker sync).
- **`Makefile`**: Fix the `sed` pattern in `konflux-update-rpm-lock-runtime` target to correctly derive the execution image when using `ubi-minimal-pqc`. The previous pattern (`s|ubi-minimal|ubi|g`) would incorrectly produce `ubi-pqc`; the updated pattern (`s|ubi-minimal[^:]*|ubi|`) correctly maps both `ubi-minimal` and `ubi-minimal-pqc` to `ubi`.

## Testing

- [ ] Verify no regressions in standard mode (non-FIPS)
- [ ] Verify no regressions in FIPS mode (PQC modules auto-disabled by FIPS provider)
- [ ] Confirm ML-KEM (`X25519MLKEM768`) is negotiated successfully via `tls-scanner`

## References

- Jira: [CNF-26435](https://redhat.atlassian.net/browse/CNF-26435)
- Parent initiative: [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113)
- Similar ticket for NROP: [CNF-26427](https://redhat.atlassian.net/browse/CNF-26427)

Made with [Cursor](https://cursor.com)