### PR TITLE
Revert "CNF-22163: embed graceful service shutdown"

### DIFF
--- a/internal/reboot/reboot.go
+++ b/internal/reboot/reboot.go
@@ -177,18 +177,11 @@ func (c *IBURebootClient) RebootToNewStateRoot(rationale string) error {
 }
 
 func (c *IBURebootClient) Reboot(rationale string) error {
-	// Stop cluster services before reboot to avoid messy shutdown cascades.
-	// Runs as a host-level systemd unit so it survives the LCA pod being killed
-	// when kubelet/CRI-O stop.
 	_, err := c.hostCommandsExecutor.Execute("systemd-run", "--unit", "lifecycle-agent-reboot",
 		"--description", fmt.Sprintf("\"lifecycle-agent: %s\"", rationale),
-		"bash", "-c",
-		"systemctl stop kubelet.service 2>/dev/null; "+
-			"crictl ps -q 2>/dev/null | xargs --no-run-if-empty --max-args 1 --max-procs 10 crictl stop --timeout 5 2>/dev/null; "+
-			"systemctl stop crio.service 2>/dev/null; "+
-			"systemctl --message='Image Based Upgrade' reboot")
+		"systemctl", "--message=\"Image Based Upgrade\"", "reboot")
 	if err != nil {
-		return fmt.Errorf("failed to reboot with systemd: %w", err)
+		return fmt.Errorf("failed to reboot with systemd :%w", err)
 	}
 
 	c.log.Info(fmt.Sprintf("Wait for %s to be killed via SIGTERM", defaultRebootTimeout.String()))


### PR DESCRIPTION
This reverts the explicit service-stop approach from PR #7726.

Testing showed that the kubelet-native GracefulNodeShutdown feature (configured via PerformanceProfile's kubeletconfig.experimental annotation) achieves equal or better downtime reduction without any LCA code changes. The kubelet's built-in inhibitor lock ensures pods terminate gracefully before shutdown, making the explicit crictl/kubelet stop sequence unnecessary.

This reverts commit 0d55199c92e5b7d9d09696349d1ce482b5d68cce.