### PR TITLE
[release-4.21] Sort manifest groups and files numerically

### DIFF
--- a/internal/backuprestore/restore.go
+++ b/internal/backuprestore/restore.go
@@ -121,7 +121,7 @@ func (h *BRHandler) StartOrTrackRestore(ctx context.Context, restores []*velerov
 func (h *BRHandler) LoadRestoresFromOadpRestorePath() ([][]*velerov1.Restore, error) {
 	var sortedRestores [][]*velerov1.Restore
 
-	// The returned list of entries are sorted by name alphabetically
+	// Groups and the files within them are returned sorted numerically by their index
 	basePath := filepath.Join(hostPath, OadpRestorePath)
 	manifests, err := utils.LoadGroupedManifestsFromPath(basePath, &h.Log)
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
+	"strconv"
 	"text/template"
 
 	"github.com/samber/lo"
@@ -501,6 +503,12 @@ func LoadGroupedManifestsFromPath(basePath string, log *logr.Logger) ([][]*unstr
 		return nil, fmt.Errorf("failed to read manifest groups subdirs in %s: %w", basePath, err)
 	}
 
+	// Sort directories numerically by extracting trailing numbers from names
+	// This fixes the issue where restore10, restore11 come before restore2 when sorted alphabetically
+	sort.Slice(groupSubDirs, func(i, j int) bool {
+		return extractTrailingNumber(groupSubDirs[i].Name()) < extractTrailingNumber(groupSubDirs[j].Name())
+	})
+
 	for _, groupSubDir := range groupSubDirs {
 		if !groupSubDir.IsDir() {
 			log.Info("Unexpected file found, skipping...", "file",
@@ -536,6 +544,22 @@ func LoadGroupedManifestsFromPath(basePath string, log *logr.Logger) ([][]*unstr
 	}
 
 	return sortedManifests, nil
+}
+
+// extractTrailingNumber extracts the numeric suffix from a string.
+// For example: "restore1" -> 1, "restore10" -> 10, "group2" -> 2.
+// Returns 0 if no trailing number is found.
+func extractTrailingNumber(s string) int {
+	re := regexp.MustCompile(`\d+$`)
+	match := re.FindString(s)
+	if match == "" {
+		return 0
+	}
+	num, err := strconv.Atoi(match)
+	if err != nil {
+		return 0
+	}
+	return num
 }
 
 // BuildKernelArguementsFromMCOFile reads the kernel arguments from MCO file

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -516,12 +516,19 @@ func LoadGroupedManifestsFromPath(basePath string, log *logr.Logger) ([][]*unstr
 			continue
 		}
 
-		// The returned list of entries are sorted by name alphabetically
 		manifestDirPath := filepath.Join(basePath, groupSubDir.Name())
 		manifestYamls, err := os.ReadDir(filepath.Clean(manifestDirPath))
 		if err != nil {
 			return nil, fmt.Errorf("failed get manifest yamls in %s: %w", manifestYamls, err)
 		}
+
+		// Sort files numerically by their leading index prefix.
+		// os.ReadDir returns entries sorted alphabetically, which places 10_, 11_ before
+		// 2_ once a group holds more than 9 files. The leading index encodes the intended
+		// apply order (<n>_<Kind>_<name>_<namespace>.yaml), so sort by it to preserve that order.
+		sort.Slice(manifestYamls, func(i, j int) bool {
+			return extractLeadingNumber(manifestYamls[i].Name()) < extractLeadingNumber(manifestYamls[j].Name())
+		})
 
 		var manifests []*unstructured.Unstructured
 		for _, yamlFile := range manifestYamls {
@@ -551,6 +558,24 @@ func LoadGroupedManifestsFromPath(basePath string, log *logr.Logger) ([][]*unstr
 // Returns 0 if no trailing number is found.
 func extractTrailingNumber(s string) int {
 	re := regexp.MustCompile(`\d+$`)
+	match := re.FindString(s)
+	if match == "" {
+		return 0
+	}
+	num, err := strconv.Atoi(match)
+	if err != nil {
+		return 0
+	}
+	return num
+}
+
+// extractLeadingNumber extracts the numeric prefix from a string.
+// For example: "1_ConfigMap_x_.yaml" -> 1, "10_SriovNetwork_x_ns.yaml" -> 10.
+// Returns 0 if no leading number is found. Unlike extractTrailingNumber, this
+// must be used for manifest filenames because their trailing characters may be
+// non-index digits (e.g. "16_RoleBinding_x_s000032-001-ec-gnb-001.yaml").
+func extractLeadingNumber(s string) int {
+	re := regexp.MustCompile(`^\d+`)
 	match := re.FindString(s)
 	if match == "" {
 		return 0

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -184,6 +185,102 @@ func TestLoadGroupedManifestsFromPath(t *testing.T) {
 	assert.Equal(t, 2, len(manifests[0]))
 	assert.Equal(t, 1, len(manifests[1]))
 
+}
+
+func TestLoadGroupedManifestsFromPathWithNumericSorting(t *testing.T) {
+	// Create temporary directory
+	tmpDir, err := os.MkdirTemp("", "restore-numeric-test")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create restores directory
+	restoreDir := filepath.Join(tmpDir, "manifests")
+	if err := os.MkdirAll(restoreDir, 0755); err != nil {
+		t.Fatalf("Failed to create restore directory: %v", err)
+	}
+
+	// Create 12 subdirectories to test numeric sorting (restore1 through restore12)
+	// This tests the bug where restore10, restore11, restore12 would come before restore2 with alphabetical sorting
+	for i := 1; i <= 12; i++ {
+		restoreSubDir := filepath.Join(restoreDir, fmt.Sprintf("restore%d", i))
+		if err := os.Mkdir(restoreSubDir, 0755); err != nil {
+			t.Fatalf("Failed to create restore subdirectory %d: %v", i, err)
+		}
+
+		// Create a restore file in each subdirectory
+		restoreFile := filepath.Join(restoreSubDir, fmt.Sprintf("1_default-restore%d.yaml", i))
+		content := fmt.Sprintf("apiVersion: velero.io/v1\nkind: Restore\nmetadata:\n  name: restore%d\nspec:\n  backupName: backup%d\n", i, i)
+		if err := os.WriteFile(restoreFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create restore file %d: %v", i, err)
+		}
+	}
+
+	manifests, err := LoadGroupedManifestsFromPath(restoreDir, &logr.Logger{})
+	if err != nil {
+		t.Fatalf("Failed to load restores: %v", err)
+	}
+
+	// Verify we have 12 groups
+	assert.Equal(t, 12, len(manifests), "Expected 12 restore groups")
+
+	// Verify each group has 1 manifest and they are in the correct numeric order
+	for i := 0; i < 12; i++ {
+		assert.Equal(t, 1, len(manifests[i]), "Expected 1 manifest in group %d", i)
+
+		// Verify the restore name matches the expected numeric order
+		expectedName := fmt.Sprintf("restore%d", i+1)
+		actualName := manifests[i][0].GetName()
+		assert.Equal(t, expectedName, actualName,
+			"Expected restore at index %d to be %s but got %s", i, expectedName, actualName)
+	}
+}
+
+func TestExtractTrailingNumber(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "single digit",
+			input:    "restore1",
+			expected: 1,
+		},
+		{
+			name:     "double digit",
+			input:    "restore10",
+			expected: 10,
+		},
+		{
+			name:     "triple digit",
+			input:    "restore123",
+			expected: 123,
+		},
+		{
+			name:     "no number",
+			input:    "restore",
+			expected: 0,
+		},
+		{
+			name:     "number in middle",
+			input:    "restore1test",
+			expected: 0,
+		},
+		{
+			name:     "group prefix",
+			input:    "group2",
+			expected: 2,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractTrailingNumber(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }
 
 func TestReadSeedReconfigurationFromFile(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -283,6 +283,84 @@ func TestExtractTrailingNumber(t *testing.T) {
 	}
 }
 
+func TestLoadGroupedManifestsFromPathWithNumericFileSorting(t *testing.T) {
+	// Create temporary directory
+	tmpDir, err := os.MkdirTemp("", "manifest-file-numeric-test")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create manifests directory with a single group holding 12 files.
+	manifestDir := filepath.Join(tmpDir, "manifests")
+	groupDir := filepath.Join(manifestDir, "group1")
+	if err := os.MkdirAll(groupDir, 0755); err != nil {
+		t.Fatalf("Failed to create group directory: %v", err)
+	}
+
+	// Create 12 manifest files with leading index prefixes (1_ through 12_).
+	// This tests the bug where 10_, 11_, 12_ would come before 2_ with alphabetical sorting.
+	for i := 1; i <= 12; i++ {
+		manifestFile := filepath.Join(groupDir, fmt.Sprintf("%d_default-restore%d.yaml", i, i))
+		content := fmt.Sprintf("apiVersion: velero.io/v1\nkind: Restore\nmetadata:\n  name: restore%d\nspec:\n  backupName: backup%d\n", i, i)
+		if err := os.WriteFile(manifestFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create manifest file %d: %v", i, err)
+		}
+	}
+
+	manifests, err := LoadGroupedManifestsFromPath(manifestDir, &logr.Logger{})
+	if err != nil {
+		t.Fatalf("Failed to load manifests: %v", err)
+	}
+
+	// Verify we have a single group with 12 manifests in ascending numeric order.
+	assert.Equal(t, 1, len(manifests), "Expected 1 manifest group")
+	assert.Equal(t, 12, len(manifests[0]), "Expected 12 manifests in the group")
+
+	for i := 0; i < 12; i++ {
+		expectedName := fmt.Sprintf("restore%d", i+1)
+		actualName := manifests[0][i].GetName()
+		assert.Equal(t, expectedName, actualName,
+			"Expected manifest at index %d to be %s but got %s", i, expectedName, actualName)
+	}
+}
+
+func TestExtractLeadingNumber(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "single digit",
+			input:    "1_ConfigMap_x_.yaml",
+			expected: 1,
+		},
+		{
+			name:     "double digit",
+			input:    "10_SriovNetwork_x_ns.yaml",
+			expected: 10,
+		},
+		{
+			name:     "trailing digits in name",
+			input:    "16_RoleBinding_x_s000032-001-ec-gnb-001.yaml",
+			expected: 16,
+		},
+		{
+			name:     "no number",
+			input:    "no-number.yaml",
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractLeadingNumber(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestReadSeedReconfigurationFromFile(t *testing.T) {
 	type dummySeedReconfiguration struct {
 		seedreconfig.SeedReconfiguration


### PR DESCRIPTION
## Summary

Manual backport of two related numeric-ordering fixes in `LoadGroupedManifestsFromPath`. Cherry-pick of #8471 failed on these branches because they never received the prerequisite group-directory sort from #5175. This PR brings both onto the release branch so extra manifests and OADP restores are applied in numeric index order instead of `os.ReadDir` lexical order.

**Upstream PRs (already on main / 4.22+):**
- https://github.com/openshift-kni/lifecycle-agent/pull/5175 — OCPBUGS-77043: sort **group directories** (`restore1` … `restore10`) by trailing number
- https://github.com/openshift-kni/lifecycle-agent/pull/8471 — OCPBUGS-82538: sort **files within each group** (`1_` … `10_`) by leading index

Once a path has more than 9 groups or more than 9 files in a group, lexical order reorders dependents (e.g. `restore10` before `restore2`, or a `RoleBinding` before its `Namespace`) and can fail the IBU.

## Changes

* Sort group directories by trailing numeric suffix (`extractTrailingNumber`).
* Sort files in each group by leading numeric prefix (`extractLeadingNumber`). A dedicated helper is required because filenames can end in non-index digits (e.g. `16_RoleBinding_..._s000032-001-ec-gnb-001.yaml`), so trailing-number extraction would sort them incorrectly.
* Update the stale “sorted by name alphabetically” comment in `internal/backuprestore/restore.go`.

Both extra-manifest apply (`ApplyExtraManifests`) and OADP restore load (`LoadRestoresFromOadpRestorePath`) share this loader.

## Test plan

- [ ] `TestLoadGroupedManifestsFromPathWithNumericSorting` — 12 group dirs `restore1`–`restore12` load in numeric order, not lexical (`restore10` before `restore2`).
- [ ] `TestExtractTrailingNumber` — `restore1`→1, `restore10`→10, `restore`→0, `restore1test`→0.
- [ ] `TestLoadGroupedManifestsFromPathWithNumericFileSorting` — one group with 12 files `1_`–`12_` loads in numeric order, not lexical (`10_` before `2_`).
- [ ] `TestExtractLeadingNumber` — `1_ConfigMap_x_.yaml`→1, `10_SriovNetwork_x_ns.yaml`→10, `16_RoleBinding_x_s000032-001-ec-gnb-001.yaml`→16, `no-number.yaml`→0.
- [ ] Existing `TestLoadGroupedManifestsFromPath` still passes.
- [ ] `go test ./utils/... ./internal/backuprestore/...`

## Notes

Cherry-pick of #8471 onto this branch conflicted in `utils/utils.go` and `utils/utils_test.go` because those files still lacked #5175 (`extractTrailingNumber` and the directory `sort.Slice`). The combined change matches current main behavior for this version. No user-facing API, CRD, or documented-behavior change.