### PR TITLE
CNF-26586: Remove openshift4 from catalog-idms and update bundle digest

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-5-0@sha256:78fca6859bac457e3f40b538d9657b2dca36c72cda680acb420ea5139599fda1
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-5-0@sha256:92f3c5644a0bcc9ff02e7ce132cac8f063172910923d176f57352071e2bd088b

--- a/.konflux/catalog/catalog-idms.yaml
+++ b/.konflux/catalog/catalog-idms.yaml
@@ -8,7 +8,4 @@ spec:
   imageDigestMirrors:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-5-0
-    source: registry.redhat.io/openshift4/lifecycle-agent-operator-bundle
-  - mirrors:
-    - quay.io/redhat-user-workloads/telco-5g-tenant/lifecycle-agent-operator-bundle-5-0
     source: registry.redhat.io/openshift5/lifecycle-agent-operator-bundle


### PR DESCRIPTION
## Summary

- Remove the legacy `openshift4` source entry from `catalog-idms.yaml` since only `openshift5` is needed going forward
- Update the bundle digest to `92f3c56` (incorporates the change from #8408)

## Jira

https://redhat.atlassian.net/browse/CNF-26586


Made with [Cursor](https://cursor.com)